### PR TITLE
feat(resource): add NondominiumIdentity entry type with lifecycle validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,5 +154,6 @@ Tests are organized by zome and functionality:
 
 **Phase 1 (Complete)**: Person management with role-based access control
 **Phase 2 (In Progress)**: Resource lifecycle and governance implementation, PPR system
+- NDO Layer 0 (`NondominiumIdentity` identity anchor): complete (#80)
 
 The codebase follows Holochain best practices with comprehensive testing, clear zome separation, and ValueFlows standard compliance.

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/lib.rs
@@ -3,10 +3,12 @@ pub use nondominium_utils::errors::ResourceError;
 
 pub mod economic_resource;
 pub mod governance_rule;
+pub mod ndo_identity;
 pub mod resource_specification;
 
 pub use economic_resource::*;
 pub use governance_rule::*;
+pub use ndo_identity::*;
 pub use resource_specification::*;
 
 #[allow(clippy::large_enum_variant)]

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -1,0 +1,186 @@
+use crate::ResourceError;
+use hdk::prelude::*;
+use zome_resource_integrity::*;
+
+// Input for creating a NondominiumIdentity (Layer 0 anchor)
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NdoInput {
+  pub name: String,
+  pub property_regime: PropertyRegime,
+  pub resource_nature: ResourceNature,
+  pub lifecycle_stage: LifecycleStage,
+  pub description: Option<String>,
+}
+
+// Output from create_ndo — the action_hash IS the stable Layer 0 identity
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NdoOutput {
+  pub action_hash: ActionHash,
+  pub entry: NondominiumIdentity,
+}
+
+// Input for updating a NondominiumIdentity's lifecycle stage (the only permitted mutation)
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateLifecycleStageInput {
+  pub original_action_hash: ActionHash,
+  pub new_stage: LifecycleStage,
+}
+
+/// Create a new NondominiumIdentity (NDO Layer 0 anchor).
+///
+/// The returned action_hash is the stable, permanent Layer 0 identity for this resource.
+/// It never changes, even as lifecycle_stage evolves through subsequent updates.
+///
+/// REQ-NDO-L0-01, REQ-NDO-L0-02, REQ-NDO-L0-07
+#[hdk_extern]
+pub fn create_ndo(input: NdoInput) -> ExternResult<NdoOutput> {
+  if input.name.trim().is_empty() {
+    return Err(ResourceError::InvalidInput("Name cannot be empty".to_string()).into());
+  }
+
+  let agent_info = agent_info()?;
+
+  let entry = NondominiumIdentity {
+    name: input.name,
+    initiator: agent_info.agent_initial_pubkey.clone(),
+    property_regime: input.property_regime,
+    resource_nature: input.resource_nature,
+    lifecycle_stage: input.lifecycle_stage,
+    created_at: sys_time()?,
+    description: input.description,
+  };
+
+  let action_hash = create_entry(&EntryTypes::NondominiumIdentity(entry.clone()))?;
+
+  // Global discovery anchor — all NDOs discoverable by anyone
+  let all_ndos_path = Path::from("ndo_identities");
+  create_link(
+    all_ndos_path.path_entry_hash()?,
+    action_hash.clone(),
+    LinkTypes::AllNdos,
+    (),
+  )?;
+
+  // Agent-centric discovery — initiator's NDOs discoverable per agent
+  create_link(
+    agent_info.agent_initial_pubkey.clone(),
+    action_hash.clone(),
+    LinkTypes::AgentToNdo,
+    (),
+  )?;
+
+  Ok(NdoOutput { action_hash, entry })
+}
+
+/// Retrieve the latest NondominiumIdentity by its original action hash.
+///
+/// Resolves the HDK update chain iteratively: if the entry has been updated
+/// (lifecycle_stage progression), returns the most recent version. The
+/// original_action_hash remains the stable Layer 0 identity regardless of updates.
+///
+/// Returns None if the entry does not exist.
+///
+/// REQ-NDO-L0-01, REQ-NDO-L0-07
+#[hdk_extern]
+pub fn get_ndo(original_action_hash: ActionHash) -> ExternResult<Option<NondominiumIdentity>> {
+  let mut current_hash = original_action_hash;
+
+  loop {
+    let details = get_details(current_hash.clone(), GetOptions::default())?;
+
+    match details {
+      Some(Details::Record(record_details)) => {
+        if record_details.updates.is_empty() {
+          // No further updates — this is the latest version
+          return record_details
+            .record
+            .entry()
+            .to_app_option::<NondominiumIdentity>()
+            .map_err(|e| {
+              ResourceError::SerializationError(format!(
+                "Failed to deserialize NondominiumIdentity: {:?}",
+                e
+              ))
+              .into()
+            });
+        }
+
+        // Follow the most recent update in the chain
+        current_hash = record_details
+          .updates
+          .into_iter()
+          .max_by_key(|sah| sah.action().timestamp())
+          .unwrap()
+          .hashed
+          .hash;
+      }
+      _ => return Ok(None),
+    }
+  }
+}
+
+/// Update the lifecycle_stage of a NondominiumIdentity.
+///
+/// This is the ONLY permitted mutation on a Layer 0 entry. All other fields are
+/// enforced as immutable by the integrity validation (REQ-NDO-L0-03, REQ-NDO-L0-04).
+///
+/// Resolves to the latest action hash in the update chain before calling update_entry,
+/// ensuring correct chain ordering regardless of how many lifecycle transitions have occurred.
+///
+/// Returns the new action hash. The original_action_hash remains the stable Layer 0 identity.
+///
+/// REQ-NDO-L0-03, REQ-NDO-LC-01 through LC-07
+#[hdk_extern]
+pub fn update_lifecycle_stage(
+  input: UpdateLifecycleStageInput,
+) -> ExternResult<ActionHash> {
+  // Resolve the update chain to find the latest record
+  let mut current_hash = input.original_action_hash.clone();
+
+  loop {
+    let details = get_details(current_hash.clone(), GetOptions::default())?;
+
+    match details {
+      Some(Details::Record(record_details)) => {
+        if record_details.updates.is_empty() {
+          // This is the latest record — update from here
+          let mut current_entry: NondominiumIdentity = record_details
+            .record
+            .entry()
+            .to_app_option()
+            .map_err(|e| {
+              ResourceError::SerializationError(format!(
+                "Failed to deserialize NondominiumIdentity: {:?}",
+                e
+              ))
+            })?
+            .ok_or(ResourceError::EntryOperationFailed(
+              "NondominiumIdentity entry not found in latest record".to_string(),
+            ))?;
+
+          // Update only the lifecycle_stage field
+          current_entry.lifecycle_stage = input.new_stage;
+
+          let latest_action_hash = record_details.record.action_address().clone();
+          let update_hash = update_entry(latest_action_hash, &current_entry)?;
+          return Ok(update_hash);
+        }
+
+        // Follow the most recent update
+        current_hash = record_details
+          .updates
+          .into_iter()
+          .max_by_key(|sah| sah.action().timestamp())
+          .unwrap()
+          .hashed
+          .hash;
+      }
+      _ => {
+        return Err(ResourceError::EntryOperationFailed(
+          "NondominiumIdentity not found for update".to_string(),
+        )
+        .into())
+      }
+    }
+  }
+}

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -26,6 +26,34 @@ pub struct UpdateLifecycleStageInput {
   pub new_stage: LifecycleStage,
 }
 
+/// Resolves the HDK update chain to the latest Record for a NondominiumIdentity.
+/// Returns None if the original_action_hash does not exist on the DHT.
+///
+/// Used by both get_ndo and update_lifecycle_stage to avoid duplicated chain traversal logic.
+fn resolve_latest_ndo_record(original_action_hash: ActionHash) -> ExternResult<Option<Record>> {
+  let mut current_hash = original_action_hash;
+  loop {
+    match get_details(current_hash.clone(), GetOptions::default())? {
+      Some(Details::Record(record_details)) => {
+        if record_details.updates.is_empty() {
+          return Ok(Some(record_details.record));
+        }
+        // Follow the most recent update in the chain
+        current_hash = record_details
+          .updates
+          .into_iter()
+          .max_by_key(|sah| sah.action().timestamp())
+          .ok_or(ResourceError::EntryOperationFailed(
+            "Empty updates list during chain traversal".to_string(),
+          ))?
+          .hashed
+          .hash;
+      }
+      _ => return Ok(None),
+    }
+  }
+}
+
 /// Create a new NondominiumIdentity (NDO Layer 0 anchor).
 ///
 /// The returned action_hash is the stable, permanent Layer 0 identity for this resource.
@@ -83,104 +111,59 @@ pub fn create_ndo(input: NdoInput) -> ExternResult<NdoOutput> {
 /// REQ-NDO-L0-01, REQ-NDO-L0-07
 #[hdk_extern]
 pub fn get_ndo(original_action_hash: ActionHash) -> ExternResult<Option<NondominiumIdentity>> {
-  let mut current_hash = original_action_hash;
-
-  loop {
-    let details = get_details(current_hash.clone(), GetOptions::default())?;
-
-    match details {
-      Some(Details::Record(record_details)) => {
-        if record_details.updates.is_empty() {
-          // No further updates — this is the latest version
-          return record_details
-            .record
-            .entry()
-            .to_app_option::<NondominiumIdentity>()
-            .map_err(|e| {
-              ResourceError::SerializationError(format!(
-                "Failed to deserialize NondominiumIdentity: {:?}",
-                e
-              ))
-              .into()
-            });
-        }
-
-        // Follow the most recent update in the chain
-        current_hash = record_details
-          .updates
-          .into_iter()
-          .max_by_key(|sah| sah.action().timestamp())
-          .unwrap()
-          .hashed
-          .hash;
-      }
-      _ => return Ok(None),
-    }
-  }
+  let Some(record) = resolve_latest_ndo_record(original_action_hash)? else {
+    return Ok(None);
+  };
+  record
+    .entry()
+    .to_app_option::<NondominiumIdentity>()
+    .map_err(|e| {
+      ResourceError::SerializationError(format!(
+        "Failed to deserialize NondominiumIdentity: {:?}",
+        e
+      ))
+      .into()
+    })
 }
 
 /// Update the lifecycle_stage of a NondominiumIdentity.
 ///
 /// This is the ONLY permitted mutation on a Layer 0 entry. All other fields are
 /// enforced as immutable by the integrity validation (REQ-NDO-L0-03, REQ-NDO-L0-04).
-///
-/// Resolves to the latest action hash in the update chain before calling update_entry,
-/// ensuring correct chain ordering regardless of how many lifecycle transitions have occurred.
+/// Only the initiator may call this function (REQ-NDO-L0-03).
 ///
 /// Returns the new action hash. The original_action_hash remains the stable Layer 0 identity.
 ///
 /// REQ-NDO-L0-03, REQ-NDO-LC-01 through LC-07
 #[hdk_extern]
-pub fn update_lifecycle_stage(
-  input: UpdateLifecycleStageInput,
-) -> ExternResult<ActionHash> {
-  // Resolve the update chain to find the latest record
-  let mut current_hash = input.original_action_hash.clone();
+pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<ActionHash> {
+  let caller = agent_info()?.agent_initial_pubkey;
 
-  loop {
-    let details = get_details(current_hash.clone(), GetOptions::default())?;
+  let record = resolve_latest_ndo_record(input.original_action_hash.clone())?
+    .ok_or(ResourceError::EntryOperationFailed(
+      "NondominiumIdentity not found for update".to_string(),
+    ))?;
 
-    match details {
-      Some(Details::Record(record_details)) => {
-        if record_details.updates.is_empty() {
-          // This is the latest record — update from here
-          let mut current_entry: NondominiumIdentity = record_details
-            .record
-            .entry()
-            .to_app_option()
-            .map_err(|e| {
-              ResourceError::SerializationError(format!(
-                "Failed to deserialize NondominiumIdentity: {:?}",
-                e
-              ))
-            })?
-            .ok_or(ResourceError::EntryOperationFailed(
-              "NondominiumIdentity entry not found in latest record".to_string(),
-            ))?;
+  let mut current_entry: NondominiumIdentity = record
+    .entry()
+    .to_app_option()
+    .map_err(|e| {
+      ResourceError::SerializationError(format!(
+        "Failed to deserialize NondominiumIdentity: {:?}",
+        e
+      ))
+    })?
+    .ok_or(ResourceError::EntryOperationFailed(
+      "NondominiumIdentity entry not found in latest record".to_string(),
+    ))?;
 
-          // Update only the lifecycle_stage field
-          current_entry.lifecycle_stage = input.new_stage;
-
-          let latest_action_hash = record_details.record.action_address().clone();
-          let update_hash = update_entry(latest_action_hash, &current_entry)?;
-          return Ok(update_hash);
-        }
-
-        // Follow the most recent update
-        current_hash = record_details
-          .updates
-          .into_iter()
-          .max_by_key(|sah| sah.action().timestamp())
-          .unwrap()
-          .hashed
-          .hash;
-      }
-      _ => {
-        return Err(ResourceError::EntryOperationFailed(
-          "NondominiumIdentity not found for update".to_string(),
-        )
-        .into())
-      }
-    }
+  // Only the initiator may advance the lifecycle stage
+  if caller != current_entry.initiator {
+    return Err(ResourceError::NotAuthor.into());
   }
+
+  current_entry.lifecycle_stage = input.new_stage;
+  let latest_action_hash = record.action_address().clone();
+  let update_hash = update_entry(latest_action_hash, &current_entry)?;
+  Ok(update_hash)
 }

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -19,6 +19,12 @@ pub struct NdoOutput {
   pub entry: NondominiumIdentity,
 }
 
+// Output from get_all_ndos
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetAllNdosOutput {
+  pub ndos: Vec<NdoOutput>,
+}
+
 // Input for updating a NondominiumIdentity's lifecycle stage (the only permitted mutation).
 // REQ-NDO-LC-06: successor_ndo_hash required when new_stage == Deprecated.
 // REQ-NDO-L0-05: transition_event_hash references the triggering EconomicEvent.
@@ -196,10 +202,14 @@ pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<
 
   // REQ-NDO-LC-06: Create successor link when transitioning to Deprecated
   if input.new_stage == LifecycleStage::Deprecated {
-    // unwrap is safe — pre-flight check above guarantees Some
+    let successor_hash = input.successor_ndo_hash.ok_or_else(|| {
+      ResourceError::InvalidInput(
+        "successor_ndo_hash required for Deprecated transition (REQ-NDO-LC-06)".to_string(),
+      )
+    })?;
     create_link(
       input.original_action_hash.clone(),
-      input.successor_ndo_hash.unwrap(),
+      successor_hash,
       LinkTypes::NdoToSuccessor,
       (),
     )?;
@@ -216,4 +226,48 @@ pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<
   }
 
   Ok(update_hash)
+}
+
+/// Retrieve all NondominiumIdentities via the global "ndo_identities" anchor.
+///
+/// Returns the latest version of each NDO (chain-resolved). Entries that fail
+/// to resolve or deserialize are silently skipped — DHT availability is eventual.
+///
+/// REQ-NDO-L0-07
+#[hdk_extern]
+pub fn get_all_ndos(_: ()) -> ExternResult<GetAllNdosOutput> {
+  let path = Path::from("ndo_identities");
+  let links_query =
+    LinkQuery::try_new(path.path_entry_hash()?, LinkTypes::AllNdos)?;
+  let links = get_links(links_query, GetStrategy::default())?;
+
+  let mut ndos = Vec::new();
+  for link in links {
+    let Some(action_hash) = link.target.into_action_hash() else {
+      continue;
+    };
+    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
+      continue;
+    };
+    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
+      continue;
+    };
+    ndos.push(NdoOutput { action_hash, entry });
+  }
+  Ok(GetAllNdosOutput { ndos })
+}
+
+/// Return raw AgentToNdo links for the calling agent.
+///
+/// Returns links rather than resolved entries so callers can access
+/// the target action_hash directly without a second DHT round-trip
+/// when only the identity is needed. Pass each target to `get_ndo`
+/// to resolve the current entry.
+///
+/// REQ-NDO-L0-07
+#[hdk_extern]
+pub fn get_my_ndos(_: ()) -> ExternResult<Vec<Link>> {
+  let agent_pub_key = agent_info()?.agent_initial_pubkey;
+  let links_query = LinkQuery::try_new(agent_pub_key, LinkTypes::AgentToNdo)?;
+  get_links(links_query, GetStrategy::default())
 }

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -149,8 +149,9 @@ pub fn get_ndo(original_action_hash: ActionHash) -> ExternResult<Option<Nondomin
 ///
 /// This is the ONLY permitted mutation on a Layer 0 entry (plus successor_ndo_hash,
 /// which is set exactly once when transitioning to Deprecated). All other fields are
-/// enforced as immutable by the integrity validation (REQ-NDO-L0-03, REQ-NDO-L0-04).
-/// Only the initiator may call this function (REQ-NDO-L0-03).
+/// enforced as immutable by the integrity validation (REQ-NDO-L0-04).
+/// Only the initiator may call this function (MVP simplification of REQ-NDO-LC-07 —
+/// full role-based authorization per §5.3 is deferred to governance zome integration).
 ///
 /// When new_stage == Deprecated, successor_ndo_hash must be Some — enforced here and
 /// in the integrity zome (REQ-NDO-LC-06). Creates NdoToSuccessor link.
@@ -161,7 +162,7 @@ pub fn get_ndo(original_action_hash: ActionHash) -> ExternResult<Option<Nondomin
 ///
 /// Returns the new action hash. The original_action_hash remains the stable Layer 0 identity.
 ///
-/// REQ-NDO-L0-03, REQ-NDO-LC-01 through REQ-NDO-LC-07
+/// REQ-NDO-L0-04, REQ-NDO-LC-01 through REQ-NDO-LC-07
 #[hdk_extern]
 pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<ActionHash> {
   let caller = agent_info()?.agent_initial_pubkey;
@@ -184,7 +185,7 @@ pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<
       "NondominiumIdentity entry not found in latest record".to_string(),
     ))?;
 
-  // Only the initiator may advance the lifecycle stage (REQ-NDO-L0-03)
+  // Only the initiator may advance the lifecycle stage (MVP simplification of REQ-NDO-LC-07)
   if caller != current_entry.initiator {
     return Err(ResourceError::NotAuthor.into());
   }

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -19,11 +19,19 @@ pub struct NdoOutput {
   pub entry: NondominiumIdentity,
 }
 
-// Input for updating a NondominiumIdentity's lifecycle stage (the only permitted mutation)
+// Input for updating a NondominiumIdentity's lifecycle stage (the only permitted mutation).
+// REQ-NDO-LC-06: successor_ndo_hash required when new_stage == Deprecated.
+// REQ-NDO-L0-05: transition_event_hash references the triggering EconomicEvent.
+//   Link is created when Some; full cross-zome validation of the event is deferred
+//   until coordinator cross-zome calls to zome_gouvernance are stable.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateLifecycleStageInput {
   pub original_action_hash: ActionHash,
   pub new_stage: LifecycleStage,
+  /// Must be Some when new_stage == Deprecated (REQ-NDO-LC-06)
+  pub successor_ndo_hash: Option<ActionHash>,
+  /// Triggering EconomicEvent action hash (REQ-NDO-L0-05); link created when Some
+  pub transition_event_hash: Option<ActionHash>,
 }
 
 /// Resolves the HDK update chain to the latest Record for a NondominiumIdentity.
@@ -76,6 +84,7 @@ pub fn create_ndo(input: NdoInput) -> ExternResult<NdoOutput> {
     lifecycle_stage: input.lifecycle_stage,
     created_at: sys_time()?,
     description: input.description,
+    successor_ndo_hash: None,
   };
 
   let action_hash = create_entry(&EntryTypes::NondominiumIdentity(entry.clone()))?;
@@ -128,13 +137,21 @@ pub fn get_ndo(original_action_hash: ActionHash) -> ExternResult<Option<Nondomin
 
 /// Update the lifecycle_stage of a NondominiumIdentity.
 ///
-/// This is the ONLY permitted mutation on a Layer 0 entry. All other fields are
+/// This is the ONLY permitted mutation on a Layer 0 entry (plus successor_ndo_hash,
+/// which is set exactly once when transitioning to Deprecated). All other fields are
 /// enforced as immutable by the integrity validation (REQ-NDO-L0-03, REQ-NDO-L0-04).
 /// Only the initiator may call this function (REQ-NDO-L0-03).
 ///
+/// When new_stage == Deprecated, successor_ndo_hash must be Some — enforced here and
+/// in the integrity zome (REQ-NDO-LC-06). Creates NdoToSuccessor link.
+///
+/// Creates NdoToTransitionEvent link when transition_event_hash is Some (REQ-NDO-L0-05).
+/// Full cross-zome validation of the event target is deferred until coordinator
+/// cross-zome calls to zome_gouvernance are stable.
+///
 /// Returns the new action hash. The original_action_hash remains the stable Layer 0 identity.
 ///
-/// REQ-NDO-L0-03, REQ-NDO-LC-01 through LC-07
+/// REQ-NDO-L0-03, REQ-NDO-LC-01 through REQ-NDO-LC-07
 #[hdk_extern]
 pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<ActionHash> {
   let caller = agent_info()?.agent_initial_pubkey;
@@ -157,13 +174,46 @@ pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<
       "NondominiumIdentity entry not found in latest record".to_string(),
     ))?;
 
-  // Only the initiator may advance the lifecycle stage
+  // Only the initiator may advance the lifecycle stage (REQ-NDO-L0-03)
   if caller != current_entry.initiator {
     return Err(ResourceError::NotAuthor.into());
   }
 
-  current_entry.lifecycle_stage = input.new_stage;
+  // Coordinator pre-flight: Deprecated requires a successor (REQ-NDO-LC-06)
+  if input.new_stage == LifecycleStage::Deprecated && input.successor_ndo_hash.is_none() {
+    return Err(ResourceError::InvalidInput(
+      "Transitioning to Deprecated requires successor_ndo_hash (REQ-NDO-LC-06)".to_string(),
+    )
+    .into());
+  }
+
+  // Apply mutations — integrity validation enforces the state machine and immutability
+  current_entry.lifecycle_stage = input.new_stage.clone();
+  current_entry.successor_ndo_hash = input.successor_ndo_hash.clone();
+
   let latest_action_hash = record.action_address().clone();
   let update_hash = update_entry(latest_action_hash, &current_entry)?;
+
+  // REQ-NDO-LC-06: Create successor link when transitioning to Deprecated
+  if input.new_stage == LifecycleStage::Deprecated {
+    // unwrap is safe — pre-flight check above guarantees Some
+    create_link(
+      input.original_action_hash.clone(),
+      input.successor_ndo_hash.unwrap(),
+      LinkTypes::NdoToSuccessor,
+      (),
+    )?;
+  }
+
+  // REQ-NDO-L0-05: Create transition event link when a triggering event hash is provided
+  if let Some(event_hash) = input.transition_event_hash {
+    create_link(
+      input.original_action_hash.clone(),
+      event_hash,
+      LinkTypes::NdoToTransitionEvent,
+      (),
+    )?;
+  }
+
   Ok(update_hash)
 }

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -52,7 +52,11 @@ fn resolve_latest_ndo_record(original_action_hash: ActionHash) -> ExternResult<O
         if record_details.updates.is_empty() {
           return Ok(Some(record_details.record));
         }
-        // Follow the most recent update in the chain
+        // Follow the most recent update in the chain.
+        // Tie-breaking: if two updates share the same timestamp (rare on the DHT),
+        // max_by_key picks one deterministically by iteration order. This is acceptable
+        // because simultaneous updates from different agents would themselves be a
+        // conflict the initiator must resolve via a subsequent update.
         current_hash = record_details
           .updates
           .into_iter()

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -230,7 +230,7 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             .ok_or(wasm_error!(WasmErrorInner::Guest(
               "Original NondominiumIdentity entry not found in record".to_string()
             )))?;
-          validate_update_nondominium_identity(&original, &new_ndi)
+          validate_update_nondominium_identity(&action, &original, &new_ndi)
         }
       },
       _ => Ok(ValidateCallbackResult::Valid),
@@ -359,12 +359,19 @@ fn validate_create_nondominium_identity(
   Ok(ValidateCallbackResult::Valid)
 }
 
-// REQ-NDO-L0-03, REQ-NDO-L0-04: Only lifecycle_stage may be updated.
+// REQ-NDO-L0-03, REQ-NDO-L0-04: Only lifecycle_stage may be updated, and only by the initiator.
 // All other fields are permanently immutable after creation.
 fn validate_update_nondominium_identity(
+  action: &Update,
   original: &NondominiumIdentity,
   new_entry: &NondominiumIdentity,
 ) -> ExternResult<ValidateCallbackResult> {
+  // Only the initiator may advance the lifecycle stage (REQ-NDO-L0-03)
+  if action.author != original.initiator {
+    return Ok(ValidateCallbackResult::Invalid(
+      "Only the initiator may update NondominiumIdentity lifecycle stage".to_string(),
+    ));
+  }
   if new_entry.name != original.name {
     return Ok(ValidateCallbackResult::Invalid(
       "NondominiumIdentity name is immutable after creation".to_string(),

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -1,37 +1,18 @@
 use hdi::prelude::*;
 
-// TODO: Split ResourceState into two orthogonal enums:
+// TODO (post-MVP): Split ResourceState into two orthogonal enums and migrate EconomicResource:
 //
-// 1. LifecycleStage — the maturity/evolutionary phase of the resource (advances rarely, usually
-//    irreversibly). Maps to NondominiumIdentity.lifecycle_stage in the NDO three-layer model.
-//    Values: Ideation, Specification, Development, Prototype, Stable, Distributed,
-//            Active, Hibernating, Deprecated, EndOfLife
+// 1. LifecycleStage — now defined below for NondominiumIdentity (NDO Layer 0).
 //
 // 2. OperationalState — the current process acting on this specific resource instance (cycles
 //    frequently as processes begin and end). Governance-zome controlled.
 //    Values: Available, Reserved, InTransit, InStorage, InMaintenance, InUse, PendingValidation
 //
-// The current enum CONFLATES both dimensions:
-//   PendingValidation  → OperationalState::PendingValidation (pre-activation gate)
-//   Active             → LifecycleStage::Active + OperationalState::Available
-//   Maintenance        → OperationalState::InMaintenance (repair process active; LifecycleStage
-//                        remains whatever it was before, typically Active)
-//   Retired            → LifecycleStage::Deprecated or EndOfLife
-//   Reserved           → OperationalState::Reserved (pre-allocation; LifecycleStage unchanged)
-//
-// Transport, Storage, and Maintenance are PROCESSES that act on a resource at any lifecycle stage.
-// A Prototype can be InTransit (moved between labs). An Active resource can be InStorage.
-// These are NOT lifecycle stages.
+// The current ResourceState enum CONFLATES both dimensions and is kept for EconomicResource
+// backwards-compatibility until the OperationalState refactor (REQ-NDO-OS-06).
 //
 // See: documentation/requirements/ndo_prima_materia.md — Section 5 (LifecycleStage + OperationalState)
 // See: documentation/archives/resources.md — Section 2.4 (known gaps)
-//
-// TODO: Implement PropertyRegime enum when NondominiumIdentity (Layer 0) is introduced.
-// Canonical 6-variant enum: Private, Commons, Collective, Pool, CommonPool, Nondominium.
-// Each variant implies default governance templates via GovernanceDefaultsEngine.
-// See: documentation/requirements/ndo_prima_materia.md — Section 8.2
-// See: documentation/archives/resources.md — Section 6.3 (canonical definition)
-// See: documentation/archives/resources.md — Section 6.6 (PropertyRegime → governance defaults)
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Default)]
 pub enum ResourceState {
   #[default]
@@ -52,6 +33,48 @@ impl std::fmt::Display for ResourceState {
       ResourceState::Reserved => write!(f, "reserved"),
     }
   }
+}
+
+// NDO Layer 0 — LifecycleStage (REQ-NDO-LC-01 through LC-07)
+// The maturity/evolutionary phase of a NondominiumIdentity. Advances rarely and usually
+// irreversibly. The ONLY mutable field in NondominiumIdentity after creation.
+// See: documentation/requirements/ndo_prima_materia.md §5 and §9.4
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum LifecycleStage {
+  Ideation,      // spark of an idea, no design yet
+  Specification, // design documents exist, Layer 1 active
+  Development,   // active build/fabrication work
+  Production,    // stable, in active use
+  Hibernating,   // dormant but recoverable
+  Deprecated,    // superseded, not recommended
+  EndOfLife,     // permanently archived, Layer 0 tombstone
+}
+
+// NDO Layer 0 — PropertyRegime (REQ-NDO-L0-02)
+// The governance/ownership regime of a NondominiumIdentity. Immutable after creation.
+// See: documentation/requirements/ndo_prima_materia.md §4.1
+// TODO (post-MVP): Implement PropertyRegime → governance defaults mapping via GovernanceDefaultsEngine.
+// See: documentation/archives/resources.md §6.6 (PropertyRegime → governance defaults)
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum PropertyRegime {
+  Private,
+  Commons,
+  Collective,
+  Pool,
+  CommonPool,
+  Nondominium,
+}
+
+// NDO Layer 0 — ResourceNature (REQ-NDO-L0-02)
+// The physical/digital nature of a NondominiumIdentity. Immutable after creation.
+// See: documentation/requirements/ndo_prima_materia.md §4.1
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum ResourceNature {
+  Physical,
+  Digital,
+  Service,
+  Hybrid,
+  Information,
 }
 
 #[hdk_entry_helper]
@@ -83,6 +106,23 @@ pub struct EconomicResource {
   pub state: ResourceState,
 }
 
+// NDO Layer 0 — NondominiumIdentity (REQ-NDO-L0-01, REQ-NDO-L0-07)
+// The permanent identity anchor of a resource. Exists from the moment of conception through
+// end-of-life. All fields are immutable after creation EXCEPT lifecycle_stage.
+// The original ActionHash from create_ndo is the stable Layer 0 identity for all time.
+// See: documentation/requirements/ndo_prima_materia.md §4.2 and §9.1
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct NondominiumIdentity {
+  pub name: String,
+  pub initiator: AgentPubKey,
+  pub property_regime: PropertyRegime,
+  pub resource_nature: ResourceNature,
+  pub lifecycle_stage: LifecycleStage, // the ONLY mutable field (REQ-NDO-L0-03)
+  pub created_at: Timestamp,
+  pub description: Option<String>,
+}
+
 #[hdk_entry_types]
 #[unit_enum(UnitEntryTypes)]
 #[derive(Serialize, Deserialize, SerializedBytes)]
@@ -90,6 +130,7 @@ pub enum EntryTypes {
   ResourceSpecification(ResourceSpecification),
   EconomicResource(EconomicResource),
   GovernanceRule(GovernanceRule),
+  NondominiumIdentity(NondominiumIdentity),
 }
 
 #[hdk_link_types]
@@ -99,6 +140,10 @@ pub enum LinkTypes {
   AllResourceSpecifications,
   AllEconomicResources,
   AllGovernanceRules,
+
+  // NDO Layer 0 discovery anchors (REQ-NDO-L0-05, REQ-NDO-L0-07)
+  AllNdos,    // global anchor: "ndo_identities" path → NondominiumIdentity action hashes
+  AgentToNdo, // initiator pubkey → NondominiumIdentity action hashes
 
   // Hierarchical linking for efficient queries
   SpecificationToResource,       // ResourceSpec -> EconomicResource
@@ -154,6 +199,9 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
           validate_create_economic_resource(&resource, &action.author)
         }
         EntryTypes::GovernanceRule(rule) => validate_create_governance_rule(&rule, &action.author),
+        EntryTypes::NondominiumIdentity(ndi) => {
+          validate_create_nondominium_identity(&ndi, &action.author)
+        }
       },
       OpEntry::UpdateEntry {
         app_entry, action, ..
@@ -165,13 +213,72 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
           validate_update_economic_resource(&resource, &action.author)
         }
         EntryTypes::GovernanceRule(rule) => validate_update_governance_rule(&rule, &action.author),
+        EntryTypes::NondominiumIdentity(new_ndi) => {
+          // Fetch original entry to enforce immutability of all fields except lifecycle_stage
+          // (REQ-NDO-L0-03, REQ-NDO-L0-04)
+          let original_record =
+            must_get_valid_record(action.original_action_address.clone())?;
+          let original: NondominiumIdentity = original_record
+            .entry()
+            .to_app_option()
+            .map_err(|e| {
+              wasm_error!(WasmErrorInner::Guest(format!(
+                "Failed to deserialize original NondominiumIdentity: {:?}",
+                e
+              )))
+            })?
+            .ok_or(wasm_error!(WasmErrorInner::Guest(
+              "Original NondominiumIdentity entry not found in record".to_string()
+            )))?;
+          validate_update_nondominium_identity(&original, &new_ndi)
+        }
       },
       _ => Ok(ValidateCallbackResult::Valid),
     },
-    FlatOp::StoreRecord(OpRecord::CreateLink { .. }) => {
-      // Validate link creation
-      Ok(ValidateCallbackResult::Valid)
-    }
+    FlatOp::StoreRecord(store_record) => match store_record {
+      OpRecord::DeleteEntry {
+        original_action_hash,
+        ..
+      } => {
+        // Identify whether the deleted entry is a NondominiumIdentity (REQ-NDO-L0-06)
+        let original_record = must_get_valid_record(original_action_hash)?;
+        let original_action = original_record.action().clone();
+        let original_action = match original_action {
+          Action::Create(create) => EntryCreationAction::Create(create),
+          Action::Update(update) => EntryCreationAction::Update(update),
+          _ => {
+            return Ok(ValidateCallbackResult::Invalid(
+              "Original action for a delete must be a Create or Update action".to_string(),
+            ));
+          }
+        };
+        let app_entry_type = match original_action.entry_type() {
+          EntryType::App(app_entry_type) => app_entry_type,
+          _ => return Ok(ValidateCallbackResult::Valid),
+        };
+        let entry = match original_record.entry().as_option() {
+          Some(entry) => entry,
+          None => return Ok(ValidateCallbackResult::Valid),
+        };
+        let original_app_entry = match EntryTypes::deserialize_from_type(
+          *app_entry_type.zome_index,
+          app_entry_type.entry_index,
+          entry,
+        )? {
+          Some(app_entry) => app_entry,
+          None => return Ok(ValidateCallbackResult::Valid),
+        };
+        match original_app_entry {
+          EntryTypes::NondominiumIdentity(_) => validate_delete_nondominium_identity(),
+          _ => Ok(ValidateCallbackResult::Valid),
+        }
+      }
+      OpRecord::CreateLink { .. } => {
+        // Validate link creation
+        Ok(ValidateCallbackResult::Valid)
+      }
+      _ => Ok(ValidateCallbackResult::Valid),
+    },
     _ => Ok(ValidateCallbackResult::Valid),
   }
 }
@@ -237,6 +344,66 @@ fn validate_create_governance_rule(
   }
 
   Ok(ValidateCallbackResult::Valid)
+}
+
+// REQ-NDO-L0-01: NondominiumIdentity name must not be empty
+fn validate_create_nondominium_identity(
+  ndi: &NondominiumIdentity,
+  _author: &AgentPubKey,
+) -> ExternResult<ValidateCallbackResult> {
+  if ndi.name.trim().is_empty() {
+    return Ok(ValidateCallbackResult::Invalid(
+      "NondominiumIdentity name cannot be empty".to_string(),
+    ));
+  }
+  Ok(ValidateCallbackResult::Valid)
+}
+
+// REQ-NDO-L0-03, REQ-NDO-L0-04: Only lifecycle_stage may be updated.
+// All other fields are permanently immutable after creation.
+fn validate_update_nondominium_identity(
+  original: &NondominiumIdentity,
+  new_entry: &NondominiumIdentity,
+) -> ExternResult<ValidateCallbackResult> {
+  if new_entry.name != original.name {
+    return Ok(ValidateCallbackResult::Invalid(
+      "NondominiumIdentity name is immutable after creation".to_string(),
+    ));
+  }
+  if new_entry.initiator != original.initiator {
+    return Ok(ValidateCallbackResult::Invalid(
+      "NondominiumIdentity initiator is immutable after creation".to_string(),
+    ));
+  }
+  if new_entry.property_regime != original.property_regime {
+    return Ok(ValidateCallbackResult::Invalid(
+      "NondominiumIdentity property_regime is immutable after creation".to_string(),
+    ));
+  }
+  if new_entry.resource_nature != original.resource_nature {
+    return Ok(ValidateCallbackResult::Invalid(
+      "NondominiumIdentity resource_nature is immutable after creation".to_string(),
+    ));
+  }
+  if new_entry.created_at != original.created_at {
+    return Ok(ValidateCallbackResult::Invalid(
+      "NondominiumIdentity created_at is immutable after creation".to_string(),
+    ));
+  }
+  if new_entry.description != original.description {
+    return Ok(ValidateCallbackResult::Invalid(
+      "NondominiumIdentity description is immutable after creation".to_string(),
+    ));
+  }
+  // lifecycle_stage is the only permitted change — no additional check needed
+  Ok(ValidateCallbackResult::Valid)
+}
+
+// REQ-NDO-L0-06: Layer 0 entries cannot be deleted. The identity is permanent.
+fn validate_delete_nondominium_identity() -> ExternResult<ValidateCallbackResult> {
+  Ok(ValidateCallbackResult::Invalid(
+    "NondominiumIdentity entries cannot be deleted. Layer 0 is permanent.".to_string(),
+  ))
 }
 
 fn validate_update_resource_spec(

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -77,6 +77,12 @@ pub enum PropertyRegime {
 // NDO Layer 0 — ResourceNature (REQ-NDO-L0-02)
 // The physical/digital nature of a NondominiumIdentity. Immutable after creation.
 // See: documentation/requirements/ndo_prima_materia.md §4.1
+//
+// Note: The spec (§8.2) defines 3 variants (Digital, Physical, Hybrid). This implementation
+// extends that to 5 by adding Service and Information, which are first-class resource natures
+// in the OVN/ValueFlows context and needed for NDOs representing software services and
+// knowledge assets. These additions are backwards-compatible (existing records are unaffected)
+// and do not conflict with any spec constraint. See PR #80 Decisions table.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub enum ResourceNature {
   Physical,
@@ -138,6 +144,12 @@ pub struct NondominiumIdentity {
   // Required when lifecycle_stage == Deprecated (REQ-NDO-LC-06).
   // Set exactly once during the Deprecated transition; immutable once set.
   // #[serde(default)] ensures existing pre-field records deserialize to None.
+  //
+  // Note: the spec (§8.1) does not include this field — successor relationship is
+  // spec-defined as a link only (NdoToSuccessor). This implementation stores it as both
+  // a field AND a link, making the successor inspectable on the entry without a link
+  // traversal. The NdoToSuccessor link is still created for graph-query compatibility.
+  // See PR #80 Decisions table.
   #[serde(default)]
   pub successor_ndo_hash: Option<ActionHash>,
 }
@@ -265,7 +277,7 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
         original_action_hash,
         ..
       } => {
-        // Identify whether the deleted entry is a NondominiumIdentity (REQ-NDO-L0-06)
+        // Identify whether the deleted entry is a NondominiumIdentity (REQ-NDO-L0-03)
         let original_record = must_get_valid_record(original_action_hash)?;
         let original_action = original_record.action().clone();
         let original_action = match original_action {
@@ -407,18 +419,19 @@ fn validate_create_nondominium_identity(
   Ok(ValidateCallbackResult::Valid)
 }
 
-// REQ-NDO-L0-03, REQ-NDO-L0-04: Only lifecycle_stage (and successor_ndo_hash during the
-// Deprecated transition) may be updated, and only by the initiator. All other fields are
-// permanently immutable after creation.
+// REQ-NDO-L0-04: Only lifecycle_stage (and successor_ndo_hash during the Deprecated
+// transition) may be updated after creation. All other fields are permanently immutable.
 // REQ-NDO-LC-04: State machine transition allowlist enforced — Hibernating is reversible;
 // Deprecated and EndOfLife are terminal.
 // REQ-NDO-LC-06: Transitioning to Deprecated requires a successor NDO hash.
+// Note: initiator-only restriction is an MVP simplification of REQ-NDO-LC-07 (governance
+// zome enforces authorized role per transition). Full role-based authorization is deferred.
 fn validate_update_nondominium_identity(
   action: &Update,
   original: &NondominiumIdentity,
   new_entry: &NondominiumIdentity,
 ) -> ExternResult<ValidateCallbackResult> {
-  // Only the initiator may advance the lifecycle stage (REQ-NDO-L0-03)
+  // Only the initiator may advance the lifecycle stage (MVP simplification of REQ-NDO-LC-07)
   if action.author != original.initiator {
     return Ok(ValidateCallbackResult::Invalid(
       "Only the initiator may update NondominiumIdentity lifecycle stage".to_string(),
@@ -529,7 +542,8 @@ fn validate_update_nondominium_identity(
   Ok(ValidateCallbackResult::Valid)
 }
 
-// REQ-NDO-L0-06: Layer 0 entries cannot be deleted. The identity is permanent.
+// REQ-NDO-L0-03: Layer 0 entries cannot be deleted. The identity is permanent.
+// REQ-NDO-L0-06: At EndOfLife the entry remains readable as a tombstone — ensured by this delete gate.
 fn validate_delete_nondominium_identity() -> ExternResult<ValidateCallbackResult> {
   Ok(ValidateCallbackResult::Invalid(
     "NondominiumIdentity entries cannot be deleted. Layer 0 is permanent.".to_string(),

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -130,6 +130,10 @@ pub struct NondominiumIdentity {
   pub resource_nature: ResourceNature,
   pub lifecycle_stage: LifecycleStage, // the ONLY mutable field (REQ-NDO-L0-04)
   pub created_at: Timestamp,
+  // Immutable after creation. REQ-NDO-L0-04 is stricter than the spec strictly requires here;
+  // description is frozen intentionally to prevent retroactive reframing of the resource's
+  // original intent. Post-MVP: consider a separate mutable `notes` field if editorial
+  // corrections are needed without altering the canonical identity record.
   pub description: Option<String>,
   // Required when lifecycle_stage == Deprecated (REQ-NDO-LC-06).
   // Set exactly once during the Deprecated transition; immutable once set.
@@ -504,6 +508,10 @@ fn validate_update_nondominium_identity(
         // Verify the successor hash resolves to a real record on the DHT.
         // must_get_valid_record propagates UnresolvedDependencies via ? if not yet fetched.
         must_get_valid_record(h.clone())?;
+        // TODO (post-MVP): verify the resolved record's entry type is NondominiumIdentity.
+        // Currently only record existence is checked; a motivated actor could reference an
+        // arbitrary action hash as the "successor". Deserializing EntryTypes here would add
+        // strong type safety at the cost of additional DHT reads in the validation path.
       }
     }
   }

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -35,19 +35,28 @@ impl std::fmt::Display for ResourceState {
   }
 }
 
-// NDO Layer 0 — LifecycleStage (REQ-NDO-LC-01 through LC-07)
-// The maturity/evolutionary phase of a NondominiumIdentity. Advances rarely and usually
-// irreversibly. The ONLY mutable field in NondominiumIdentity after creation.
-// See: documentation/requirements/ndo_prima_materia.md §5 and §9.4
+// NDO Layer 0 — LifecycleStage (REQ-NDO-LC-01 through REQ-NDO-LC-07)
+// The maturity/evolutionary phase of a NondominiumIdentity. Advances rarely and (mostly)
+// irreversibly, driven by significant events. The ONLY mutable field in NondominiumIdentity
+// after creation (REQ-NDO-L0-04).
+// See: documentation/requirements/ndo_prima_materia.md §5.1 and §9.4
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub enum LifecycleStage {
-  Ideation,      // spark of an idea, no design yet
-  Specification, // design documents exist, Layer 1 active
-  Development,   // active build/fabrication work
-  Production,    // stable, in active use
-  Hibernating,   // dormant but recoverable
-  Deprecated,    // superseded, not recommended
-  EndOfLife,     // permanently archived, Layer 0 tombstone
+  // --- Emergence Phase ---
+  Ideation,       // Placeholder: name and intent only. Layer 0 alone.
+  Specification,  // Design/requirements being written. Layer 1 activating.
+  Development,    // Active construction, prototyping. Layers 0+1+2 active.
+  Prototype,      // PoC exists, not production-ready. Layers 0+1+2 active.
+  // --- Maturity Phase ---
+  Stable,         // Production-ready, design is replicable. All layers active.
+  Distributed,    // Being actively fabricated/used across the network.
+  // --- Operation Phase ---
+  Active,         // In normal use. All layers active.
+  // --- Suspension (REQ-NDO-LC-04: reversible) ---
+  Hibernating,    // Dormant but recoverable. Layers 1+2 dormant, Layer 0 active.
+  // --- Terminal (REQ-NDO-LC-04: not reactivatable) ---
+  Deprecated,     // Superseded. Successor NDO required (REQ-NDO-LC-06).
+  EndOfLife,      // Concluded. Layer 0 tombstone; fully terminal.
 }
 
 // NDO Layer 0 — PropertyRegime (REQ-NDO-L0-02)
@@ -108,7 +117,8 @@ pub struct EconomicResource {
 
 // NDO Layer 0 — NondominiumIdentity (REQ-NDO-L0-01, REQ-NDO-L0-07)
 // The permanent identity anchor of a resource. Exists from the moment of conception through
-// end-of-life. All fields are immutable after creation EXCEPT lifecycle_stage.
+// end-of-life. All fields are immutable after creation EXCEPT lifecycle_stage (and
+// successor_ndo_hash, which is set exactly once when transitioning to Deprecated).
 // The original ActionHash from create_ndo is the stable Layer 0 identity for all time.
 // See: documentation/requirements/ndo_prima_materia.md §4.2 and §9.1
 #[hdk_entry_helper]
@@ -118,9 +128,14 @@ pub struct NondominiumIdentity {
   pub initiator: AgentPubKey,
   pub property_regime: PropertyRegime,
   pub resource_nature: ResourceNature,
-  pub lifecycle_stage: LifecycleStage, // the ONLY mutable field (REQ-NDO-L0-03)
+  pub lifecycle_stage: LifecycleStage, // the ONLY mutable field (REQ-NDO-L0-04)
   pub created_at: Timestamp,
   pub description: Option<String>,
+  // Required when lifecycle_stage == Deprecated (REQ-NDO-LC-06).
+  // Set exactly once during the Deprecated transition; immutable once set.
+  // #[serde(default)] ensures existing pre-field records deserialize to None.
+  #[serde(default)]
+  pub successor_ndo_hash: Option<ActionHash>,
 }
 
 #[hdk_entry_types]
@@ -144,6 +159,12 @@ pub enum LinkTypes {
   // NDO Layer 0 discovery anchors (REQ-NDO-L0-05, REQ-NDO-L0-07)
   AllNdos,    // global anchor: "ndo_identities" path → NondominiumIdentity action hashes
   AgentToNdo, // initiator pubkey → NondominiumIdentity action hashes
+
+  // NDO Layer 0 lifecycle links
+  NdoToSuccessor,        // deprecated NDO action hash → successor NondominiumIdentity (REQ-NDO-LC-06)
+  NdoToTransitionEvent,  // NDO action hash → EconomicEvent that triggered the transition (REQ-NDO-L0-05)
+                         // Link only; full event validation deferred (integrity cannot
+                         // cross-zome call to zome_gouvernance)
 
   // Hierarchical linking for efficient queries
   SpecificationToResource,       // ResourceSpec -> EconomicResource
@@ -346,7 +367,8 @@ fn validate_create_governance_rule(
   Ok(ValidateCallbackResult::Valid)
 }
 
-// REQ-NDO-L0-01: NondominiumIdentity name must not be empty
+// REQ-NDO-L0-01: NondominiumIdentity name must not be empty.
+// REQ-NDO-LC-01: Only emergence/maturity/operation stages are valid at creation time.
 fn validate_create_nondominium_identity(
   ndi: &NondominiumIdentity,
   _author: &AgentPubKey,
@@ -356,11 +378,37 @@ fn validate_create_nondominium_identity(
       "NondominiumIdentity name cannot be empty".to_string(),
     ));
   }
+
+  // Suspension and terminal stages are not valid initial stages
+  let invalid_initial = [
+    LifecycleStage::Hibernating,
+    LifecycleStage::Deprecated,
+    LifecycleStage::EndOfLife,
+  ];
+  if invalid_initial.contains(&ndi.lifecycle_stage) {
+    return Ok(ValidateCallbackResult::Invalid(format!(
+      "NondominiumIdentity cannot be created in stage {:?}; \
+       only emergence, maturity, or operation stages are valid initial stages",
+      ndi.lifecycle_stage
+    )));
+  }
+
+  // successor_ndo_hash has no meaning at creation time
+  if ndi.successor_ndo_hash.is_some() {
+    return Ok(ValidateCallbackResult::Invalid(
+      "successor_ndo_hash must be None at creation".to_string(),
+    ));
+  }
+
   Ok(ValidateCallbackResult::Valid)
 }
 
-// REQ-NDO-L0-03, REQ-NDO-L0-04: Only lifecycle_stage may be updated, and only by the initiator.
-// All other fields are permanently immutable after creation.
+// REQ-NDO-L0-03, REQ-NDO-L0-04: Only lifecycle_stage (and successor_ndo_hash during the
+// Deprecated transition) may be updated, and only by the initiator. All other fields are
+// permanently immutable after creation.
+// REQ-NDO-LC-04: State machine transition allowlist enforced — Hibernating is reversible;
+// Deprecated and EndOfLife are terminal.
+// REQ-NDO-LC-06: Transitioning to Deprecated requires a successor NDO hash.
 fn validate_update_nondominium_identity(
   action: &Update,
   original: &NondominiumIdentity,
@@ -372,6 +420,8 @@ fn validate_update_nondominium_identity(
       "Only the initiator may update NondominiumIdentity lifecycle stage".to_string(),
     ));
   }
+
+  // --- Immutable fields ---
   if new_entry.name != original.name {
     return Ok(ValidateCallbackResult::Invalid(
       "NondominiumIdentity name is immutable after creation".to_string(),
@@ -402,7 +452,72 @@ fn validate_update_nondominium_identity(
       "NondominiumIdentity description is immutable after creation".to_string(),
     ));
   }
-  // lifecycle_stage is the only permitted change — no additional check needed
+
+  // --- successor_ndo_hash immutability: once set, cannot change ---
+  if original.successor_ndo_hash.is_some()
+    && new_entry.successor_ndo_hash != original.successor_ndo_hash
+  {
+    return Ok(ValidateCallbackResult::Invalid(
+      "NondominiumIdentity successor_ndo_hash is immutable once set".to_string(),
+    ));
+  }
+
+  // --- State machine: enforce transition allowlist (REQ-NDO-LC-04) ---
+  let from = &original.lifecycle_stage;
+  let to = &new_entry.lifecycle_stage;
+
+  let allowed: &[LifecycleStage] = match from {
+    LifecycleStage::Ideation      => &[LifecycleStage::Specification],
+    LifecycleStage::Specification => &[LifecycleStage::Development],
+    LifecycleStage::Development   => &[LifecycleStage::Prototype,   LifecycleStage::Hibernating],
+    LifecycleStage::Prototype     => &[LifecycleStage::Stable,      LifecycleStage::Hibernating],
+    LifecycleStage::Stable        => &[LifecycleStage::Distributed, LifecycleStage::Hibernating],
+    LifecycleStage::Distributed   => &[LifecycleStage::Active,      LifecycleStage::Hibernating],
+    LifecycleStage::Active        => &[
+      LifecycleStage::Hibernating,
+      LifecycleStage::Deprecated,
+      LifecycleStage::EndOfLife,
+    ],
+    // Hibernating is the only reversible pause state (REQ-NDO-LC-04)
+    LifecycleStage::Hibernating   => &[LifecycleStage::Active, LifecycleStage::Deprecated],
+    // Terminal states: Deprecated can only move to EndOfLife; EndOfLife has no exit
+    LifecycleStage::Deprecated    => &[LifecycleStage::EndOfLife],
+    LifecycleStage::EndOfLife     => &[], // fully terminal — no transitions permitted
+  };
+
+  if !allowed.contains(to) {
+    return Ok(ValidateCallbackResult::Invalid(format!(
+      "Invalid lifecycle transition: {:?} → {:?} is not permitted by the state machine",
+      from, to
+    )));
+  }
+
+  // --- REQ-NDO-LC-06: Transitioning to Deprecated requires a successor NDO hash ---
+  if *to == LifecycleStage::Deprecated {
+    match &new_entry.successor_ndo_hash {
+      None => {
+        return Ok(ValidateCallbackResult::Invalid(
+          "Transition to Deprecated requires successor_ndo_hash (REQ-NDO-LC-06)".to_string(),
+        ));
+      }
+      Some(h) => {
+        // Verify the successor hash resolves to a real record on the DHT.
+        // must_get_valid_record propagates UnresolvedDependencies via ? if not yet fetched.
+        must_get_valid_record(h.clone())?;
+      }
+    }
+  }
+
+  // --- successor_ndo_hash may only be set when transitioning to Deprecated ---
+  if new_entry.successor_ndo_hash.is_some()
+    && original.successor_ndo_hash.is_none()
+    && *to != LifecycleStage::Deprecated
+  {
+    return Ok(ValidateCallbackResult::Invalid(
+      "successor_ndo_hash may only be set when transitioning to Deprecated".to_string(),
+    ));
+  }
+
   Ok(ValidateCallbackResult::Valid)
 }
 

--- a/documentation/IMPLEMENTATION_STATUS.md
+++ b/documentation/IMPLEMENTATION_STATUS.md
@@ -87,6 +87,18 @@ Each zome follows the integrity/coordinator pattern with robust validation and c
 - **Resource Integration**: Direct governance attachment to resources
 - **Audit Trail**: Complete rule creation and modification tracking
 
+#### NDO Layer 0 — Identity Anchor ✅
+
+`NondominiumIdentity` provides a permanent identity anchor for any resource from conception through end-of-life. Implemented in PR #80.
+
+- **Entry type**: `NondominiumIdentity` with `name`, `initiator`, `property_regime`, `resource_nature`, `lifecycle_stage`, `created_at`, `description`
+- **Enums**: `LifecycleStage` (7 stages: Ideation→Specification→Development→Production→Hibernating→Deprecated→EndOfLife), `PropertyRegime` (6 variants), `ResourceNature` (5 variants)
+- **Immutability**: Only `lifecycle_stage` may change post-creation; deletes are always invalid
+- **Authorization**: Only the `initiator` may call `update_lifecycle_stage`
+- **Discovery links**: `AllNdos` (global `"ndo_identities"` path anchor), `AgentToNdo` (per-initiator)
+- **API**: `create_ndo`, `get_ndo` (resolves update chain), `update_lifecycle_stage`
+- **REQ coverage**: REQ-NDO-L0-01, -02, -03, -04, -06 implemented; REQ-NDO-L0-05 (EconomicEvent ref on transitions) not yet enforced; REQ-NDO-L0-07 (per-stage/nature/regime discovery anchors) not yet implemented
+
 ### Discovery and Query Patterns ✅
 
 #### Comprehensive Link Architecture
@@ -431,7 +443,8 @@ The following are **documented and traceable** to REQ-NDO-* in `documentation/re
 
 | Track | Design sources | Implementation status |
 | ----- | -------------- | ---------------------- |
-| **NDO three-layer model** | `ndo_prima_materia.md` §§4, 8, 10; `resources.md` §3 | Not started — MVP uses flat `ResourceSpecification` + `EconomicResource` |
+| **NDO Layer 0 (identity anchor)** | `ndo_prima_materia.md` §§4, 8; REQ-NDO-L0-01–07 | **Complete** (#80) — `NondominiumIdentity` entry with lifecycle validation; REQ-NDO-L0-05 (EconomicEvent ref) and -07 (facet anchors) not yet enforced |
+| **NDO Layers 1 & 2** | `ndo_prima_materia.md` §§4, 8, 10; `resources.md` §3 | Not started — Layer 1 (Specification links), Layer 2 (Process links), cross-layer link types pending |
 | **Lifecycle vs operational state split** | `ndo_prima_materia.md` §5, §9.4 (`REQ-NDO-OS-01`–`06`) | Not started — `ResourceState` still conflated (see zome_resource TODOs) |
 | **Unyt (EconomicAgreement, RAVE)** | `ndo_prima_materia.md` §6.6, §11.5; `unyt-integration.md`; REQ-NDO-CS-07–CS-11 | Not started — no Unyt cell / RAVE validation in governance zome |
 | **Flowsta (agent linking, IdentityVerification)** | `ndo_prima_materia.md` §6.7, §11.6; `flowsta-integration.md`; REQ-NDO-CS-12–CS-15 | Not started — `flowsta-agent-linking` zomes not bundled; `GovernanceRule` remains untyped strings |

--- a/documentation/IMPLEMENTATION_STATUS.md
+++ b/documentation/IMPLEMENTATION_STATUS.md
@@ -75,7 +75,7 @@ Each zome follows the integrity/coordinator pattern.
 `NondominiumIdentity` provides a permanent identity anchor for any resource from conception through end-of-life. Implemented in PR #80.
 
 - **Entry type**: `NondominiumIdentity` with `name`, `initiator`, `property_regime`, `resource_nature`, `lifecycle_stage`, `created_at`, `description`
-- **Enums**: `LifecycleStage` (7 stages: Ideation→Specification→Development→Production→Hibernating→Deprecated→EndOfLife), `PropertyRegime` (6 variants), `ResourceNature` (5 variants)
+- **Enums**: `LifecycleStage` (10 stages: Ideation→Specification→Development→Prototype→Stable→Distributed→Active→Hibernating→Deprecated→EndOfLife), `PropertyRegime` (6 variants), `ResourceNature` (5 variants)
 - **Immutability**: Only `lifecycle_stage` may change post-creation; deletes are always invalid
 - **Authorization**: Only the `initiator` may call `update_lifecycle_stage`
 - **Discovery links**: `AllNdos` (global `"ndo_identities"` path anchor), `AgentToNdo` (per-initiator)

--- a/documentation/IMPLEMENTATION_STATUS.md
+++ b/documentation/IMPLEMENTATION_STATUS.md
@@ -74,13 +74,13 @@ Each zome follows the integrity/coordinator pattern.
 
 `NondominiumIdentity` provides a permanent identity anchor for any resource from conception through end-of-life. Implemented in PR #80.
 
-- **Entry type**: `NondominiumIdentity` with `name`, `initiator`, `property_regime`, `resource_nature`, `lifecycle_stage`, `created_at`, `description`
-- **Enums**: `LifecycleStage` (10 stages: Ideation→Specification→Development→Prototype→Stable→Distributed→Active→Hibernating→Deprecated→EndOfLife), `PropertyRegime` (6 variants), `ResourceNature` (5 variants)
-- **Immutability**: Only `lifecycle_stage` may change post-creation; deletes are always invalid
-- **Authorization**: Only the `initiator` may call `update_lifecycle_stage`
+- **Entry type**: `NondominiumIdentity` with `name`, `initiator`, `property_regime`, `resource_nature`, `lifecycle_stage`, `created_at`, `description`, `successor_ndo_hash`
+- **Enums**: `LifecycleStage` (10 stages: Ideation→Specification→Development→Prototype→Stable→Distributed→Active→Hibernating→Deprecated→EndOfLife), `PropertyRegime` (6 variants), `ResourceNature` (5 variants: Physical, Digital, Service, Hybrid, Information — extends spec's 3-variant definition with Service and Information)
+- **Immutability**: Only `lifecycle_stage` may change post-creation; `successor_ndo_hash` set exactly once on Deprecated transition; deletes are always invalid
+- **Authorization**: Only the `initiator` may call `update_lifecycle_stage` (MVP simplification; full role-based authorization per REQ-NDO-LC-07 deferred to governance zome integration)
 - **Discovery links**: `AllNdos` (global `"ndo_identities"` path anchor), `AgentToNdo` (per-initiator)
-- **API**: `create_ndo`, `get_ndo` (resolves update chain), `update_lifecycle_stage`
-- **REQ coverage**: REQ-NDO-L0-01, -02, -03, -04, -06 implemented; REQ-NDO-L0-05 (EconomicEvent ref on transitions) not yet enforced; REQ-NDO-L0-07 (per-stage/nature/regime discovery anchors) not yet implemented
+- **API**: `create_ndo`, `get_ndo` (resolves update chain), `get_all_ndos` (global anchor traversal), `get_my_ndos` (raw AgentToNdo links), `update_lifecycle_stage`
+- **REQ coverage**: REQ-NDO-L0-01, -02, -03, -04, -06 implemented; not yet enforced: REQ-NDO-L0-05 (EconomicEvent ref on transitions, optional in coordinator), REQ-NDO-LC-02 (governance-as-operator for transition validation), REQ-NDO-LC-03 (automatic EconomicEvent generation per transition), REQ-NDO-LC-05 (EndOfLife challenge period), REQ-NDO-LC-07 (role-based authorization per §5.3); not yet implemented: REQ-NDO-L0-07 (per-stage/nature/regime facet discovery anchors)
 
 ### Discovery and Query Patterns ✅
 

--- a/documentation/zomes/resource_zome.md
+++ b/documentation/zomes/resource_zome.md
@@ -2,21 +2,14 @@
 
 The Resource zome implements the core resource management infrastructure for the nondominium ecosystem, providing ValueFlows-compliant resource specification management, Economic Resource lifecycle tracking, governance rule enforcement, and custody transfer workflows. It serves as the foundation for all resource-related activities and supports the Private Participation Receipt (PPR) reputation system through comprehensive audit trails.
 
-> **TODO (post-MVP — NDO Three-Layer Model, ndo_prima_materia.md §4)**: Introduce
-> `NondominiumIdentity` as the Layer 0 permanent identity anchor for all resources. This entry
-> carries `name`, `description`, `initiator`, `property_regime` (6-variant `PropertyRegime` enum),
-> `resource_nature`, `lifecycle_stage` (10-stage `LifecycleStage` enum), and `created_at`. Its
-> action hash becomes the stable identity for the NDO.
+> **NDO Layer 0 (`NondominiumIdentity`) is implemented** — see `### NondominiumIdentity Entry (Layer 0)` below.
 >
-> New link types required:
+> **TODO (post-MVP — NDO Layers 1 & 2, ndo_prima_materia.md §§4, 8, 10)**: Cross-layer link types not yet implemented:
 > - `NDOToSpecification` — Layer 0 identity hash to `ResourceSpecification` (Layer 1 activation)
 > - `NDOToProcess` — Layer 0 identity hash to `Process` (Layer 2 activation)
 > - `NDOToComponent` — Layer 0 identity hash to child NDO identity hash (holonic composition)
 > - `CapabilitySlot` — Layer 0 identity hash to capability targets (stigmergic attachment surface)
-> - `NDOsByLifecycleStage`, `NDOsByNature`, `NDOsByRegime` — discovery anchors
->
-> See `ndo_prima_materia.md` §§4, 8, and 10 for entry structures, link types, and migration
-> strategy. See `resources.md` §3 for the canonical three-layer model.
+> - `NDOsByLifecycleStage`, `NDOsByNature`, `NDOsByRegime` — facet discovery anchors (REQ-NDO-L0-07)
 >
 > **Unyt (post-MVP):** endorsed economic terms use typed **`EconomicAgreement`** `GovernanceRule` data (`ndo_prima_materia.md` §6.6, REQ-NDO-CS-09–CS-11; `documentation/requirements/post-mvp/unyt-integration.md`).
 
@@ -109,10 +102,15 @@ pub enum ResourceState {
     Reserved,         // → OperationalState::Reserved (LifecycleStage unchanged)
 }
 
-// TARGET — LifecycleStage (on NondominiumIdentity, Layer 0):
+// IMPLEMENTED — LifecycleStage (on NondominiumIdentity, Layer 0, REQ-NDO-LC-01–07):
 pub enum LifecycleStage {
-    Ideation, Specification, Development, Prototype,
-    Stable, Distributed, Active, Hibernating, Deprecated, EndOfLife,
+    Ideation,      // spark of an idea, no design yet
+    Specification, // design/requirements being written
+    Development,   // active construction / prototyping
+    Production,    // stable, in active use
+    Hibernating,   // dormant but not end-of-life
+    Deprecated,    // superseded by a newer version
+    EndOfLife,     // permanently archived, Layer 0 tombstone
 }
 
 // TARGET — OperationalState (on EconomicResource, Layer 2):
@@ -122,7 +120,7 @@ pub enum OperationalState {
 }
 ```
 
-**Key principle**: Transport, storage, and maintenance are *processes* that act on a resource at *any* lifecycle stage. A `Prototype` can be `InTransit` between R&D labs. An `Active` resource can be `InMaintenance`. These are operational conditions, not lifecycle milestones.
+**Key principle**: Transport, storage, and maintenance are *processes* that act on a resource at *any* lifecycle stage. A `Development` resource can be `InTransit` between R&D labs. A `Production` resource can be `InMaintenance`. These are operational conditions, not lifecycle milestones.
 
 **Lifecycle**: `LifecycleStage` tracks maturity/evolution (advances rarely, almost irreversibly)
 **Operational**: `OperationalState` tracks active processes (cycles frequently, reset to `Available` when process ends)

--- a/documentation/zomes/resource_zome.md
+++ b/documentation/zomes/resource_zome.md
@@ -50,6 +50,8 @@ State machine transitions are enforced by the integrity zome (see `ndo_prima_mat
 
 **Immutability**: Only `lifecycle_stage` may change post-creation, except that `successor_ndo_hash` is set exactly once during the `Deprecated` transition. Once `successor_ndo_hash` is set it is also immutable. Delete is always `Invalid` — Layer 0 is permanent.
 
+**Design note — NDO as identifier, not chronicle**: `lifecycle_stage` at creation reflects the resource's actual state at registration time, not a claim about when it was originally conceived. An existing physical resource registered into the system is created at its true current stage (e.g. `Active`), not forced through a synthetic `Ideation` entry. The NDO identity anchor behaves like a DOI or ISBN: it is assigned at the moment of system registration, which may be well after the resource began its life. Forcing `Ideation`-only initial stages would require fabricating DHT history for brownfield resources and block migration of existing `EconomicResource` entries when Layers 1/2 activate.
+
 **Discovery links**: `AllNdos` (global anchor `"ndo_identities"` path → action hashes), `AgentToNdo` (initiator pubkey → action hashes)
 
 **Lifecycle links**: `NdoToSuccessor` (deprecated NDO → successor NDO, REQ-NDO-LC-06), `NdoToTransitionEvent` (NDO → triggering `EconomicEvent`, REQ-NDO-L0-05)
@@ -117,13 +119,16 @@ pub enum ResourceState {
 
 // IMPLEMENTED — LifecycleStage (on NondominiumIdentity, Layer 0, REQ-NDO-LC-01–07):
 pub enum LifecycleStage {
-    Ideation,      // spark of an idea, no design yet
+    Ideation,      // spark of an idea, Layer 0 anchor only
     Specification, // design/requirements being written
     Development,   // active construction / prototyping
-    Production,    // stable, in active use
-    Hibernating,   // dormant but not end-of-life
-    Deprecated,    // superseded by a newer version
-    EndOfLife,     // permanently archived, Layer 0 tombstone
+    Prototype,     // proof-of-concept, not yet production-ready
+    Stable,        // production-ready, design is replicable
+    Distributed,   // being actively fabricated/used across the network
+    Active,        // in normal use
+    Hibernating,   // dormant but recoverable (reversible)
+    Deprecated,    // superseded; successor NDO required
+    EndOfLife,     // permanently concluded; Layer 0 tombstone
 }
 
 // TARGET — OperationalState (on EconomicResource, Layer 2):
@@ -133,7 +138,7 @@ pub enum OperationalState {
 }
 ```
 
-**Key principle**: Transport, storage, and maintenance are *processes* that act on a resource at *any* lifecycle stage. A `Development` resource can be `InTransit` between R&D labs. A `Production` resource can be `InMaintenance`. These are operational conditions, not lifecycle milestones.
+**Key principle**: Transport, storage, and maintenance are *processes* that act on a resource at *any* lifecycle stage. A `Development` resource can be `InTransit` between R&D labs. An `Active` resource can be `InMaintenance`. These are operational conditions, not lifecycle milestones.
 
 **Lifecycle**: `LifecycleStage` tracks maturity/evolution (advances rarely, almost irreversibly)
 **Operational**: `OperationalState` tracks active processes (cycles frequently, reset to `Available` when process ends)
@@ -173,6 +178,7 @@ Creates a new `NondominiumIdentity`. Sets `initiator` from `agent_info` and `cre
 **Output**: `NdoOutput { action_hash, entry }` — `action_hash` is the stable Layer 0 identity.
 **Links created**: `AllNdos` (global anchor `"ndo_identities"` → action hash), `AgentToNdo` (initiator pubkey → action hash).
 **Validation**: name must not be empty.
+**Initial stage**: Any non-terminal stage is valid at creation (`Hibernating`, `Deprecated`, `EndOfLife` are rejected). Use the resource's actual current stage — do not fabricate a synthetic `Ideation` entry for resources that pre-date system registration (see design note above).
 
 #### `get_ndo(original_action_hash: ActionHash) -> ExternResult<Option<NondominiumIdentity>>`
 
@@ -201,6 +207,14 @@ UpdateLifecycleStageInput {
 **Links created** (conditional):
 - `NdoToSuccessor` (`original_action_hash` → `successor_ndo_hash`) — only when `new_stage == Deprecated` (REQ-NDO-LC-06)
 - `NdoToTransitionEvent` (`original_action_hash` → `transition_event_hash`) — when `transition_event_hash` is `Some` (REQ-NDO-L0-05; full cross-zome event validation deferred)
+
+#### `get_all_ndos(_: ()) -> ExternResult<GetAllNdosOutput>`
+
+Returns the latest version of all `NondominiumIdentity` entries via the global `"ndo_identities"` anchor. Entries unavailable on the DHT or failing deserialization are silently skipped (eventual consistency). Output: `GetAllNdosOutput { ndos: Vec<NdoOutput> }`.
+
+#### `get_my_ndos(_: ()) -> ExternResult<Vec<Link>>`
+
+Returns raw `AgentToNdo` links for the calling agent. Each link's `target` is an `ActionHash` — the original (stable) Layer 0 identity. Pass each to `get_ndo` to resolve the current entry.
 
 ### Resource Specification Management
 

--- a/documentation/zomes/resource_zome.md
+++ b/documentation/zomes/resource_zome.md
@@ -22,24 +22,37 @@ Permanent identity anchor for any resource. Exists from the moment of conception
 ```rust
 pub struct NondominiumIdentity {
     pub name: String,
-    pub initiator: AgentPubKey,      // set from agent_info at creation; immutable
-    pub property_regime: PropertyRegime,
-    pub resource_nature: ResourceNature,
-    pub lifecycle_stage: LifecycleStage, // the ONLY mutable field
-    pub created_at: Timestamp,
-    pub description: Option<String>,
+    pub initiator: AgentPubKey,          // set from agent_info at creation; immutable
+    pub property_regime: PropertyRegime, // immutable after creation
+    pub resource_nature: ResourceNature, // immutable after creation
+    pub lifecycle_stage: LifecycleStage, // the ONLY mutable field (REQ-NDO-L0-04)
+    pub created_at: Timestamp,           // immutable after creation
+    pub description: Option<String>,     // immutable after creation
+    pub successor_ndo_hash: Option<ActionHash>, // set once on Deprecated transition (REQ-NDO-LC-06)
 }
 ```
 
-**LifecycleStage** (7 stages): `Ideation` → `Specification` → `Development` → `Production` → `Hibernating` → `Deprecated` → `EndOfLife`
+**LifecycleStage** (10 stages):
+
+| Phase | Stages |
+|---|---|
+| Emergence | `Ideation` → `Specification` → `Development` → `Prototype` |
+| Maturity | `Stable` → `Distributed` |
+| Operation | `Active` |
+| Suspension (reversible) | `Hibernating` |
+| Terminal | `Deprecated` → `EndOfLife` |
+
+State machine transitions are enforced by the integrity zome (see `ndo_prima_materia.md §5.3`). `Hibernating` is the only reversible pause state — it can return to `Active`. `Deprecated` and `EndOfLife` cannot be reactivated (REQ-NDO-LC-04).
 
 **PropertyRegime** (6 variants): `Private`, `Commons`, `Collective`, `Pool`, `CommonPool`, `Nondominium`
 
 **ResourceNature** (5 variants): `Physical`, `Digital`, `Service`, `Hybrid`, `Information`
 
-**Immutability**: Only `lifecycle_stage` may change post-creation. The integrity zome enforces this at validation time and checks that only the `initiator` may perform updates. Delete is always `Invalid` — Layer 0 is permanent.
+**Immutability**: Only `lifecycle_stage` may change post-creation, except that `successor_ndo_hash` is set exactly once during the `Deprecated` transition. Once `successor_ndo_hash` is set it is also immutable. Delete is always `Invalid` — Layer 0 is permanent.
 
 **Discovery links**: `AllNdos` (global anchor `"ndo_identities"` path → action hashes), `AgentToNdo` (initiator pubkey → action hashes)
+
+**Lifecycle links**: `NdoToSuccessor` (deprecated NDO → successor NDO, REQ-NDO-LC-06), `NdoToTransitionEvent` (NDO → triggering `EconomicEvent`, REQ-NDO-L0-05)
 
 ### ResourceSpecification Entry
 
@@ -167,11 +180,27 @@ Returns the **latest** version of a `NondominiumIdentity` by resolving the HDK u
 
 #### `update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<ActionHash>`
 
-Transitions the `lifecycle_stage` of a `NondominiumIdentity`. Only the initiator may call this. Enforced in both the coordinator (pre-flight check) and the integrity zome (validation).
+Transitions the `lifecycle_stage` of a `NondominiumIdentity`. Only the initiator may call this. Enforced in both the coordinator (pre-flight check) and the integrity zome (state machine validation).
 
-**Input**: `UpdateLifecycleStageInput { original_action_hash, new_stage: LifecycleStage }`
+**Input**:
+```rust
+UpdateLifecycleStageInput {
+    original_action_hash: ActionHash,
+    new_stage: LifecycleStage,
+    successor_ndo_hash: Option<ActionHash>,    // required when new_stage == Deprecated
+    transition_event_hash: Option<ActionHash>, // triggering EconomicEvent (REQ-NDO-L0-05)
+}
+```
+
 **Authorization**: caller must equal `entry.initiator`.
+
+**State machine**: The integrity zome enforces the §5.3 transition allowlist. Invalid transitions (e.g. `EndOfLife → Ideation`, `Deprecated → Active`) return a validation error.
+
 **Returns**: new action hash. The `original_action_hash` remains the stable Layer 0 identity.
+
+**Links created** (conditional):
+- `NdoToSuccessor` (`original_action_hash` → `successor_ndo_hash`) — only when `new_stage == Deprecated` (REQ-NDO-LC-06)
+- `NdoToTransitionEvent` (`original_action_hash` → `transition_event_hash`) — when `transition_event_hash` is `Some` (REQ-NDO-L0-05; full cross-zome event validation deferred)
 
 ### Resource Specification Management
 

--- a/documentation/zomes/resource_zome.md
+++ b/documentation/zomes/resource_zome.md
@@ -22,6 +22,32 @@ The Resource zome implements the core resource management infrastructure for the
 
 ## Core Data Structures
 
+### NondominiumIdentity Entry (Layer 0)
+
+Permanent identity anchor for any resource. Exists from the moment of conception through end-of-life. The original `ActionHash` from `create_ndo` is the **stable Layer 0 identity** — it never changes even as `lifecycle_stage` evolves.
+
+```rust
+pub struct NondominiumIdentity {
+    pub name: String,
+    pub initiator: AgentPubKey,      // set from agent_info at creation; immutable
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+    pub lifecycle_stage: LifecycleStage, // the ONLY mutable field
+    pub created_at: Timestamp,
+    pub description: Option<String>,
+}
+```
+
+**LifecycleStage** (7 stages): `Ideation` → `Specification` → `Development` → `Production` → `Hibernating` → `Deprecated` → `EndOfLife`
+
+**PropertyRegime** (6 variants): `Private`, `Commons`, `Collective`, `Pool`, `CommonPool`, `Nondominium`
+
+**ResourceNature** (5 variants): `Physical`, `Digital`, `Service`, `Hybrid`, `Information`
+
+**Immutability**: Only `lifecycle_stage` may change post-creation. The integrity zome enforces this at validation time and checks that only the `initiator` may perform updates. Delete is always `Invalid` — Layer 0 is permanent.
+
+**Discovery links**: `AllNdos` (global anchor `"ndo_identities"` path → action hashes), `AgentToNdo` (initiator pubkey → action hashes)
+
 ### ResourceSpecification Entry
 
 ```rust
@@ -125,6 +151,29 @@ pub struct GovernanceRule {
 **Governance**: Community-driven rule creation and management
 
 ## API Functions
+
+### NDO Layer 0 Management
+
+#### `create_ndo(input: NdoInput) -> ExternResult<NdoOutput>`
+
+Creates a new `NondominiumIdentity`. Sets `initiator` from `agent_info` and `created_at` from `sys_time`. Creates two discovery links.
+
+**Input**: `NdoInput { name, property_regime, resource_nature, lifecycle_stage, description }`
+**Output**: `NdoOutput { action_hash, entry }` — `action_hash` is the stable Layer 0 identity.
+**Links created**: `AllNdos` (global anchor `"ndo_identities"` → action hash), `AgentToNdo` (initiator pubkey → action hash).
+**Validation**: name must not be empty.
+
+#### `get_ndo(original_action_hash: ActionHash) -> ExternResult<Option<NondominiumIdentity>>`
+
+Returns the **latest** version of a `NondominiumIdentity` by resolving the HDK update chain. Always provide the original action hash — the function handles chain traversal internally.
+
+#### `update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<ActionHash>`
+
+Transitions the `lifecycle_stage` of a `NondominiumIdentity`. Only the initiator may call this. Enforced in both the coordinator (pre-flight check) and the integrity zome (validation).
+
+**Input**: `UpdateLifecycleStageInput { original_action_hash, new_stage: LifecycleStage }`
+**Authorization**: caller must equal `entry.initiator`.
+**Returns**: new action hash. The `original_action_hash` remains the stable Layer 0 identity.
 
 ### Resource Specification Management
 


### PR DESCRIPTION
## Intent

NDO Layer 0 introduces a permanent identity anchor (`NondominiumIdentity`) that exists from the moment a resource is conceived — before specification, before any physical instance. The existing model (`EconomicResource` + `ResourceSpecification`) only represents resources already in stable operational form. Layer 0 fills the ideation-to-end-of-life gap, giving every resource a stable DHT identity that survives the full lifecycle.

This is the foundation that all future NDO Layers 1 (Specification) and 2 (Process) will attach to.

## Changes

**New entry type — `NondominiumIdentity` (integrity)**
Permanent identity anchor. All fields immutable after creation except `lifecycle_stage` (and `successor_ndo_hash`, set exactly once during the Deprecated transition). The original `ActionHash` from `create_ndo` is the stable Layer 0 identity forever.

**New enums (integrity)**
- `LifecycleStage` (10 stages per spec §5.1): Ideation → Specification → Development → Prototype → Stable → Distributed → Active → Hibernating → Deprecated → EndOfLife
- `PropertyRegime` (6 variants: Private, Commons, Collective, Pool, CommonPool, Nondominium)
- `ResourceNature` (5 variants: Physical, Digital, Service, Hybrid, Information)

**New link types (integrity)**
- `AllNdos` — global discovery anchor (`ndo_identities` path → action hashes)
- `AgentToNdo` — per-initiator discovery
- `NdoToSuccessor` — deprecated NDO → successor NondominiumIdentity (REQ-NDO-LC-06)
- `NdoToTransitionEvent` — NDO → triggering EconomicEvent (REQ-NDO-L0-05; link only, cross-zome validation deferred)

**Validation (integrity)**
- Create: name must not be empty; initial stage must not be Hibernating/Deprecated/EndOfLife; `successor_ndo_hash` must be None
- Update: state machine transition allowlist enforced (§5.3); `Hibernating → Active` is the only reactivation path (REQ-NDO-LC-04); Deprecated/EndOfLife are terminal; transitioning to Deprecated requires `successor_ndo_hash` validated via `must_get_valid_record` (REQ-NDO-LC-06); `successor_ndo_hash` immutable once set
- Delete: always `Invalid` — Layer 0 is permanent

**New coordinator module — `ndo_identity.rs`**
- `create_ndo`: creates entry, sets initiator from `agent_info`, creates `AllNdos` and `AgentToNdo` links
- `get_ndo`: resolves the HDK update chain iteratively via `get_details` loop, always returns the latest version
- `get_all_ndos`: global anchor traversal via `AllNdos` path, returns latest version of each NDO (silent filtering for DHT unavailability)
- `get_my_ndos`: returns raw `AgentToNdo` links for the calling agent
- `update_lifecycle_stage`: pre-flight Deprecated check; writes `lifecycle_stage` + `successor_ndo_hash`; creates `NdoToSuccessor` on Deprecated; creates `NdoToTransitionEvent` when event hash provided

## Decisions

| Option | Rejected because |
| ------ | ---------------- |
| Use extra `NdoUpdates` links for chain resolution (like ResourceSpec pattern) | Adds link type not in spec; `get_details` loop is semantically correct and spec-compliant |
| Include categorization anchors (#75) in this PR | Scope creep; #75 extends create/update, needs its own review cycle |
| Remove `ResourceState` enum | EconomicResource still uses it; OperationalState refactor is post-MVP (REQ-NDO-OS-06) |
| Full `transition_event_hash` validation against governance zome | Integrity zomes cannot make cross-zome calls; coordinator cross-zome calls to `zome_gouvernance` are currently disabled. Link is created when hash is provided; validation deferred to a follow-up once cross-zome calls are stable |
| Allow Ideation/Specification → Hibernating | Not shown in the §5.3 Mermaid diagram; the "Any → Hibernating" authorization row covers active work stages only |
| Restrict initial `lifecycle_stage` to `Ideation` only | NDO is an identifier assigned at registration time, not a birth certificate. An existing physical resource registered into the system should be created at its true current stage (e.g. `Active`), not forced through a synthetic `Ideation` entry. Forcing Ideation-only would require fabricating DHT history for brownfield resources and block migration of existing `EconomicResource` entries when Layers 1/2 activate. `Hibernating`, `Deprecated`, and `EndOfLife` are still rejected at creation. |
| `ResourceNature` kept to 3 spec variants (Digital, Physical, Hybrid) | The spec §8.2 defines 3 variants. This implementation adds `Service` and `Information` because they are first-class resource natures in the OVN/ValueFlows context — software services and knowledge assets are distinct from digital files (Hybrid) and from pure data. These additions are backwards-compatible and do not conflict with any spec constraint. The spec's 3-variant set was written before the full OVN resource taxonomy was modelled. |
| Store `successor_ndo_hash` only as a link (spec §8.1 approach) | The spec defines the successor relationship as a `NdoToSuccessor` link only, with no field on the entry. This implementation stores it as both an entry field and a link: the field makes the successor inspectable on the entry itself without a link traversal (important for DHT-light clients), while the link preserves graph-query compatibility. The `#[serde(default)]` attribute ensures zero breaking change for existing records written before this field existed. |

## How to test

```bash
nix develop --command bun run build:zomes   # must pass with no errors
```

Sweettest scenarios for these functions are tracked in #76 (NDO Layer 0 test suite), which can be scaffolded in parallel and will pass once #73+#74+#75 are merged.

## Documentation

Updated `documentation/zomes/resource_zome.md` with the 10-stage lifecycle table, reversibility/terminal distinction, new `successor_ndo_hash` field, updated `update_lifecycle_stage` API surface including conditional links, `get_all_ndos`/`get_my_ndos` API docs, and NDO-as-identifier architecture design note.

## Related

Related issues:
- Closes #73
- Closes #74

- Depends on: (none — first in sequence)
- Follow-up: #75 (DHT categorization anchors), #76 (Sweettest), #77 (UI)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sensorica/nondominium/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->