### PR TITLE
feat(resource): redesign lifecycle state machine with hibernation memory

### DIFF
--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -216,8 +216,13 @@ pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<
     current_entry.hibernation_origin = None;
   }
 
-  current_entry.lifecycle_stage = to;
-  current_entry.successor_ndo_hash = input.successor_ndo_hash.clone();
+  current_entry.lifecycle_stage = to.clone();
+  // Only update successor_ndo_hash when entering Deprecated. Preserve the existing value
+  // for all other transitions — Deprecated → EndOfLife must not overwrite the already-set
+  // successor hash with None (integrity rejects immutable-once-set field changes).
+  if to == LifecycleStage::Deprecated {
+    current_entry.successor_ndo_hash = input.successor_ndo_hash.clone();
+  }
 
   let latest_action_hash = record.action_address().clone();
   let update_hash = update_entry(latest_action_hash, &current_entry)?;

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -95,6 +95,7 @@ pub fn create_ndo(input: NdoInput) -> ExternResult<NdoOutput> {
     created_at: sys_time()?,
     description: input.description,
     successor_ndo_hash: None,
+    hibernation_origin: None,
   };
 
   let action_hash = create_entry(&EntryTypes::NondominiumIdentity(entry.clone()))?;
@@ -198,8 +199,24 @@ pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<
     .into());
   }
 
-  // Apply mutations — integrity validation enforces the state machine and immutability
-  current_entry.lifecycle_stage = input.new_stage.clone();
+  // Apply mutations — integrity validation enforces the state machine and immutability.
+  // hibernation_origin is managed automatically; callers do not set it directly.
+  let from = current_entry.lifecycle_stage.clone();
+  let to = input.new_stage.clone();
+
+  // Entering Hibernating: record the stage being paused
+  if to == LifecycleStage::Hibernating {
+    current_entry.hibernation_origin = Some(from.clone());
+  }
+  // Exiting Hibernating or entering a terminal state: clear the origin field
+  if from == LifecycleStage::Hibernating
+    || to == LifecycleStage::Deprecated
+    || to == LifecycleStage::EndOfLife
+  {
+    current_entry.hibernation_origin = None;
+  }
+
+  current_entry.lifecycle_stage = to;
   current_entry.successor_ndo_hash = input.successor_ndo_hash.clone();
 
   let latest_action_hash = record.action_address().clone();

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -512,6 +512,13 @@ fn validate_update_nondominium_identity(
     ));
   }
 
+  // Terminal source: Deprecated exits only to EndOfLife
+  if *from == LifecycleStage::Deprecated && *to != LifecycleStage::EndOfLife {
+    return Ok(ValidateCallbackResult::Invalid(
+      "Deprecated is terminal; only EndOfLife transition is permitted".to_string(),
+    ));
+  }
+
   // Terminal destination: any non-terminal source may Deprecate or end
   if *to == LifecycleStage::Deprecated || *to == LifecycleStage::EndOfLife {
     // hibernation_origin must be cleared when entering a terminal state

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -123,8 +123,10 @@ pub struct EconomicResource {
 
 // NDO Layer 0 — NondominiumIdentity (REQ-NDO-L0-01, REQ-NDO-L0-07)
 // The permanent identity anchor of a resource. Exists from the moment of conception through
-// end-of-life. All fields are immutable after creation EXCEPT lifecycle_stage (and
-// successor_ndo_hash, which is set exactly once when transitioning to Deprecated).
+// end-of-life. Most fields are immutable after creation; three are conditionally mutable:
+//   lifecycle_stage    — changes on every transition (REQ-NDO-L0-04)
+//   successor_ndo_hash — set once when entering Deprecated (REQ-NDO-LC-06)
+//   hibernation_origin — set on → Hibernating, cleared on Hibernating → (see §5.3)
 // The original ActionHash from create_ndo is the stable Layer 0 identity for all time.
 // See: documentation/requirements/ndo_prima_materia.md §4.2 and §9.1
 #[hdk_entry_helper]
@@ -134,7 +136,7 @@ pub struct NondominiumIdentity {
   pub initiator: AgentPubKey,
   pub property_regime: PropertyRegime,
   pub resource_nature: ResourceNature,
-  pub lifecycle_stage: LifecycleStage, // the ONLY mutable field (REQ-NDO-L0-04)
+  pub lifecycle_stage: LifecycleStage,
   pub created_at: Timestamp,
   // Immutable after creation. REQ-NDO-L0-04 is stricter than the spec strictly requires here;
   // description is frozen intentionally to prevent retroactive reframing of the resource's
@@ -152,6 +154,13 @@ pub struct NondominiumIdentity {
   // See PR #80 Decisions table.
   #[serde(default)]
   pub successor_ndo_hash: Option<ActionHash>,
+  // Records the stage that was active immediately before entering Hibernating.
+  // Set by the coordinator on → Hibernating; cleared on Hibernating → (any stage).
+  // Always None in non-Hibernating states. Enables "Hibernating → {origin}" resume
+  // semantics so a paused resource returns to exactly where it was.
+  // #[serde(default)] ensures forward-compatibility with pre-field records.
+  #[serde(default)]
+  pub hibernation_origin: Option<LifecycleStage>,
 }
 
 #[hdk_entry_types]
@@ -416,16 +425,29 @@ fn validate_create_nondominium_identity(
     ));
   }
 
+  // hibernation_origin has no meaning at creation time
+  if ndi.hibernation_origin.is_some() {
+    return Ok(ValidateCallbackResult::Invalid(
+      "hibernation_origin must be None at creation".to_string(),
+    ));
+  }
+
   Ok(ValidateCallbackResult::Valid)
 }
 
-// REQ-NDO-L0-04: Only lifecycle_stage (and successor_ndo_hash during the Deprecated
-// transition) may be updated after creation. All other fields are permanently immutable.
-// REQ-NDO-LC-04: State machine transition allowlist enforced — Hibernating is reversible;
-// Deprecated and EndOfLife are terminal.
+// REQ-NDO-L0-04: Only lifecycle_stage, successor_ndo_hash (once, on Deprecated), and
+// hibernation_origin (set/cleared with Hibernating) may change after creation.
+// All other fields are permanently immutable.
+// REQ-NDO-LC-04: Hibernating is reversible; Deprecated and EndOfLife are terminal.
 // REQ-NDO-LC-06: Transitioning to Deprecated requires a successor NDO hash.
 // Note: initiator-only restriction is an MVP simplification of REQ-NDO-LC-07 (governance
 // zome enforces authorized role per transition). Full role-based authorization is deferred.
+//
+// State machine (per ndo_prima_materia.md §5.3):
+//   Forward chain (monotonic): Ideation→Spec→Dev→Proto→Stable→Dist→Active
+//   Suspend (any non-terminal → Hibernating): records hibernation_origin
+//   Resume (Hibernating → origin): clears hibernation_origin; target MUST equal origin
+//   Terminal (any → Deprecated [+successor] or EndOfLife): Deprecated → EndOfLife only exit
 fn validate_update_nondominium_identity(
   action: &Update,
   original: &NondominiumIdentity,
@@ -438,7 +460,7 @@ fn validate_update_nondominium_identity(
     ));
   }
 
-  // --- Immutable fields ---
+  // --- Permanently immutable fields ---
   if new_entry.name != original.name {
     return Ok(ValidateCallbackResult::Invalid(
       "NondominiumIdentity name is immutable after creation".to_string(),
@@ -470,7 +492,7 @@ fn validate_update_nondominium_identity(
     ));
   }
 
-  // --- successor_ndo_hash immutability: once set, cannot change ---
+  // --- successor_ndo_hash: immutable once set ---
   if original.successor_ndo_hash.is_some()
     && new_entry.successor_ndo_hash != original.successor_ndo_hash
   {
@@ -479,67 +501,119 @@ fn validate_update_nondominium_identity(
     ));
   }
 
-  // --- State machine: enforce transition allowlist (REQ-NDO-LC-04) ---
+  // --- Semantic state machine ---
   let from = &original.lifecycle_stage;
   let to = &new_entry.lifecycle_stage;
 
-  let allowed: &[LifecycleStage] = match from {
-    LifecycleStage::Ideation      => &[LifecycleStage::Specification],
-    LifecycleStage::Specification => &[LifecycleStage::Development],
-    LifecycleStage::Development   => &[LifecycleStage::Prototype,   LifecycleStage::Hibernating],
-    LifecycleStage::Prototype     => &[LifecycleStage::Stable,      LifecycleStage::Hibernating],
-    LifecycleStage::Stable        => &[LifecycleStage::Distributed, LifecycleStage::Hibernating],
-    LifecycleStage::Distributed   => &[LifecycleStage::Active,      LifecycleStage::Hibernating],
-    LifecycleStage::Active        => &[
-      LifecycleStage::Hibernating,
-      LifecycleStage::Deprecated,
-      LifecycleStage::EndOfLife,
-    ],
-    // Hibernating is the only reversible pause state (REQ-NDO-LC-04)
-    LifecycleStage::Hibernating   => &[LifecycleStage::Active, LifecycleStage::Deprecated],
-    // Terminal states: Deprecated can only move to EndOfLife; EndOfLife has no exit
-    LifecycleStage::Deprecated    => &[LifecycleStage::EndOfLife],
-    LifecycleStage::EndOfLife     => &[], // fully terminal — no transitions permitted
-  };
-
-  if !allowed.contains(to) {
-    return Ok(ValidateCallbackResult::Invalid(format!(
-      "Invalid lifecycle transition: {:?} → {:?} is not permitted by the state machine",
-      from, to
-    )));
+  // Terminal source: EndOfLife has no exit
+  if *from == LifecycleStage::EndOfLife {
+    return Ok(ValidateCallbackResult::Invalid(
+      "EndOfLife is terminal; no further transitions are permitted".to_string(),
+    ));
   }
 
-  // --- REQ-NDO-LC-06: Transitioning to Deprecated requires a successor NDO hash ---
-  if *to == LifecycleStage::Deprecated {
-    match &new_entry.successor_ndo_hash {
-      None => {
-        return Ok(ValidateCallbackResult::Invalid(
-          "Transition to Deprecated requires successor_ndo_hash (REQ-NDO-LC-06)".to_string(),
-        ));
-      }
-      Some(h) => {
-        // Verify the successor hash resolves to a real record on the DHT.
-        // must_get_valid_record propagates UnresolvedDependencies via ? if not yet fetched.
-        must_get_valid_record(h.clone())?;
-        // TODO (post-MVP): verify the resolved record's entry type is NondominiumIdentity.
-        // Currently only record existence is checked; a motivated actor could reference an
-        // arbitrary action hash as the "successor". Deserializing EntryTypes here would add
-        // strong type safety at the cost of additional DHT reads in the validation path.
+  // Terminal destination: any non-terminal source may Deprecate or end
+  if *to == LifecycleStage::Deprecated || *to == LifecycleStage::EndOfLife {
+    // hibernation_origin must be cleared when entering a terminal state
+    if new_entry.hibernation_origin.is_some() {
+      return Ok(ValidateCallbackResult::Invalid(
+        "hibernation_origin must be None when entering a terminal state".to_string(),
+      ));
+    }
+    // REQ-NDO-LC-06: Deprecated requires a validated successor hash
+    if *to == LifecycleStage::Deprecated {
+      match &new_entry.successor_ndo_hash {
+        None => {
+          return Ok(ValidateCallbackResult::Invalid(
+            "Transition to Deprecated requires successor_ndo_hash (REQ-NDO-LC-06)".to_string(),
+          ));
+        }
+        Some(h) => {
+          // Verify the successor hash resolves to a real record on the DHT.
+          // must_get_valid_record propagates UnresolvedDependencies via ? if not yet fetched.
+          must_get_valid_record(h.clone())?;
+          // TODO (post-MVP): verify the resolved record's entry type is NondominiumIdentity.
+          // Currently only record existence is checked; a motivated actor could reference an
+          // arbitrary action hash as the "successor". Deserializing EntryTypes here would add
+          // strong type safety at the cost of additional DHT reads in the validation path.
+        }
       }
     }
+    return Ok(ValidateCallbackResult::Valid);
   }
 
-  // --- successor_ndo_hash may only be set when transitioning to Deprecated ---
-  if new_entry.successor_ndo_hash.is_some()
-    && original.successor_ndo_hash.is_none()
-    && *to != LifecycleStage::Deprecated
-  {
+  // successor_ndo_hash may only be set when entering Deprecated (caught above)
+  if new_entry.successor_ndo_hash.is_some() && original.successor_ndo_hash.is_none() {
     return Ok(ValidateCallbackResult::Invalid(
       "successor_ndo_hash may only be set when transitioning to Deprecated".to_string(),
     ));
   }
 
-  Ok(ValidateCallbackResult::Valid)
+  // Entering Hibernating: record origin, reject Hibernating → Hibernating
+  if *to == LifecycleStage::Hibernating {
+    if *from == LifecycleStage::Hibernating {
+      return Ok(ValidateCallbackResult::Invalid(
+        "Cannot transition Hibernating → Hibernating".to_string(),
+      ));
+    }
+    // hibernation_origin must be set to the stage being paused
+    if new_entry.hibernation_origin.as_ref() != Some(from) {
+      return Ok(ValidateCallbackResult::Invalid(format!(
+        "hibernation_origin must equal the current stage ({:?}) when entering Hibernating",
+        from
+      )));
+    }
+    return Ok(ValidateCallbackResult::Valid);
+  }
+
+  // Resuming from Hibernating: must return to origin, clear origin field
+  if *from == LifecycleStage::Hibernating {
+    let origin = original.hibernation_origin.as_ref().ok_or_else(|| {
+      wasm_error!(WasmErrorInner::Guest(
+        "Hibernating entry is missing hibernation_origin — data integrity error".to_string()
+      ))
+    })?;
+    if to != origin {
+      return Ok(ValidateCallbackResult::Invalid(format!(
+        "Resuming from Hibernating must return to the origin stage ({:?}), not {:?}",
+        origin, to
+      )));
+    }
+    if new_entry.hibernation_origin.is_some() {
+      return Ok(ValidateCallbackResult::Invalid(
+        "hibernation_origin must be None after resuming from Hibernating".to_string(),
+      ));
+    }
+    return Ok(ValidateCallbackResult::Valid);
+  }
+
+  // hibernation_origin must remain None outside of Hibernating transitions
+  if new_entry.hibernation_origin.is_some() {
+    return Ok(ValidateCallbackResult::Invalid(
+      "hibernation_origin must be None for non-Hibernating transitions".to_string(),
+    ));
+  }
+
+  // Forward maturity chain (monotonic, no skipping)
+  let allowed_next = match from {
+    LifecycleStage::Ideation      => Some(LifecycleStage::Specification),
+    LifecycleStage::Specification => Some(LifecycleStage::Development),
+    LifecycleStage::Development   => Some(LifecycleStage::Prototype),
+    LifecycleStage::Prototype     => Some(LifecycleStage::Stable),
+    LifecycleStage::Stable        => Some(LifecycleStage::Distributed),
+    LifecycleStage::Distributed   => Some(LifecycleStage::Active),
+    LifecycleStage::Active        => None, // Active exits only via Hibernating/terminal (above)
+    LifecycleStage::Deprecated    => None, // Deprecated exits only via EndOfLife (above)
+    _ => None,
+  };
+
+  match allowed_next {
+    Some(ref next) if next == to => Ok(ValidateCallbackResult::Valid),
+    _ => Ok(ValidateCallbackResult::Invalid(format!(
+      "Invalid lifecycle transition: {:?} → {:?} is not permitted",
+      from, to
+    ))),
+  }
 }
 
 // REQ-NDO-L0-03: Layer 0 entries cannot be deleted. The identity is permanent.

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -575,11 +575,12 @@ fn validate_update_nondominium_identity(
 
   // Resuming from Hibernating: must return to origin, clear origin field
   if *from == LifecycleStage::Hibernating {
-    let origin = original.hibernation_origin.as_ref().ok_or_else(|| {
-      wasm_error!(WasmErrorInner::Guest(
-        "Hibernating entry is missing hibernation_origin — data integrity error".to_string()
-      ))
-    })?;
+    let origin = match original.hibernation_origin.as_ref() {
+      Some(o) => o,
+      None => return Ok(ValidateCallbackResult::Invalid(
+        "Hibernating entry is missing hibernation_origin — data integrity error".to_string(),
+      )),
+    };
     if to != origin {
       return Ok(ValidateCallbackResult::Invalid(format!(
         "Resuming from Hibernating must return to the origin stage ({:?}), not {:?}",

--- a/documentation/requirements/ndo_prima_materia.md
+++ b/documentation/requirements/ndo_prima_materia.md
@@ -388,21 +388,47 @@ Each transition between lifecycle stages is driven by a **VfAction economic even
 ```mermaid
 stateDiagram-v2
     [*] --> Ideation : "NondominiumIdentity created"
+
+    %% Forward maturity chain (monotonic, no skipping)
     Ideation --> Specification : "Produce (spec created)"
     Specification --> Development : "Work (contributions begin)"
     Development --> Prototype : "Produce (PoC delivered)"
     Prototype --> Stable : "Accept (peer validated)"
     Stable --> Distributed : "Transfer (first fabrication)"
     Distributed --> Active : "Use (operational)"
+
+    %% Suspend — any non-terminal stage may enter Hibernating
+    Ideation --> Hibernating : "Lower"
+    Specification --> Hibernating : "Lower"
+    Development --> Hibernating : "Lower"
+    Prototype --> Hibernating : "Lower"
+    Stable --> Hibernating : "Lower"
+    Distributed --> Hibernating : "Lower"
     Active --> Hibernating : "Lower (activity paused)"
-    Hibernating --> Active : "Raise (reactivated)"
+
+    %% Resume — always returns to the stage that was paused (hibernation_origin)
+    Hibernating --> Ideation : "Raise (to origin)"
+    Hibernating --> Specification : "Raise (to origin)"
+    Hibernating --> Development : "Raise (to origin)"
+    Hibernating --> Prototype : "Raise (to origin)"
+    Hibernating --> Stable : "Raise (to origin)"
+    Hibernating --> Distributed : "Raise (to origin)"
+    Hibernating --> Active : "Raise (to origin)"
+
+    %% Terminal — any non-terminal stage may deprecate or end
     Hibernating --> Deprecated : "Cite (successor declared)"
     Active --> Deprecated : "Cite (superseded)"
     Deprecated --> EndOfLife : "Consume (formally concluded)"
     Active --> EndOfLife : "Consume (formally concluded)"
-    Stable --> Hibernating : "Lower"
-    Development --> Hibernating : "Lower"
 ```
+
+> **Hibernating is a memory-preserving pause.** The `hibernation_origin` field records the stage
+> that was active before entering `Hibernating`. On resume ("Raise"), the resource returns to
+> exactly that stage — not necessarily `Active`. This means a resource paused at `Specification`
+> resumes at `Specification`, preserving the integrity of the maturity chain.
+>
+> The Mermaid above shows representative "Raise" arrows; in practice, the valid resume target
+> is always `hibernation_origin`, enforced by the integrity zome.
 
 **Transition authorization by role:**
 
@@ -412,8 +438,10 @@ stateDiagram-v2
 | Specification → Development | Initiator or any Accountable Agent with contribution |
 | Development → Prototype | Custodian + governance validation |
 | Prototype → Stable | Multi-agent peer validation (configurable N-of-M) |
+| Stable → Distributed | Custodian |
+| Distributed → Active | Custodian |
 | Any → Hibernating | Current custodian(s) |
-| Hibernating → Active | Current custodian(s) |
+| Hibernating → {origin stage} | Current custodian(s) |
 | Any → Deprecated | Custodian + declaration of successor NDO |
 | Any → EndOfLife | Custodian + challenge period (see REQ-GOV-11 to REQ-GOV-13) |
 

--- a/documentation/zomes/resource_zome.md
+++ b/documentation/zomes/resource_zome.md
@@ -22,13 +22,14 @@ Permanent identity anchor for any resource. Exists from the moment of conception
 ```rust
 pub struct NondominiumIdentity {
     pub name: String,
-    pub initiator: AgentPubKey,          // set from agent_info at creation; immutable
+    pub initiator: AgentPubKey,          // immutable after creation
     pub property_regime: PropertyRegime, // immutable after creation
     pub resource_nature: ResourceNature, // immutable after creation
-    pub lifecycle_stage: LifecycleStage, // the ONLY mutable field (REQ-NDO-L0-04)
+    pub lifecycle_stage: LifecycleStage, // mutable — changes on every transition
     pub created_at: Timestamp,           // immutable after creation
     pub description: Option<String>,     // immutable after creation
-    pub successor_ndo_hash: Option<ActionHash>, // set once on Deprecated transition (REQ-NDO-LC-06)
+    pub successor_ndo_hash: Option<ActionHash>, // set once on → Deprecated (REQ-NDO-LC-06)
+    pub hibernation_origin: Option<LifecycleStage>, // set on → Hibernating, cleared on exit
 }
 ```
 
@@ -42,13 +43,21 @@ pub struct NondominiumIdentity {
 | Suspension (reversible) | `Hibernating` |
 | Terminal | `Deprecated` → `EndOfLife` |
 
-State machine transitions are enforced by the integrity zome (see `ndo_prima_materia.md §5.3`). `Hibernating` is the only reversible pause state — it can return to `Active`. `Deprecated` and `EndOfLife` cannot be reactivated (REQ-NDO-LC-04).
+State machine transitions are enforced by the integrity zome (see `ndo_prima_materia.md §5.3`). `Hibernating` is a memory-preserving pause — it resumes to the exact stage that was paused, not necessarily `Active`. `Deprecated` and `EndOfLife` are terminal (REQ-NDO-LC-04). Any non-terminal stage may enter `Hibernating`, `Deprecated`, or `EndOfLife`.
 
 **PropertyRegime** (6 variants): `Private`, `Commons`, `Collective`, `Pool`, `CommonPool`, `Nondominium`
 
 **ResourceNature** (5 variants): `Physical`, `Digital`, `Service`, `Hybrid`, `Information`
 
-**Immutability**: Only `lifecycle_stage` may change post-creation, except that `successor_ndo_hash` is set exactly once during the `Deprecated` transition. Once `successor_ndo_hash` is set it is also immutable. Delete is always `Invalid` — Layer 0 is permanent.
+**Mutability** (three conditionally-mutable fields):
+
+| Field | Rule |
+|---|---|
+| `lifecycle_stage` | Changes on every transition |
+| `successor_ndo_hash` | Set exactly once when entering `Deprecated`; immutable after |
+| `hibernation_origin` | Set to the paused stage when entering `Hibernating`; cleared on exit |
+
+All other fields are permanently immutable after creation. Delete is always `Invalid` — Layer 0 is permanent.
 
 **Design note — NDO as identifier, not chronicle**: `lifecycle_stage` at creation reflects the resource's actual state at registration time, not a claim about when it was originally conceived. An existing physical resource registered into the system is created at its true current stage (e.g. `Active`), not forced through a synthetic `Ideation` entry. The NDO identity anchor behaves like a DOI or ISBN: it is assigned at the moment of system registration, which may be well after the resource began its life. Forcing `Ideation`-only initial stages would require fabricating DHT history for brownfield resources and block migration of existing `EconomicResource` entries when Layers 1/2 activate.
 


### PR DESCRIPTION
## Intent

The NDO lifecycle state machine had a structural flaw: `Hibernating` was modeled as a peer node with a single hardcoded exit (`Hibernating → Active`). This caused two problems:

1. **Stage-skipping on resume.** A resource paused at `Development` would emerge at `Active`, skipping `Prototype → Stable → Distributed`. The maturity chain could be bypassed silently.
2. **Incomplete "Any → Hibernating" implementation.** The spec §5.3 auth table says any custodian can hibernate any stage, but the implementation only allowed it from `Development`, `Prototype`, `Stable`, `Distributed`, and `Active`. `Ideation` and `Specification` could not be paused.

This PR redesigns `Hibernating` as a **memory-preserving pause operator**: it records where it came from (`hibernation_origin`) and always resumes to exactly that stage.

## Changes

**`NondominiumIdentity` struct (integrity)**
- Add `hibernation_origin: Option<LifecycleStage>` — the third conditionally-mutable field alongside `lifecycle_stage` and `successor_ndo_hash`
- `#[serde(default)]` ensures forward-compatibility with pre-field records on the DHT
- Always `None` in non-Hibernating states; set by the coordinator on `→ Hibernating`, cleared on exit

**`validate_update_nondominium_identity` (integrity)**
- Replace flat per-stage allowlist with a semantic three-case validator:
  1. **Terminal destination** (`→ Deprecated` or `→ EndOfLife`): valid from any non-terminal source; clears `hibernation_origin`; enforces `successor_ndo_hash` for `Deprecated`
  2. **Entering Hibernating** (`→ Hibernating`): validates `hibernation_origin == current stage`; rejects `Hibernating → Hibernating`
  3. **Resuming from Hibernating** (`Hibernating → X`): enforces `X == hibernation_origin`; validates `hibernation_origin` is cleared
  4. **Forward chain** (everything else): `Ideation→Spec→Dev→Proto→Stable→Dist→Active`, one step at a time

**`update_lifecycle_stage` coordinator**
- Auto-manages `hibernation_origin`: set on `→ Hibernating`, cleared on exit or terminal transition
- Callers are unaffected — `UpdateLifecycleStageInput` is unchanged

**Spec `ndo_prima_materia.md §5.3`**
- Revise Mermaid to show "Any → Hibernating" and "Hibernating → {origin stage}" transitions
- Add explanatory note on hibernation memory semantics
- Complete the auth table with `Stable → Distributed`, `Distributed → Active`, and `Hibernating → {origin stage}` rows

**`resource_zome.md`**
- Add `hibernation_origin` to struct documentation
- Replace "only mutable field" phrasing with a three-row mutability table
- Update state machine prose

## Decisions

| Option | Rejected because |
|---|---|
| Keep `Hibernating → Active` as the only exit | Causes stage-skipping for any resource paused before reaching `Active`; semantically broken |
| Traverse update chain in coordinator to infer origin | Coordinator can do it; integrity cannot — and integrity is the validation authority |
| Allow `Hibernating → {any stage}` freely | Enables shortcuts: `Specification → Hibernating → Active` bypasses the full maturity chain |
| Two-node model (`Hibernating` + `OnHold` for early stages) | Complexity without benefit; `hibernation_origin` solves the same problem with a single node |

## How to test

```bash
nix develop --command bun run build:zomes   # must pass with no errors
```

Sweettest scenarios (issue #76):
- Early-stage hibernation: `Ideation → Hibernating → Ideation` ✓, `Ideation → Hibernating → Specification` ✗
- Mid-chain: `Development → Hibernating → Development` ✓, `Development → Hibernating → Active` ✗
- Multiple cycles: `Active → Hibernating → Active → Hibernating → Active` ✓
- Any-stage terminal: `Specification → Deprecated` ✓, `Ideation → EndOfLife` ✓

## Documentation

Updated `documentation/requirements/ndo_prima_materia.md` §5.3 (Mermaid + auth table) and `documentation/zomes/resource_zome.md` (struct, mutability table, state machine description).

## Related

- Depends on: #80 (NDO Layer 0 `NondominiumIdentity` implementation)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sensorica/nondominium/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
