### PR TITLE
test(sweettest): deprecate Tryorama, scaffold hREA bridge tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ bun install              # Install all dependencies
 ```bash
 bun run start            # Start 2-agent development network with UIs
 bun run network          # Custom agent network: AGENTS=3 bun run network
-bun run tests             # Run full test suite (foundation, integration, scenarios)
+bun run tests             # DEPRECATED: Tryorama TypeScript tests — see tests/DEPRECATED.md
 ```
 
 ### Build Pipeline
@@ -34,17 +34,28 @@ bun run package          # Create final .webhapp distribution
 
 ### Testing Commands
 
-**Running specific test files**: Use `bun run tests` followed by the test file path or pattern.
+**Primary test suite: Sweettest (Rust)** in `dnas/nondominium/tests/`
+
+```bash
+# Prerequisites — must run before any test execution:
+bun run build:happ
+
+# Run all Sweettest tests
+CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
+
+# Run a specific test module
+CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test person
+CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test misc
+
+# Run a specific test function
+CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test person person_create_populates_hrea_agent_hash
+```
+
+> **Deprecated:** `bun run tests` runs the legacy Tryorama (TypeScript) test suite. All tests in `tests/` are deprecated. New tests must be written in Sweettest. See `tests/DEPRECATED.md`.
 
 **Test Development Tips**:
 
-1. **Test Isolation**: Use `.only()` on `describe` or `it` blocks to run specific tests during development:
-
-```typescript
-describe.only('specific test suite', () => { ... })  // Run only this suite
-it.only('specific test', async () => { ... })       // Run only this test
-test.only('specific test', async () => { ... })       // Run only this test
-```
+1. **Test Isolation**: Use `#[ignore]` on tests not yet ready, or filter by name with `cargo test <name>`.
 
 2. **Rust Debugging**: Use the `warn!` macro in Rust zome functions to log debugging information that will appear in test output:
 
@@ -77,7 +88,7 @@ nondominium is a **3-zome Holochain hApp** implementing ValueFlows-compliant res
 
 - **Backend**: Rust (Holochain HDK ^0.6.0 / HDI ^0.7.0), WASM compilation target
 - **Frontend**: Svelte 5.0 + TypeScript + Vite 6.2.5
-- **Testing**: Vitest 3.1.3 + @holochain/tryorama 0.18.2
+- **Testing**: Sweettest (Rust, `holochain = "=0.6.0" features = ["test_utils"]`) — primary; Tryorama (TypeScript) deprecated
 - **Client**: @holochain/client 0.19.0 for DHT interaction
 
 ### Data Model Foundations
@@ -128,27 +139,29 @@ create_link(path.path_entry_hash()?, hash.clone(), LinkTypes::AnchorType, LinkTa
 
 ## Test Architecture
 
-### 4-Layer Testing Strategy
+### Primary: Sweettest (Rust)
 
-1. **Foundation Tests**: Basic zome function calls and connectivity
-2. **Integration Tests**: Cross-zome interactions and multi-agent scenarios
-3. **Scenario Tests**: Complete user journeys and workflows
-4. **Performance Tests**: Load and stress testing (in progress for PPR system)
+All new tests are written in Sweettest (Rust) in `dnas/nondominium/tests/src/`.
 
-### Test Configuration
+```
+dnas/nondominium/tests/src/
+├── lib.rs                  # Module declarations
+├── common/
+│   └── conductors.rs       # Shared setup: setup_two_agents(), setup_dual_dna_two_agents()
+├── misc/mod.rs             # Misc zome tests (ping)
+└── person/mod.rs           # Person zome + hREA bridge tests
+```
 
-- **Timeout**: 4 minutes for complex multi-agent scenarios
-- **Concurrency**: Single fork execution for DHT consistency
-- **Agent Simulation**: Supports 2+ distributed agents per test
+**Shared setup functions** (from `common::conductors`):
+- `setup_two_agents()` — two conductors with nondominium DNA
+- `setup_three_agents()` — three conductors with nondominium DNA
+- `setup_dual_dna_two_agents()` — two conductors with nondominium + hREA DNAs (explicit role names)
 
-### Test File Organization
+**DHT sync** between agents: `await_consistency(&[&cell_a, &cell_b]).await.unwrap()`
 
-Tests are organized by zome and functionality:
+### Deprecated: Tryorama (TypeScript)
 
-- `tests/src/nondominium/person/`: Person zome tests
-- `tests/src/nondominium/resource/`: Resource zome tests
-- `tests/src/nondominium/governance/`: Governance zome tests
-- `tests/src/nondominium/governance/ppr-system/`: PPR system tests
+Tests in `tests/` use Tryorama and are deprecated. See `tests/DEPRECATED.md` for migration status.
 
 ## Development Status
 

--- a/dnas/nondominium/tests/Cargo.toml
+++ b/dnas/nondominium/tests/Cargo.toml
@@ -15,8 +15,10 @@ edition = "2021"
 # (see documentation/requirements/ndo_prima_materia.md §10 migration phases).
 
 [dependencies]
-holochain = { workspace = true }
-tokio     = { workspace = true }
+holochain                  = { workspace = true }
+tokio                      = { workspace = true }
+serde                      = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
 
 [[test]]
 name = "misc"

--- a/dnas/nondominium/tests/Cargo.toml
+++ b/dnas/nondominium/tests/Cargo.toml
@@ -21,3 +21,7 @@ tokio     = { workspace = true }
 [[test]]
 name = "misc"
 path = "src/misc/mod.rs"
+
+[[test]]
+name = "person"
+path = "src/person/mod.rs"

--- a/dnas/nondominium/tests/src/common/conductors.rs
+++ b/dnas/nondominium/tests/src/common/conductors.rs
@@ -83,8 +83,10 @@ pub async fn setup_dual_dna_two_agents() -> (
         .await
         .expect("Failed to load hREA DNA bundle");
 
+    // Explicit role names are required so that `CallTargetCell::OtherRole("hrea")`
+    // resolves correctly inside the nondominium zomes.
     let apps = conductors
-        .setup_app("dual", &[dna_nd, dna_hrea])
+        .setup_app("dual", &[("nondominium", dna_nd), ("hrea", dna_hrea)])
         .await
         .expect("Failed to install dual-DNA app on conductors");
 

--- a/dnas/nondominium/tests/src/common/conductors.rs
+++ b/dnas/nondominium/tests/src/common/conductors.rs
@@ -83,10 +83,12 @@ pub async fn setup_dual_dna_two_agents() -> (
         .await
         .expect("Failed to load hREA DNA bundle");
 
-    // Explicit role names are required so that `CallTargetCell::OtherRole("hrea")`
-    // resolves correctly inside the nondominium zomes.
+    // Explicit role names (RoleName = String) are required so that
+    // `CallTargetCell::OtherRole("hrea")` resolves correctly inside the nondominium zomes.
+    let role_nd: (RoleName, DnaFile) = (RoleName::from("nondominium"), dna_nd);
+    let role_hrea: (RoleName, DnaFile) = (RoleName::from("hrea"), dna_hrea);
     let apps = conductors
-        .setup_app("dual", &[("nondominium", dna_nd), ("hrea", dna_hrea)])
+        .setup_app("dual", &[role_nd, role_hrea])
         .await
         .expect("Failed to install dual-DNA app on conductors");
 

--- a/dnas/nondominium/tests/src/lib.rs
+++ b/dnas/nondominium/tests/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod common;
+pub mod person;

--- a/dnas/nondominium/tests/src/lib.rs
+++ b/dnas/nondominium/tests/src/lib.rs
@@ -1,2 +1,1 @@
 pub mod common;
-pub mod person;

--- a/dnas/nondominium/tests/src/person/mod.rs
+++ b/dnas/nondominium/tests/src/person/mod.rs
@@ -1,0 +1,168 @@
+//! Person zome Sweettest integration tests.
+//!
+//! Covers the hREA bridge: creating a Person entry triggers a cross-DNA
+//! `create_rea_agent` call into the hREA DNA, and the resulting ActionHash
+//! is stored in `Person.hrea_agent_hash`.
+//!
+//! Prerequisites (runtime — not compile-time):
+//!   bun run build:happ   # builds both nondominium.dna and hrea.dna
+//!
+//! Run:
+//!   CARGO_TARGET_DIR=target/native-tests cargo test --test person
+
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use serde::{Deserialize, Serialize};
+
+use nondominium_sweettest::common::*;
+
+// ---------------------------------------------------------------------------
+// Local mirror structs — avoids importing zome crates into the test binary.
+// These must match the serialized form of their counterparts in the zomes.
+// ---------------------------------------------------------------------------
+
+/// Mirrors `zome_person_coordinator::PersonInput`.
+#[derive(Debug, Serialize, Deserialize)]
+struct PersonInput {
+    pub name: String,
+    pub avatar_url: Option<String>,
+    pub bio: Option<String>,
+}
+
+/// Mirrors `zome_person_integrity::Person`.
+/// `#[serde(default)]` on `hrea_agent_hash` matches the zome field — required
+/// so that entries serialized before the field existed still deserialize.
+#[derive(Debug, Serialize, Deserialize)]
+struct PersonOutput {
+    pub name: String,
+    pub avatar_url: Option<String>,
+    pub bio: Option<String>,
+    #[serde(default)]
+    pub hrea_agent_hash: Option<ActionHash>,
+}
+
+/// Mirrors the ReaAgent entry type from the hREA coordinator zome.
+/// Only the fields asserted in these tests are included.
+#[derive(Debug, Serialize, Deserialize)]
+struct ReaAgent {
+    pub id: Option<ActionHash>,
+    pub name: String,
+    pub agent_type: String,
+    pub image: Option<String>,
+    pub classified_as: Option<Vec<String>>,
+    pub note: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Decode helper
+// ---------------------------------------------------------------------------
+
+/// Extract and msgpack-deserialize the App entry from a Holochain Record.
+///
+/// Panics if the record has no entry, or if the entry is not an `App` entry,
+/// or if deserialization fails. All three cases indicate a programming error
+/// (wrong return type annotation on the `conductor.call` site).
+fn decode_record_entry<T: serde::de::DeserializeOwned>(record: Record) -> T {
+    match record.entry.into_option().expect("record has no entry") {
+        Entry::App(app_bytes) => holochain_serialized_bytes::decode(app_bytes.into_sb().bytes())
+            .expect("entry deserialization failed"),
+        other => panic!("expected Entry::App, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Creating a Person in the dual-DNA environment populates `hrea_agent_hash`.
+///
+/// Verifies that the cross-DNA bridge (`create_rea_agent_bridge`) runs
+/// successfully and stores the resulting ActionHash on the Person entry.
+#[tokio::test(flavor = "multi_thread")]
+async fn person_create_populates_hrea_agent_hash() {
+    let (conductors, nd_alice, _hrea_alice, _nd_bob, _hrea_bob) =
+        setup_dual_dna_two_agents().await;
+
+    let input = PersonInput {
+        name: "Alice".to_string(),
+        avatar_url: None,
+        bio: None,
+    };
+
+    let record: Record = conductors[0]
+        .call(&nd_alice.zome("zome_person"), "create_person", input)
+        .await;
+
+    let person: PersonOutput = decode_record_entry(record);
+
+    assert!(
+        person.hrea_agent_hash.is_some(),
+        "Person.hrea_agent_hash should be populated after dual-DNA creation. \
+         If None, the cross-DNA bridge call failed — check hREA DNA is built \
+         and both DNA bundles are present in workdir/."
+    );
+}
+
+/// `get_hrea_agents` retrieves the ReaAgent that was created by `create_person`.
+///
+/// Verifies the full round-trip:
+///   create_person → hrea_agent_hash populated
+///   → get_hrea_agents([hash]) → ReaAgent.name matches input
+///   → ReaAgent.agent_type == "Person"
+///   → ReaAgent.image matches avatar_url input
+#[tokio::test(flavor = "multi_thread")]
+async fn get_hrea_agents_returns_matching_rea_agent() {
+    let (conductors, nd_alice, _hrea_alice, _nd_bob, _hrea_bob) =
+        setup_dual_dna_two_agents().await;
+
+    let avatar = "https://example.com/avatar.jpg".to_string();
+    let input = PersonInput {
+        name: "Bob".to_string(),
+        avatar_url: Some(avatar.clone()),
+        bio: None,
+    };
+
+    let person_record: Record = conductors[0]
+        .call(&nd_alice.zome("zome_person"), "create_person", input)
+        .await;
+
+    let person: PersonOutput = decode_record_entry(person_record);
+    let hrea_hash = person
+        .hrea_agent_hash
+        .expect("hrea_agent_hash must be set to test cross-DNA read");
+
+    // Retrieve the ReaAgent from hREA via the cross-DNA read function.
+    // No await_consistency needed here — the read goes through the same
+    // conductor that just wrote the entry.
+    let agents: Vec<Option<Record>> = conductors[0]
+        .call(
+            &nd_alice.zome("zome_person"),
+            "get_hrea_agents",
+            vec![hrea_hash],
+        )
+        .await;
+
+    assert_eq!(agents.len(), 1, "get_hrea_agents should return one entry");
+
+    let agent_record = agents
+        .into_iter()
+        .next()
+        .unwrap()
+        .expect("agent record should not be None");
+
+    let rea_agent: ReaAgent = decode_record_entry(agent_record);
+
+    assert_eq!(
+        rea_agent.name, "Bob",
+        "ReaAgent.name should match Person.name"
+    );
+    assert_eq!(
+        rea_agent.agent_type, "Person",
+        "ReaAgent.agent_type should be 'Person'"
+    );
+    assert_eq!(
+        rea_agent.image,
+        Some(avatar),
+        "ReaAgent.image should match Person.avatar_url"
+    );
+}

--- a/dnas/nondominium/tests/src/person/mod.rs
+++ b/dnas/nondominium/tests/src/person/mod.rs
@@ -11,7 +11,6 @@
 //!   CARGO_TARGET_DIR=target/native-tests cargo test --test person
 
 use holochain::prelude::*;
-use holochain::sweettest::*;
 use serde::{Deserialize, Serialize};
 
 use nondominium_sweettest::common::*;

--- a/dnas/nondominium/tests/src/person/mod.rs
+++ b/dnas/nondominium/tests/src/person/mod.rs
@@ -62,11 +62,13 @@ struct ReaAgent {
 /// Panics if the record has no entry, or if the entry is not an `App` entry,
 /// or if deserialization fails. All three cases indicate a programming error
 /// (wrong return type annotation on the `conductor.call` site).
-fn decode_record_entry<T: serde::de::DeserializeOwned>(record: Record) -> T {
-    match record.entry.into_option().expect("record has no entry") {
-        Entry::App(app_bytes) => holochain_serialized_bytes::decode(app_bytes.into_sb().bytes())
-            .expect("entry deserialization failed"),
-        other => panic!("expected Entry::App, got {other:?}"),
+fn decode_record_entry<T: serde::de::DeserializeOwned>(record: &Record) -> T {
+    match record.entry().as_option() {
+        Some(Entry::App(app_bytes)) => {
+            holochain_serialized_bytes::decode(app_bytes.as_sb().bytes())
+                .expect("entry deserialization failed")
+        }
+        _ => panic!("expected Present App entry"),
     }
 }
 
@@ -93,7 +95,7 @@ async fn person_create_populates_hrea_agent_hash() {
         .call(&nd_alice.zome("zome_person"), "create_person", input)
         .await;
 
-    let person: PersonOutput = decode_record_entry(record);
+    let person: PersonOutput = decode_record_entry(&record);
 
     assert!(
         person.hrea_agent_hash.is_some(),
@@ -126,7 +128,7 @@ async fn get_hrea_agents_returns_matching_rea_agent() {
         .call(&nd_alice.zome("zome_person"), "create_person", input)
         .await;
 
-    let person: PersonOutput = decode_record_entry(person_record);
+    let person: PersonOutput = decode_record_entry(&person_record);
     let hrea_hash = person
         .hrea_agent_hash
         .expect("hrea_agent_hash must be set to test cross-DNA read");
@@ -150,7 +152,7 @@ async fn get_hrea_agents_returns_matching_rea_agent() {
         .unwrap()
         .expect("agent record should not be None");
 
-    let rea_agent: ReaAgent = decode_record_entry(agent_record);
+    let rea_agent: ReaAgent = decode_record_entry(&agent_record);
 
     assert_eq!(
         rea_agent.name, "Bob",

--- a/dnas/nondominium/tests/src/person/mod.rs
+++ b/dnas/nondominium/tests/src/person/mod.rs
@@ -62,10 +62,11 @@ struct ReaAgent {
 /// Panics if the record has no entry, or if the entry is not an `App` entry,
 /// or if deserialization fails. All three cases indicate a programming error
 /// (wrong return type annotation on the `conductor.call` site).
-fn decode_record_entry<T: serde::de::DeserializeOwned>(record: &Record) -> T {
+fn decode_record_entry<T: serde::de::DeserializeOwned + std::fmt::Debug>(record: &Record) -> T {
     match record.entry().as_option() {
         Some(Entry::App(app_bytes)) => {
-            holochain_serialized_bytes::decode(app_bytes.as_sb().bytes())
+            // app_bytes: &AppEntryBytes; Deref<Target=SerializedBytes> gives .bytes() -> &[u8]
+            holochain_serialized_bytes::decode(app_bytes.bytes())
                 .expect("entry deserialization failed")
         }
         _ => panic!("expected Present App entry"),

--- a/documentation/IMPLEMENTATION_STATUS.md
+++ b/documentation/IMPLEMENTATION_STATUS.md
@@ -2,455 +2,246 @@
 
 ## Overview
 
-**nondominium** is a comprehensive Holochain hApp implementing ValueFlows-compliant resource sharing with embedded governance and a Private Participation Rights (PPR) reputation system. This document provides a detailed overview of all implemented functionality as of the current development state.
+**nondominium** is a Holochain hApp implementing ValueFlows-compliant resource sharing with embedded governance and a Private Participation Receipt (PPR) reputation system.
+
+This document tracks what is **actually implemented and verified** in the current codebase. Claims are grounded in code, not design documents.
 
 ## Architecture Overview
 
 ### Technology Stack
 
 - **Backend**: Rust (Holochain HDK ^0.6.0 / HDI ^0.7.0), compiled to WASM
-- **Frontend**: Svelte 5.0 + TypeScript + Vite 6.2.5
-- **Testing**: Vitest 3.1.3 + @holochain/tryorama 0.18.2
+- **Frontend**: Svelte 5.0 + TypeScript + Vite 6.2.5 + TailwindCSS
+- **Testing**: Sweettest (Rust, primary) — Tryorama (TypeScript) is deprecated
 - **Client**: @holochain/client 0.19.0 for DHT interaction
 
 ### Zome Architecture (3-Zome Structure)
-
-The hApp implements a clean separation of concerns across three core zomes:
 
 1. **`zome_person`** - Agent identity, profiles, roles, and capability-based access control
 2. **`zome_resource`** - Resource specifications, lifecycle management, and governance rules
 3. **`zome_gouvernance`** - Economic events, commitments, claims, and the PPR reputation system
 
-Each zome follows the integrity/coordinator pattern with robust validation and comprehensive testing.
+Each zome follows the integrity/coordinator pattern.
 
 ---
 
-## Phase 1: Complete Implementation ✅
+## Phase 1: Complete ✅
 
-### Person Management System
-
-#### Core Identity Management
+### Person Management
 
 - **Public Profiles**: `Person` entries with name, avatar, and bio
-- **Private Data**: `PrivatePersonData` entries with PII (legal name, email, phone, address, emergency contact)
-- **Role-Based Access**: `PersonRole` assignments with predefined role types
+- **Private Data**: `EncryptedProfile` entries with PII (legal name, email, phone, address, emergency contact)
+- **Role-Based Access**: `PersonRole` assignments — `SimpleAgent`, `AccountableAgent`, `PrimaryAccountableAgent`, `Transport`, `Repair`, `Storage`
 - **Agent-to-Person Mapping**: Secure linking between Holochain agents and their profiles
 
-#### Role Types Implemented
-
-- `SimpleAgent` - Basic network participation
-- `AccountableAgent` - Enhanced accountability level
-- `PrimaryAccountableAgent` - Highest accountability level
-- `Transport` - Transport process access
-- `Repair` - Repair process access
-- `Storage` - Storage process access
-
 #### Capability-Based Access Control ✅
-
-**Advanced private data sharing system with granular permissions:**
 
 - **Capability Grants**: Time-limited access tokens with field-level permissions
 - **Filtered Data Access**: `FilteredPrivateData` entries with selective field exposure
 - **Grant Metadata**: `PrivateDataCapabilityMetadata` for tracking access grants
 - **Field-Level Control**: Granular permissions for email, phone, location, time_zone, emergency_contact, address
 - **Time-Based Expiration**: 30-day maximum grant duration with configurable expiration
-- **Context-Aware Access**: Access grants include business context and purpose
 
-**Key Features:**
+#### Not yet implemented (person domain)
 
-- Cryptographic capability tokens using Holochain's capability system
-- Private entry storage for sensitive data
-- Secure delegation with audit trail
-- Revocable access through grant expiration
+- Private data access request/approval workflow (#40)
+- Audit trail for private data access events (#38)
+- `get_expiring_grants()` for proactive grant lifecycle management (#37)
+- Full agent promotion workflow logic (#33) — roles exist, promotion workflow incomplete
+- Specialized role validation (#34)
 
-### Resource Management System
+### Resource Management
 
 #### Resource Specifications ✅
 
-- **Structured Specifications**: `ResourceSpecification` entries with name, description, category
-- **Tag-Based Discovery**: Flexible tagging system for resource categorization
-- **Governance Integration**: Direct linking to governance rules
-- **Active/Inactive Status**: Lifecycle management for specifications
+- `ResourceSpecification` entries with name, description, category
+- Tag-based discovery, governance rule linking, active/inactive status
 
 #### Economic Resources ✅
 
-- **Resource Instances**: `EconomicResource` entries conforming to specifications
-- **Quantity Management**: Precise quantity tracking with units
-- **Custodian Assignment**: Primary Accountable Agent designation
-- **Location Tracking**: Physical or virtual location metadata
-- **State Management**: Five-state lifecycle (PendingValidation, Active, Maintenance, Retired, Reserved)
+- `EconomicResource` entries conforming to specifications
+- Quantity tracking with units, custodian assignment, location metadata
+- Five-state lifecycle: `PendingValidation`, `Active`, `Maintenance`, `Retired`, `Reserved`
+
+> **Note**: The current `ResourceState` conflates lifecycle maturity and operational condition. The NDO three-layer model (post-MVP) separates these into `LifecycleStage` + `OperationalState`. See `documentation/requirements/ndo_prima_materia.md`.
 
 #### Governance Rules ✅
 
-- **Rule Types**: Extensible rule system with JSON-encoded parameters
-- **Enforcement Roles**: Optional role requirements for rule enforcement
-- **Resource Integration**: Direct governance attachment to resources
-- **Audit Trail**: Complete rule creation and modification tracking
+- Extensible rule system with JSON-encoded parameters
+- Enforcement role requirements, resource attachment, audit trail
 
-### Discovery and Query Patterns ✅
+#### Discovery and Query Patterns ✅
 
-#### Comprehensive Link Architecture
-
-- **Discovery Anchors**: `AllResourceSpecifications`, `AllEconomicResources`, `AllGovernanceRules`
-- **Hierarchical Links**: Specification → Resource, Custodian → Resources
-- **Agent-Centric Patterns**: Agent → Owned Specs, Agent → Managed Resources
-- **Service-Type Patterns**: Category-based and location-based queries
-- **Update Patterns**: Version tracking for all major entities
-
-#### Efficient Query Support
-
-- Category-based resource discovery
-- Location-based resource filtering
-  State-based resource queries
-- Role-based access patterns
-- Governance rule type filtering
+- Anchors: `AllResourceSpecifications`, `AllEconomicResources`, `AllGovernanceRules`
+- Hierarchical links: Specification → Resource, Custodian → Resources
+- Category-based, location-based, and state-based query support
 
 ---
 
-## Phase 2: Advanced Governance & PPR System ✅
+## Phase 2: In Progress 🔄
 
-### ValueFlows Economic Framework ✅
+### ValueFlows Economic Framework
 
-#### Complete Action Vocabulary
+#### Action Vocabulary ✅
 
-**Standard ValueFlows Actions:**
-
-- `Transfer` - Ownership/custody transfer
-- `Move` - Location change
-- `Use` - Resource utilization
-- `Consume` - Resource consumption/destruction
-- `Produce` - New resource creation
-- `Work` - Labor application
-- `Modify` - Resource modification
-- `Combine`/`Separate` - Resource composition
-- `Raise`/`Lower` - Quantity adjustment
-- `Cite`/`Accept` - Reference and acceptance
-
-**nondominium-Specific Actions:**
-
-- `InitialTransfer` - First transfer by Simple Agent
-- `AccessForUse` - Usage access request
-- `TransferCustody` - Custodial transfer
+Standard ValueFlows actions (`Transfer`, `Move`, `Use`, `Consume`, `Produce`, `Work`, `Modify`, `Combine`, `Separate`, `Raise`, `Lower`, `Cite`, `Accept`) plus nondominium extensions (`InitialTransfer`, `AccessForUse`, `TransferCustody`).
 
 #### Economic Events ✅
 
-- **Event Recording**: Complete `EconomicEvent` capture with provider/receiver
-- **Resource Linking**: Direct connection to affected resources
-- **Quantity Tracking**: Precise quantity changes with units
-- **Temporal Accuracy**: Event timestamping with note support
+- `EconomicEvent` entry capture with provider/receiver, resource linking, quantity, timestamping
 
 #### Commitments & Claims ✅
 
-- **Commitment Management**: Future economic commitments with due dates
-- **Claim Fulfillment**: Completion tracking through `Claim` entries
-- **Bidirectional Linking**: Commitments ↔ Events ↔ Claims
-- **Performance Tracking**: Optional notes and fulfillment evidence
+- Future economic commitments with due dates
+- `Claim` entries for fulfillment tracking
+- Bidirectional links: Commitments ↔ Events ↔ Claims
 
-### Private Participation Rights (PPR) System ✅
+#### Economic Processes ❌ Not implemented
 
-#### Revolutionary Reputation Framework
+Use, Transport, Storage, and Repair process workflows are specified but not implemented. Tracked in #28, #29, #31, #32.
 
-**Complete PPR implementation with 16 distinct claim categories:**
+### PPR Reputation System
 
-**Genesis Roles (Network Entry):**
+#### Data Structures ✅
 
-- `ResourceCreation` - Recognition for successful resource contributions
-- `ResourceValidation` - Credit for network validation activities
+16 `ParticipationClaimType` variants are defined in `zome_gouvernance/src/ppr.rs`:
+- Genesis: `ResourceCreation`, `ResourceValidation`
+- Custody: `CustodyTransfer`, `CustodyAcceptance`
+- Services: `MaintenanceCommitmentAccepted`, `MaintenanceFulfillmentCompleted`, `StorageCommitmentAccepted`, `StorageFulfillmentCompleted`, `TransportCommitmentAccepted`, `TransportFulfillmentCompleted`, `GoodFaithTransfer`
+- Governance: `DisputeResolutionParticipation`, `ValidationActivity`, `RuleCompliance`
+- End-of-Life: `EndOfLifeDeclaration`, `EndOfLifeValidation`
 
-**Core Usage Roles (Custodianship):**
-
-- `CustodyTransfer` - Outgoing custodian recognition
-- `CustodyAcceptance` - Incoming custodian validation
-
-**Intermediate Roles (Specialized Services):**
-
-- `MaintenanceCommitmentAccepted`/`MaintenanceFulfillmentCompleted`
-- `StorageCommitmentAccepted`/`StorageFulfillmentCompleted`
-- `TransportCommitmentAccepted`/`TransportFulfillmentCompleted`
-- `GoodFaithTransfer` - Trust-based transfer recognition
-
-**Network Governance:**
-
-- `DisputeResolutionParticipation` - Constructive conflict resolution
-- `ValidationActivity` - Ongoing validation duties
-- `RuleCompliance` - Consistent governance adherence
-
-**Resource End-of-Life:**
-
-- `EndOfLifeDeclaration` - Responsible lifecycle management
-- `EndOfLifeValidation` - Expert validation services
-
-#### Advanced Performance Metrics ✅
-
-**Quantitative Performance Tracking:**
-
-- **Timeliness Score** (0.0-1.0) - Punctuality assessment
-- **Quality Score** (0.0-1.0) - Work quality evaluation
-- **Reliability Score** (0.0-1.0) - Commitment fulfillment
-- **Communication Score** (0.0-1.0) - Communication effectiveness
-- **Overall Satisfaction** (0.0-1.0) - Counterparty satisfaction
-- **Weighted Average Calculation** - 25%/30%/25%/20% weighting system
+Performance score fields (timeliness, quality, reliability, communication, satisfaction) and `ReputationSummary` struct with category breakdowns are implemented.
 
 #### Cryptographic Authentication ✅
 
-**Bilateral Signature System:**
+Bilateral signature system with dual signatures, hash-based security, and temporal validation is implemented in the integrity zome.
 
-- **Dual Signatures**: Both recipient and counterparty authentication
-- **Verification Context**: Reconstructible signing contexts
-- **Hash-Based Security**: SHA-256 hashing of signed data
-- **Temporal Validation**: Signature timestamping
-- **Role-Based Contexting**: Different contexts for different roles
+#### Not yet implemented (PPR domain)
 
-#### Privacy-Preserving Reputation ✅
+- Bi-directional receipt generation zome functions (#14)
+- Genesis role and custody receipt issuance workflows (#15, #16)
+- End-of-life management with multi-validator security (#18)
+- Challenge period mechanism for EOL declarations (#19)
+- Historical review system for EOL abuse prevention (#20)
+- PPR reputation aggregation zome function (#21)
 
-**ReputationSummary System:**
+### Governance-as-Operator Architecture ❌ Not implemented
 
-- **Aggregated Metrics**: Total claims, average performance by category
-- **Category Breakdown**: Creation, Custody, Service, Governance, End-of-Life
-- **Period-Based Summaries**: Time-bounded reputation windows
-- **Selective Disclosure**: Privacy-preserving reputation sharing
-
-### Resource Validation System ✅
-
-#### Multi-Party Validation
-
-- **ValidationReceipt**: Signed validation records with approver status
-- **ResourceValidation**: Configurable validation schemes ("2-of-3", "simple_majority")
-- **Progress Tracking**: Current vs. required validator counting
-- **Status Management**: Pending → Approved/Rejected workflow
-- **Evidence Collection**: Optional validation notes and documentation
+The governance-as-operator pattern (pure-function `GovernanceEngine`, cross-zome interface types, Request-Evaluate-Apply resource refactor, automatic event generation on state transitions) is fully specified in `documentation/specifications/governance/` but not yet implemented. Tracked in #41–#44.
 
 ---
 
-## Frontend Implementation ✅
+## hREA Dual-DNA Integration
 
-### Svelte 5 Architecture ✅
+### Phase 1: Complete ✅
 
-- **Modern SvelteKit**: Full Svelte 5.0 implementation with TypeScript
-- **Holochain Integration**: Comprehensive `HolochainProvider` component
-- **Responsive Layout**: Clean, accessible UI design
-- **Error Handling**: Robust error management and user feedback
+- hREA git submodule (`vendor/hrea`, Sensorica fork)
+- `happ.yaml` dual-DNA roles configuration
+- hREA DNA compiled and included in `.webhapp` bundle
+- `hrea_agent_hash` field added to `Person` integrity entry
+- `create_rea_agent` bridge call in `zome_person` coordinator
+- `create_person` creates a `ReaAgent` in hREA first
+- Cross-DNA validation tests in Sweettest
 
-### UI Components ✅
+### Phases 2–4: Not started ❌
 
-- **Profile Management**: Person profile creation and editing
-- **Resource Browser**: Resource discovery and management interface
-- **Role Assignment**: Role management and assignment tools
-- **Capability Management**: Private data sharing controls
-- **Real-time Updates**: Live DHT synchronization
+Resource lifecycle, governance/PPR wiring, and production hardening via hREA are tracked under epic #47.
 
 ---
 
-## Testing Infrastructure ✅
+## Frontend
 
-### Comprehensive Test Suite ✅
+### Infrastructure ✅
 
-#### 4-Layer Testing Strategy
+- SvelteKit + TailwindCSS project scaffolded (`vite.config.ts`, `svelte.config.js`)
+- `HolochainProvider.svelte` — Holochain client connection management
+- Service layer stubs: `person.service.ts`, `resource.service.ts`, `governance.service.ts`
+- Store layer stubs: `person.store.svelte.ts`, `resource.store.svelte.ts`, `governance.store.svelte.ts`
 
-1. **Foundation Tests**: Basic zome function validation and connectivity
-2. **Integration Tests**: Cross-zome interactions and multi-agent scenarios
-3. **Scenario Tests**: Complete user journeys and end-to-end workflows
-4. **PPR System Tests**: Cryptographic validation and reputation calculation
+### UI Components ❌ Not implemented
 
-#### Test Coverage by Domain
+No domain-specific UI components exist yet. The following are tracked as open issues:
 
-**Person Zome Tests:**
+- Person management components (#8)
+- Resource management components (#9)
+- Effect-TS service layer (#7) — current services use plain TypeScript
+- Capability-based private data sharing UI (#39)
+- PPR reputation visualization (#22)
 
-- `person-foundation-tests.test.ts` - Core functionality validation
-- `person-integration-tests.test.ts` - Cross-component interactions
-- `person-scenario-tests.test.ts` - Complete user workflows
-- `capability_based_sharing_tests.test.ts` - Advanced access control
+---
 
-**Resource Zome Tests:**
+## Testing Infrastructure
 
-- `resource-foundation-tests.test.ts` - Basic resource operations
-- `resource-integration-tests.test.ts` - Cross-zome interactions
-- `resource-scenario-tests.test.ts` - Complex resource workflows
-- `resource-update-test.test.ts` - Update and versioning
+### Sweettest (Rust) — Primary ✅
 
-**Governance Zome Tests:**
+All new tests are written in Sweettest in `dnas/nondominium/tests/src/`.
 
-- `governance-foundation-tests.test.ts` - Core governance validation
-- `ppr-foundation.test.ts` - PPR system basics
-- `ppr-cryptography.test.ts` - Cryptographic signature validation
-- `ppr-integration.test.ts` - Cross-system PPR interactions
-- `ppr-scenarios.test.ts` - Complete PPR workflows
+**Shared setup utilities** (`common::conductors`):
+- `setup_two_agents()` — two conductors, nondominium DNA
+- `setup_three_agents()` — three conductors, nondominium DNA
+- `setup_dual_dna_two_agents()` — two conductors, nondominium + hREA DNAs
 
-#### Test Configuration ✅
+**Test modules:**
+- `misc/mod.rs` — zome connectivity (ping)
+- `person/mod.rs` — person zome + hREA bridge tests
 
-- **Timeout**: 4-minute timeout for complex multi-agent scenarios
-- **Concurrency**: Single-fork execution for DHT consistency
-- **Agent Simulation**: Support for 2+ distributed agents per test
-- **Performance Testing**: Load testing capabilities for PPR system
+### Tryorama (TypeScript) — Deprecated ⚠
+
+Tests in `tests/` are deprecated. See `tests/DEPRECATED.md` for migration status. Do not write new tests there.
 
 ---
 
 ## Development Environment & Tooling ✅
 
-### Build System ✅
-
-- **Nix Environment**: Reproducible development environment
-- **WASM Compilation**: Rust to WASM pipeline with optimized builds
-- **Package Management**: Bun-based dependency management
-- **Hot Reload**: Development server with live reload
-
-### Development Commands ✅
-
 ```bash
+git submodule update --init --recursive  # Initialize hREA submodule (REQUIRED)
 nix develop              # Reproducible environment (REQUIRED)
 bun install              # Dependency installation
 bun run start            # 2-agent development network with UIs
-bun run network          # Custom agent networks
-bun run tests             # Full test suite execution
 bun run build:zomes      # WASM compilation
 bun run build:happ       # DNA packaging
 bun run package          # Final .webhapp distribution
+
+# Sweettest (primary test runner)
+CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
 ```
-
-### Quality Assurance ✅
-
-- **TypeScript**: Full type safety across frontend and shared types
-- **Code Formatting**: Consistent code formatting and linting
-- **Validation Rules**: Comprehensive input validation at all layers
-- **Error Handling**: Robust error propagation and user feedback
-
----
-
-## Data Model Completeness ✅
-
-### Person Domain ✅
-
-- **Public Identity**: Name, avatar, bio with validation
-- **Private Data**: PII with encrypted storage and capability access
-- **Role Management**: Hierarchical role assignments with audit trails
-- **Access Control**: Time-limited, context-aware capability grants
-
-### Resource Domain ✅
-
-- **Specifications**: Structured resource definitions with governance links
-- **Instances**: Economic resources with quantity and custodian tracking
-- **Lifecycle**: Complete state management (pending → active → retired)
-- **Governance**: Embedded rule system with enforcement roles
-
-### Governance Domain ✅
-
-- **Economic Events**: Complete ValueFlows action vocabulary
-- **Commitments**: Future economic agreements with fulfillment tracking
-- **Claims**: Bilateral completion evidence with performance metrics
-- **Reputation**: Privacy-preserving PPR system with cryptographic validation
-
----
-
-## Security & Privacy ✅
-
-### Data Protection ✅
-
-- **Private Entries**: Sensitive data stored as private Holochain entries
-- **Capability-Based Access**: Granular, revocable access permissions
-- **Cryptographic Authentication**: Bilateral signatures for all PPR claims
-- **Context-Aware Sharing**: Access grants include business purpose and time limits
-
-### Access Control ✅
-
-- **Role-Based Permissions**: Hierarchical access through role assignments
-- **Agent Authorization**: Only authorized agents can perform specific actions
-- **Validation Layers**: Multi-layer validation (integrity + coordinator + business logic)
-- **Audit Trails**: Complete audit trail for all access and modifications
-
----
-
-## ValueFlows Compliance ✅
-
-### Standard Implementation ✅
-
-- **Action Vocabulary**: Complete ValueFlows action set with extensions
-- **Economic Events**: Standard event structure with resource linking
-- **Commitments**: Future commitment framework with due dates
-- **Claims**: Completion evidence with performance metrics
-- **Resource Lifecycle**: Standard resource state management
-
-### nondominium Extensions ✅
-
-- **Enhanced Actions**: InitialTransfer, AccessForUse, TransferCustody
-- **PPR Integration**: Reputation system integrated with ValueFlows flows
-- **Governance Embedding**: Rules directly attached to resources
-- **Agent Roles**: Extended role system beyond basic agent types
-
----
-
-## Performance & Scalability ✅
-
-### Optimization Features ✅
-
-- **Efficient Queries**: Optimized link structures for common query patterns
-- **Caching Strategy**: Local caching for frequently accessed data
-- **Parallel Operations**: Concurrent testing and development operations
-- **Memory Management**: Efficient WASM compilation and resource usage
-
-### Scalability Design ✅
-
-- **DHT Optimization**: Efficient data distribution across Holochain DHT
-- **Link-Based Queries**: Scalable discovery patterns without centralized indexing
-- **Validation Distribution**: Distributed validation across network participants
-- **Reputation Aggregation**: Efficient reputation calculation without data exposure
 
 ---
 
 ## Current Status Summary
 
-### ✅ Fully Implemented
-
-1. **Complete Person Management** - Profiles, roles, private data, capability access
-2. **Comprehensive Resource System** - Specifications, instances, governance, lifecycle
-3. **Advanced Governance Framework** - ValueFlows compliance, economic events, commitments
-4. **Revolutionary PPR System** - 16 claim types, performance metrics, cryptographic validation
-5. **Modern Frontend** - Svelte 5, TypeScript, responsive design
-6. **Comprehensive Testing** - 4-layer strategy, 95%+ coverage, performance testing
-7. **Development Tooling** - Nix environment, build pipeline, quality assurance
-
-### 🔄 Development Phase
-
-- **Status**: Phase 2 Complete - Production Ready
-- **Test Coverage**: Comprehensive across all domains
-- **Documentation**: Complete technical documentation
-- **Quality**: Production-ready with robust error handling and validation
-
-### 🎯 Key Innovations
-
-1. **Capability-Based Private Data Sharing** - Industry-leading privacy control
-2. **PPR Reputation System** - Cryptographic, privacy-preserving reputation
-3. **Embedded Governance** - Rules directly attached to resources
-4. **ValueFlows Compliance** - Complete economic vocabulary implementation
-5. **Bilateral Authentication** - Dual-signature system for all interactions
+| Area | Status |
+|---|---|
+| Person management (profiles, roles, capability grants) | ✅ Complete |
+| Resource specifications and economic resources | ✅ Complete |
+| ValueFlows action vocabulary + economic events | ✅ Complete |
+| Commitments and claims | ✅ Complete |
+| PPR data structures + cryptographic auth | ✅ Complete |
+| hREA Phase 1 (Person/ReaAgent bridge) | ✅ Complete |
+| SvelteKit + TailwindCSS setup | ✅ Complete |
+| Sweettest scaffold + person tests | ✅ Complete |
+| Economic processes (Use/Transport/Storage/Repair) | ❌ Not started |
+| PPR receipt generation and EOL workflows | ❌ Not started |
+| Governance-as-Operator architecture | ❌ Not started |
+| Agent promotion + role validation workflows | 🔄 Partial |
+| Frontend UI components | ❌ Not started |
+| Effect-TS service layer | ❌ Not started |
+| hREA Phase 2–4 | ❌ Not started |
+| NDO three-layer model (Layer 0) | ❌ Not started |
 
 ---
 
-## Post-MVP design specifications (not in shipped DNA yet)
+## Post-MVP Design Specifications
 
-The following are **documented and traceable** to REQ-NDO-* in `documentation/requirements/ndo_prima_materia.md` but **not implemented** in the current MVP codebase unless noted otherwise:
+The following are documented and traceable to REQ-NDO-* in `documentation/requirements/ndo_prima_materia.md` but are not in scope for the current development milestone:
 
 | Track | Design sources | Implementation status |
-| ----- | -------------- | ---------------------- |
-| **NDO three-layer model** | `ndo_prima_materia.md` §§4, 8, 10; `resources.md` §3 | Not started — MVP uses flat `ResourceSpecification` + `EconomicResource` |
-| **Lifecycle vs operational state split** | `ndo_prima_materia.md` §5, §9.4 (`REQ-NDO-OS-01`–`06`) | Not started — `ResourceState` still conflated (see zome_resource TODOs) |
+|---|---|---|
+| **NDO three-layer model** | `ndo_prima_materia.md` §§4, 8, 10; `resources.md` §3 | Not started — tracked in #73–#77 |
+| **Lifecycle vs operational state split** | `ndo_prima_materia.md` §5, §9.4 (`REQ-NDO-OS-01`–`06`) | Not started — `ResourceState` still conflated (see `zome_resource` TODOs) |
 | **Unyt (EconomicAgreement, RAVE)** | `ndo_prima_materia.md` §6.6, §11.5; `unyt-integration.md`; REQ-NDO-CS-07–CS-11 | Not started — no Unyt cell / RAVE validation in governance zome |
-| **Flowsta (agent linking, IdentityVerification)** | `ndo_prima_materia.md` §6.7, §11.6; `flowsta-integration.md`; REQ-NDO-CS-12–CS-15 | Not started — `flowsta-agent-linking` zomes not bundled; `GovernanceRule` remains untyped strings |
+| **Flowsta (agent linking, IdentityVerification)** | `ndo_prima_materia.md` §6.7, §11.6; `flowsta-integration.md`; REQ-NDO-CS-12–CS-15 | Not started — `flowsta-agent-linking` zomes not bundled |
 | **Person capability slot (G15)** | `agent.md` §3.2; `person_zome.md`; REQ-AGENT-11, REQ-NDO-AGENT-07 | Not started — no `FlowstaIdentity` links on `Person` hash |
 
-See `documentation/implementation_plan.md` Section 12 for a phased checklist aligned with prima materia.
-
----
-
-## Conclusion
-
-The nondominium hApp represents a **complete, production-ready implementation** of a sophisticated ValueFlows-compliant resource sharing ecosystem with advanced privacy controls and revolutionary reputation mechanics. All major components are fully implemented, thoroughly tested, and ready for deployment.
-
-The implementation demonstrates:
-
-- **Technical Excellence** - Modern stack, comprehensive testing, robust architecture
-- **Privacy Leadership** - Capability-based access, private data protection, cryptographic validation
-- **Economic Innovation** - Complete ValueFlows integration, PPR reputation system
-- **Governance Integration** - Embedded rules, multi-party validation, role-based access
-- **Production Readiness** - Comprehensive testing, error handling, development tooling
-
-This is not a proof-of-concept but a **complete implementation** ready for real-world deployment and user adoption.
+See `documentation/implementation_plan.md` Section 12 for a phased checklist aligned with the prima materia.

--- a/tests/DEPRECATED.md
+++ b/tests/DEPRECATED.md
@@ -1,0 +1,50 @@
+# DEPRECATED: Tryorama Test Suite
+
+This directory (`tests/`) contains the legacy Tryorama (TypeScript + Vitest) test suite.
+
+## Status
+
+**All tests in this directory are deprecated.** They are kept as a historical reference only and will not be maintained.
+
+## Migration
+
+The active test suite is **Sweettest (Rust)** located at:
+
+```
+dnas/nondominium/tests/src/
+```
+
+Run Sweettest tests with:
+
+```bash
+# Prerequisites: build the DNA bundles first
+bun run build:happ
+
+# Run all Sweettest tests
+CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
+
+# Run a specific test module
+CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test person
+
+# Run a specific test function
+CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test person person_create_populates_hrea_agent_hash
+```
+
+## Why Sweettest
+
+nondominium is a Rust-native Holochain application. Sweettest runs the conductor in-process using native Rust types — no TypeScript serialization layer, faster iteration, and direct DHT database inspection. It is the official Holochain team recommendation for integration testing.
+
+## Test Coverage Migration Status
+
+| Tryorama file | Sweettest equivalent | Status |
+|---|---|---|
+| `misc/misc.test.ts` | `dnas/nondominium/tests/src/misc/mod.rs` | Migrated |
+| `person/person-hrea-bridge-tests.test.ts` | `dnas/nondominium/tests/src/person/mod.rs` | Migrated |
+| `person/person-foundation-tests.test.ts` | pending | Not started |
+| `person/person-integration-tests.test.ts` | pending | Not started |
+| `person/person-scenario-tests.test.ts` | pending | Not started |
+| `person/person-capability-based-sharing.test.ts` | pending | Not started |
+| `person/device-*.test.ts` | pending | Not started |
+| `resource/*.test.ts` | pending | Not started |
+| `governance/*.test.ts` | pending | Not started |
+| `governance/ppr-system/*.test.ts` | pending | Not started |

--- a/tests/src/nondominium/governance/governance-foundation-tests.test.ts
+++ b/tests/src/nondominium/governance/governance-foundation-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 import { runScenarioWithTwoAgents } from "../utils.js";

--- a/tests/src/nondominium/governance/ppr-system/ppr-cryptography.test.ts
+++ b/tests/src/nondominium/governance/ppr-system/ppr-cryptography.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { test, expect } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 import { runScenarioWithTwoAgents } from "../../utils.js";

--- a/tests/src/nondominium/governance/ppr-system/ppr-debug.test.ts
+++ b/tests/src/nondominium/governance/ppr-system/ppr-debug.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { test, expect } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 import { runScenarioWithTwoAgents } from "../../utils.js";

--- a/tests/src/nondominium/governance/ppr-system/ppr-foundation.test.ts
+++ b/tests/src/nondominium/governance/ppr-system/ppr-foundation.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { test, expect } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 import { runScenarioWithTwoAgents } from "../../utils.js";

--- a/tests/src/nondominium/governance/ppr-system/ppr-integration.test.ts
+++ b/tests/src/nondominium/governance/ppr-system/ppr-integration.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { test, expect } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 import { runScenarioWithTwoAgents } from "../../utils.js";

--- a/tests/src/nondominium/governance/ppr-system/ppr-scenarios.test.ts
+++ b/tests/src/nondominium/governance/ppr-system/ppr-scenarios.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { test, expect } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 import { runScenarioWithTwoAgents } from "../../utils.js";

--- a/tests/src/nondominium/misc/misc.test.ts
+++ b/tests/src/nondominium/misc/misc.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, expect, test } from "vitest";
 import { Scenario, runScenario } from "@holochain/tryorama";
 import { decode } from "@msgpack/msgpack";

--- a/tests/src/nondominium/person/device-foundation-tests.test.ts
+++ b/tests/src/nondominium/person/device-foundation-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 import { ActionHash } from "@holochain/client";

--- a/tests/src/nondominium/person/device-integration-tests.test.ts
+++ b/tests/src/nondominium/person/device-integration-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/person/device-multi-device-tests.test.ts
+++ b/tests/src/nondominium/person/device-multi-device-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/person/device-security-tests.test.ts
+++ b/tests/src/nondominium/person/device-security-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/person/person-capability-based-sharing.test.ts
+++ b/tests/src/nondominium/person/person-capability-based-sharing.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/person/person-foundation-tests.test.ts
+++ b/tests/src/nondominium/person/person-foundation-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/person/person-hrea-bridge-tests.test.ts
+++ b/tests/src/nondominium/person/person-hrea-bridge-tests.test.ts
@@ -1,4 +1,12 @@
 /**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
+/**
  * hREA Bridge Integration Tests — Issues #51, #52, #53, #55
  *
  * Validates that create_person creates a corresponding ReaAgent in the hREA DNA

--- a/tests/src/nondominium/person/person-integration-tests.test.ts
+++ b/tests/src/nondominium/person/person-integration-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/person/person-scenario-tests.test.ts
+++ b/tests/src/nondominium/person/person-scenario-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/resource/resource-foundation-tests.test.ts
+++ b/tests/src/nondominium/resource/resource-foundation-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { test } from "vitest";
 import {
   runScenario,

--- a/tests/src/nondominium/resource/resource-integration-tests.test.ts
+++ b/tests/src/nondominium/resource/resource-integration-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/resource/resource-scenario-tests.test.ts
+++ b/tests/src/nondominium/resource/resource-scenario-tests.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/resource/resource-update-test.test.ts
+++ b/tests/src/nondominium/resource/resource-update-test.test.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import { assert, test } from "vitest";
 import { Scenario, PlayerApp, dhtSync } from "@holochain/tryorama";
 

--- a/tests/src/nondominium/utils.ts
+++ b/tests/src/nondominium/utils.ts
@@ -1,3 +1,11 @@
+/**
+ * @deprecated Tryorama (TypeScript) tests are deprecated.
+ *
+ * All new tests must be written in Sweettest (Rust): `dnas/nondominium/tests/`
+ * These files are kept as reference but will not be maintained going forward.
+ * See tests/DEPRECATED.md for migration context.
+ */
+
 import * as fs from "fs";
 import {
   Conductor,


### PR DESCRIPTION
## Intent

Deprecate the Tryorama (TypeScript) test suite and establish Sweettest (Rust) as the sole active testing framework. All new tests must be written in Sweettest. Tryorama files are kept as historical reference only.

## Changes

**Deprecation (21 files):**
- Added `@deprecated` banner to all 21 Tryorama test files in `tests/src/nondominium/`
- Created `tests/DEPRECATED.md` with migration table and Sweettest run commands

**CLAUDE.md:**
- Marked `bun run tests` as deprecated in Core Development Commands
- Replaced Testing Commands section with Sweettest-first commands
- Replaced Test Architecture section with Sweettest-primary layout

**Sweettest — person/hREA bridge tests (`dnas/nondominium/tests/src/person/mod.rs`):**
- `person_create_populates_hrea_agent_hash` — verifies dual-DNA bridge sets `hrea_agent_hash`
- `get_hrea_agents_returns_matching_rea_agent` — verifies cross-DNA read returns correct ReaAgent fields
- `decode_record_entry` helper using `record.entry().as_option()` / `app_bytes.as_sb().bytes()` (Holochain 0.6.x pattern)

**Bug fix — `conductors.rs`:**
- `setup_dual_dna_two_agents()` now uses explicit role names `("nondominium", dna_nd)` and `("hrea", dna_hrea)`
- Required so `CallTargetCell::OtherRole("hrea")` resolves correctly inside the nondominium zomes

**documentation/IMPLEMENTATION_STATUS.md (refactored):**
- Trimmed ~335 lines of speculative/aspirational content
- Grounded all claims in what is actually implemented vs. not started
- Marked unimplemented features (economic processes, PPR workflows, UI components) with ❌ explicitly
- Added hREA Phase 1 completion and Sweettest scaffold to current-status table

## Decisions

| Option | Rejected because |
| ------ | ---------------- |
| Import `zome_person_integrity` as dev-dep for `Person` type | Adds native compilation dependency on `hdk_entry_helper` macros; local mirror structs are simpler and sufficient for test assertions |
| Positional `&[dna_nd, dna_hrea]` in `setup_dual_dna_two_agents` | Role names not guaranteed by position — `CallTargetCell::OtherRole("hrea")` requires exact name match; explicit tuple `("hrea", dna)` is required |

## How to test

```bash
bun run build:happ
CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
```

## Documentation

- `tests/DEPRECATED.md` — created; migration table with Sweettest run commands and per-file status
- `documentation/IMPLEMENTATION_STATUS.md` — refactored; see Changes section above