### PR TITLE
feat(resource): add NDO DHT categorization anchors and query functions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = vendor/hrea
 	url = git@github.com:Sensorica/hREA.git
 	branch = main-0.6
+[submodule ".claude/skills/holochain-agent-skill"]
+	path = .claude/skills/holochain-agent-skill
+	url = git@github.com:Soushi888/holochain-agent-skill.git

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -54,6 +54,28 @@ fn property_regime_path(regime: &PropertyRegime) -> ExternResult<EntryHash> {
   Path::from(format!("ndo.regime.{:?}", regime)).path_entry_hash()
 }
 
+/// Resolve a batch of DHT links into NdoOutput entries.
+///
+/// For each link, extracts the target action hash, resolves the latest record via the
+/// update chain, and deserializes the entry. Links that fail any step are silently
+/// skipped (DHT availability is eventual). Used by all NDO query functions.
+fn resolve_ndo_links(links: Vec<Link>) -> ExternResult<Vec<NdoOutput>> {
+  let mut ndos = Vec::new();
+  for link in links {
+    let Some(action_hash) = link.target.into_action_hash() else {
+      continue;
+    };
+    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
+      continue;
+    };
+    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
+      continue;
+    };
+    ndos.push(NdoOutput { action_hash, entry });
+  }
+  Ok(ndos)
+}
+
 /// Resolves the HDK update chain to the latest Record for a NondominiumIdentity.
 /// Returns None if the original_action_hash does not exist on the DHT.
 ///
@@ -329,21 +351,7 @@ pub fn get_all_ndos(_: ()) -> ExternResult<GetAllNdosOutput> {
   let links_query =
     LinkQuery::try_new(path.path_entry_hash()?, LinkTypes::AllNdos)?;
   let links = get_links(links_query, GetStrategy::default())?;
-
-  let mut ndos = Vec::new();
-  for link in links {
-    let Some(action_hash) = link.target.into_action_hash() else {
-      continue;
-    };
-    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
-      continue;
-    };
-    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
-      continue;
-    };
-    ndos.push(NdoOutput { action_hash, entry });
-  }
-  Ok(GetAllNdosOutput { ndos })
+  Ok(GetAllNdosOutput { ndos: resolve_ndo_links(links)? })
 }
 
 /// Return all NondominiumIdentities at a given lifecycle stage.
@@ -359,20 +367,7 @@ pub fn get_ndos_by_lifecycle_stage(stage: LifecycleStage) -> ExternResult<GetAll
     LinkQuery::try_new(lifecycle_stage_path(&stage)?, LinkTypes::NdoByLifecycleStage)?,
     GetStrategy::default(),
   )?;
-  let mut ndos = Vec::new();
-  for link in links {
-    let Some(action_hash) = link.target.into_action_hash() else {
-      continue;
-    };
-    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
-      continue;
-    };
-    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
-      continue;
-    };
-    ndos.push(NdoOutput { action_hash, entry });
-  }
-  Ok(GetAllNdosOutput { ndos })
+  Ok(GetAllNdosOutput { ndos: resolve_ndo_links(links)? })
 }
 
 /// Return all NondominiumIdentities of a given resource nature.
@@ -388,20 +383,7 @@ pub fn get_ndos_by_nature(nature: ResourceNature) -> ExternResult<GetAllNdosOutp
     LinkQuery::try_new(resource_nature_path(&nature)?, LinkTypes::NdoByNature)?,
     GetStrategy::default(),
   )?;
-  let mut ndos = Vec::new();
-  for link in links {
-    let Some(action_hash) = link.target.into_action_hash() else {
-      continue;
-    };
-    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
-      continue;
-    };
-    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
-      continue;
-    };
-    ndos.push(NdoOutput { action_hash, entry });
-  }
-  Ok(GetAllNdosOutput { ndos })
+  Ok(GetAllNdosOutput { ndos: resolve_ndo_links(links)? })
 }
 
 /// Return all NondominiumIdentities under a given property regime.
@@ -417,20 +399,7 @@ pub fn get_ndos_by_property_regime(regime: PropertyRegime) -> ExternResult<GetAl
     LinkQuery::try_new(property_regime_path(&regime)?, LinkTypes::NdoByPropertyRegime)?,
     GetStrategy::default(),
   )?;
-  let mut ndos = Vec::new();
-  for link in links {
-    let Some(action_hash) = link.target.into_action_hash() else {
-      continue;
-    };
-    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
-      continue;
-    };
-    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
-      continue;
-    };
-    ndos.push(NdoOutput { action_hash, entry });
-  }
-  Ok(GetAllNdosOutput { ndos })
+  Ok(GetAllNdosOutput { ndos: resolve_ndo_links(links)? })
 }
 
 /// Return all NondominiumIdentities created by the calling agent, resolved to latest entries.
@@ -446,18 +415,5 @@ pub fn get_my_ndos(_: ()) -> ExternResult<GetAllNdosOutput> {
     LinkQuery::try_new(agent_pub_key, LinkTypes::AgentToNdo)?,
     GetStrategy::default(),
   )?;
-  let mut ndos = Vec::new();
-  for link in links {
-    let Some(action_hash) = link.target.into_action_hash() else {
-      continue;
-    };
-    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
-      continue;
-    };
-    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
-      continue;
-    };
-    ndos.push(NdoOutput { action_hash, entry });
-  }
-  Ok(GetAllNdosOutput { ndos })
+  Ok(GetAllNdosOutput { ndos: resolve_ndo_links(links)? })
 }

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_identity.rs
@@ -40,6 +40,20 @@ pub struct UpdateLifecycleStageInput {
   pub transition_event_hash: Option<ActionHash>,
 }
 
+// Path helpers for NDO categorization anchors (issue #75).
+// Using {:#?} would add newlines; {:?} gives the variant name: LifecycleStage::Ideation → "Ideation".
+fn lifecycle_stage_path(stage: &LifecycleStage) -> ExternResult<EntryHash> {
+  Path::from(format!("ndo.lifecycle.{:?}", stage)).path_entry_hash()
+}
+
+fn resource_nature_path(nature: &ResourceNature) -> ExternResult<EntryHash> {
+  Path::from(format!("ndo.nature.{:?}", nature)).path_entry_hash()
+}
+
+fn property_regime_path(regime: &PropertyRegime) -> ExternResult<EntryHash> {
+  Path::from(format!("ndo.regime.{:?}", regime)).path_entry_hash()
+}
+
 /// Resolves the HDK update chain to the latest Record for a NondominiumIdentity.
 /// Returns None if the original_action_hash does not exist on the DHT.
 ///
@@ -114,6 +128,28 @@ pub fn create_ndo(input: NdoInput) -> ExternResult<NdoOutput> {
     agent_info.agent_initial_pubkey.clone(),
     action_hash.clone(),
     LinkTypes::AgentToNdo,
+    (),
+  )?;
+
+  // Categorization anchors for filtered discovery (issue #75).
+  // NdoByNature and NdoByPropertyRegime are immutable — created once, never moved.
+  // NdoByLifecycleStage is moved by update_lifecycle_stage when stage changes.
+  create_link(
+    lifecycle_stage_path(&entry.lifecycle_stage)?,
+    action_hash.clone(),
+    LinkTypes::NdoByLifecycleStage,
+    (),
+  )?;
+  create_link(
+    resource_nature_path(&entry.resource_nature)?,
+    action_hash.clone(),
+    LinkTypes::NdoByNature,
+    (),
+  )?;
+  create_link(
+    property_regime_path(&entry.property_regime)?,
+    action_hash.clone(),
+    LinkTypes::NdoByPropertyRegime,
     (),
   )?;
 
@@ -201,7 +237,8 @@ pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<
 
   // Apply mutations — integrity validation enforces the state machine and immutability.
   // hibernation_origin is managed automatically; callers do not set it directly.
-  let from = current_entry.lifecycle_stage.clone();
+  let old_stage = current_entry.lifecycle_stage.clone();
+  let from = old_stage.clone();
   let to = input.new_stage.clone();
 
   // Entering Hibernating: record the stage being paused
@@ -252,6 +289,31 @@ pub fn update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<
     )?;
   }
 
+  // Move NdoByLifecycleStage categorization anchor when stage changes (issue #75).
+  // Delete the link from the old stage anchor that targets original_action_hash,
+  // then create a new link from the new stage anchor. NdoByNature and NdoByPropertyRegime
+  // are immutable and never moved.
+  if old_stage != input.new_stage {
+    let old_links = get_links(
+      LinkQuery::try_new(lifecycle_stage_path(&old_stage)?, LinkTypes::NdoByLifecycleStage)?,
+      GetStrategy::default(),
+    )?;
+    for link in old_links {
+      if let Some(target_hash) = link.target.into_action_hash() {
+        if target_hash == input.original_action_hash {
+          delete_link(link.create_link_hash, GetOptions::default())?;
+          break;
+        }
+      }
+    }
+    create_link(
+      lifecycle_stage_path(&input.new_stage)?,
+      input.original_action_hash.clone(),
+      LinkTypes::NdoByLifecycleStage,
+      (),
+    )?;
+  }
+
   Ok(update_hash)
 }
 
@@ -284,17 +346,118 @@ pub fn get_all_ndos(_: ()) -> ExternResult<GetAllNdosOutput> {
   Ok(GetAllNdosOutput { ndos })
 }
 
-/// Return raw AgentToNdo links for the calling agent.
+/// Return all NondominiumIdentities at a given lifecycle stage.
 ///
-/// Returns links rather than resolved entries so callers can access
-/// the target action_hash directly without a second DHT round-trip
-/// when only the identity is needed. Pass each target to `get_ndo`
-/// to resolve the current entry.
+/// Uses the NdoByLifecycleStage categorization anchor maintained by create_ndo
+/// and update_lifecycle_stage. Returns the latest version of each NDO.
+/// Entries that fail to resolve or deserialize are silently skipped.
+///
+/// REQ-NDO-L0-05, REQ-NDO-L0-07
+#[hdk_extern]
+pub fn get_ndos_by_lifecycle_stage(stage: LifecycleStage) -> ExternResult<GetAllNdosOutput> {
+  let links = get_links(
+    LinkQuery::try_new(lifecycle_stage_path(&stage)?, LinkTypes::NdoByLifecycleStage)?,
+    GetStrategy::default(),
+  )?;
+  let mut ndos = Vec::new();
+  for link in links {
+    let Some(action_hash) = link.target.into_action_hash() else {
+      continue;
+    };
+    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
+      continue;
+    };
+    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
+      continue;
+    };
+    ndos.push(NdoOutput { action_hash, entry });
+  }
+  Ok(GetAllNdosOutput { ndos })
+}
+
+/// Return all NondominiumIdentities of a given resource nature.
+///
+/// Uses the NdoByNature categorization anchor created at NDO creation time.
+/// The nature field is immutable — this anchor never moves.
+/// Entries that fail to resolve or deserialize are silently skipped.
+///
+/// REQ-NDO-L0-05, REQ-NDO-L0-07
+#[hdk_extern]
+pub fn get_ndos_by_nature(nature: ResourceNature) -> ExternResult<GetAllNdosOutput> {
+  let links = get_links(
+    LinkQuery::try_new(resource_nature_path(&nature)?, LinkTypes::NdoByNature)?,
+    GetStrategy::default(),
+  )?;
+  let mut ndos = Vec::new();
+  for link in links {
+    let Some(action_hash) = link.target.into_action_hash() else {
+      continue;
+    };
+    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
+      continue;
+    };
+    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
+      continue;
+    };
+    ndos.push(NdoOutput { action_hash, entry });
+  }
+  Ok(GetAllNdosOutput { ndos })
+}
+
+/// Return all NondominiumIdentities under a given property regime.
+///
+/// Uses the NdoByPropertyRegime categorization anchor created at NDO creation time.
+/// The property_regime field is immutable — this anchor never moves.
+/// Entries that fail to resolve or deserialize are silently skipped.
+///
+/// REQ-NDO-L0-05, REQ-NDO-L0-07
+#[hdk_extern]
+pub fn get_ndos_by_property_regime(regime: PropertyRegime) -> ExternResult<GetAllNdosOutput> {
+  let links = get_links(
+    LinkQuery::try_new(property_regime_path(&regime)?, LinkTypes::NdoByPropertyRegime)?,
+    GetStrategy::default(),
+  )?;
+  let mut ndos = Vec::new();
+  for link in links {
+    let Some(action_hash) = link.target.into_action_hash() else {
+      continue;
+    };
+    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
+      continue;
+    };
+    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
+      continue;
+    };
+    ndos.push(NdoOutput { action_hash, entry });
+  }
+  Ok(GetAllNdosOutput { ndos })
+}
+
+/// Return all NondominiumIdentities created by the calling agent, resolved to latest entries.
+///
+/// Uses AgentToNdo links set at creation time. Returns the latest version of each NDO
+/// (chain-resolved). Entries that fail to resolve or deserialize are silently skipped.
 ///
 /// REQ-NDO-L0-07
 #[hdk_extern]
-pub fn get_my_ndos(_: ()) -> ExternResult<Vec<Link>> {
+pub fn get_my_ndos(_: ()) -> ExternResult<GetAllNdosOutput> {
   let agent_pub_key = agent_info()?.agent_initial_pubkey;
-  let links_query = LinkQuery::try_new(agent_pub_key, LinkTypes::AgentToNdo)?;
-  get_links(links_query, GetStrategy::default())
+  let links = get_links(
+    LinkQuery::try_new(agent_pub_key, LinkTypes::AgentToNdo)?,
+    GetStrategy::default(),
+  )?;
+  let mut ndos = Vec::new();
+  for link in links {
+    let Some(action_hash) = link.target.into_action_hash() else {
+      continue;
+    };
+    let Some(record) = resolve_latest_ndo_record(action_hash.clone())? else {
+      continue;
+    };
+    let Ok(Some(entry)) = record.entry().to_app_option::<NondominiumIdentity>() else {
+      continue;
+    };
+    ndos.push(NdoOutput { action_hash, entry });
+  }
+  Ok(GetAllNdosOutput { ndos })
 }

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -326,7 +326,11 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
         }
       }
       OpRecord::CreateLink { .. } => {
-        // Validate link creation
+        // TODO(next-pr): Add per-LinkType integrity validation for NdoByLifecycleStage,
+        // NdoByNature, and NdoByPropertyRegime. Currently all CreateLink ops return Valid,
+        // matching the existing zome-wide pattern, but a malicious peer could create spurious
+        // or delete legitimate categorization links. Future validation should verify base/target
+        // types and author permissions before accepting link ops.
         Ok(ValidateCallbackResult::Valid)
       }
       _ => Ok(ValidateCallbackResult::Valid),

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -185,6 +185,12 @@ pub enum LinkTypes {
   AllNdos,    // global anchor: "ndo_identities" path → NondominiumIdentity action hashes
   AgentToNdo, // initiator pubkey → NondominiumIdentity action hashes
 
+  // NDO Layer 0 categorization anchors for filtered discovery (REQ-NDO-L0-05, issue #75)
+  // anchor path pattern: "ndo.lifecycle.{Stage:?}" / "ndo.nature.{Nature:?}" / "ndo.regime.{Regime:?}"
+  NdoByLifecycleStage, // Path("ndo.lifecycle.{stage}") → NondominiumIdentity action hashes
+  NdoByNature,         // Path("ndo.nature.{nature}")   → NondominiumIdentity action hashes
+  NdoByPropertyRegime, // Path("ndo.regime.{regime}")   → NondominiumIdentity action hashes
+
   // NDO Layer 0 lifecycle links
   NdoToSuccessor,        // deprecated NDO action hash → successor NondominiumIdentity (REQ-NDO-LC-06)
   NdoToTransitionEvent,  // NDO action hash → EconomicEvent that triggered the transition (REQ-NDO-L0-05)

--- a/documentation/API_REFERENCE.md
+++ b/documentation/API_REFERENCE.md
@@ -527,6 +527,76 @@ pub struct ApprovePromotionInput {
 
 ## 🏗️ zome_resource - Resource Lifecycle Management
 
+### NDO (NondominiumIdentity) Layer 0 Management
+
+#### `create_ndo(input: NdoInput) -> ExternResult<NdoOutput>`
+**Purpose**: Create a new Nondominium Identity (Layer 0 anchor) for a resource
+**Authorization**: Any agent
+**Input**:
+```rust
+pub struct NdoInput {
+    pub name: String,
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+    pub lifecycle_stage: LifecycleStage, // any non-terminal stage
+    pub description: Option<String>,
+}
+```
+**Returns**: `NdoOutput { action_hash, entry }` — `action_hash` is the permanent Layer 0 identity
+**Side Effects**: Creates `AllNdos`, `AgentToNdo`, `NdoByLifecycleStage`, `NdoByNature`, and `NdoByPropertyRegime` links
+**Error Cases**: Empty name, terminal initial stage (`Hibernating`, `Deprecated`, `EndOfLife`)
+
+#### `get_ndo(original_action_hash: ActionHash) -> ExternResult<Option<NondominiumIdentity>>`
+**Purpose**: Retrieve the latest version of an NDO by its stable Layer 0 identity hash
+**Authorization**: Public
+**Returns**: Latest `NondominiumIdentity` entry or `None` if not found on DHT
+
+#### `update_lifecycle_stage(input: UpdateLifecycleStageInput) -> ExternResult<ActionHash>`
+**Purpose**: Transition an NDO's lifecycle stage through the state machine
+**Authorization**: Initiator only
+**Input**:
+```rust
+pub struct UpdateLifecycleStageInput {
+    pub original_action_hash: ActionHash,
+    pub new_stage: LifecycleStage,
+    pub successor_ndo_hash: Option<ActionHash>,    // required when new_stage == Deprecated
+    pub transition_event_hash: Option<ActionHash>, // optional EconomicEvent reference
+}
+```
+**Returns**: New `ActionHash` (original remains the stable Layer 0 identity)
+**Side Effects**: Moves `NdoByLifecycleStage` link to new stage anchor; conditionally creates `NdoToSuccessor` and `NdoToTransitionEvent` links
+**Error Cases**: Unauthorized, invalid state machine transition, missing `successor_ndo_hash` when entering `Deprecated`
+
+#### `get_all_ndos(()) -> ExternResult<GetAllNdosOutput>`
+**Purpose**: Discover all NDOs in the network
+**Authorization**: Public
+**Returns**: `GetAllNdosOutput { ndos: Vec<NdoOutput> }` — resolved to latest versions; unavailable entries silently skipped
+
+#### `get_my_ndos(()) -> ExternResult<GetAllNdosOutput>`
+**Purpose**: Retrieve all NDOs created by the calling agent
+**Authorization**: Any agent (scoped to caller)
+**Returns**: `GetAllNdosOutput { ndos: Vec<NdoOutput> }` — resolved to latest versions; unavailable entries silently skipped
+
+#### `get_ndos_by_lifecycle_stage(stage: LifecycleStage) -> ExternResult<GetAllNdosOutput>`
+**Purpose**: Query NDOs currently at a specific lifecycle stage
+**Authorization**: Public
+**Returns**: `GetAllNdosOutput { ndos: Vec<NdoOutput> }` — uses `NdoByLifecycleStage` anchor; silently skips unavailable entries
+**Requirements**: REQ-NDO-L0-05, REQ-NDO-L0-07
+
+#### `get_ndos_by_nature(nature: ResourceNature) -> ExternResult<GetAllNdosOutput>`
+**Purpose**: Query NDOs of a specific resource nature
+**Authorization**: Public
+**Returns**: `GetAllNdosOutput { ndos: Vec<NdoOutput> }` — uses `NdoByNature` anchor; silently skips unavailable entries
+**Requirements**: REQ-NDO-L0-05, REQ-NDO-L0-07
+
+#### `get_ndos_by_property_regime(regime: PropertyRegime) -> ExternResult<GetAllNdosOutput>`
+**Purpose**: Query NDOs under a specific property regime
+**Authorization**: Public
+**Returns**: `GetAllNdosOutput { ndos: Vec<NdoOutput> }` — uses `NdoByPropertyRegime` anchor; silently skips unavailable entries
+**Requirements**: REQ-NDO-L0-05, REQ-NDO-L0-07
+
+---
+
 ### Resource Specification Management
 
 #### `create_resource_specification(input: ResourceSpecificationInput) -> ExternResult<Record>`

--- a/documentation/IMPLEMENTATION_STATUS.md
+++ b/documentation/IMPLEMENTATION_STATUS.md
@@ -78,9 +78,9 @@ Each zome follows the integrity/coordinator pattern.
 - **Enums**: `LifecycleStage` (10 stages: Ideation→Specification→Development→Prototype→Stable→Distributed→Active→Hibernating→Deprecated→EndOfLife), `PropertyRegime` (6 variants), `ResourceNature` (5 variants: Physical, Digital, Service, Hybrid, Information — extends spec's 3-variant definition with Service and Information)
 - **Immutability**: Only `lifecycle_stage` may change post-creation; `successor_ndo_hash` set exactly once on Deprecated transition; deletes are always invalid
 - **Authorization**: Only the `initiator` may call `update_lifecycle_stage` (MVP simplification; full role-based authorization per REQ-NDO-LC-07 deferred to governance zome integration)
-- **Discovery links**: `AllNdos` (global `"ndo_identities"` path anchor), `AgentToNdo` (per-initiator)
-- **API**: `create_ndo`, `get_ndo` (resolves update chain), `get_all_ndos` (global anchor traversal), `get_my_ndos` (raw AgentToNdo links), `update_lifecycle_stage`
-- **REQ coverage**: REQ-NDO-L0-01, -02, -03, -04, -06 implemented; not yet enforced: REQ-NDO-L0-05 (EconomicEvent ref on transitions, optional in coordinator), REQ-NDO-LC-02 (governance-as-operator for transition validation), REQ-NDO-LC-03 (automatic EconomicEvent generation per transition), REQ-NDO-LC-05 (EndOfLife challenge period), REQ-NDO-LC-07 (role-based authorization per §5.3); not yet implemented: REQ-NDO-L0-07 (per-stage/nature/regime facet discovery anchors)
+- **Discovery links**: `AllNdos` (global `"ndo_identities"` path anchor), `AgentToNdo` (per-initiator), `NdoByLifecycleStage` / `NdoByNature` / `NdoByPropertyRegime` (categorization anchors — PR #84)
+- **API**: `create_ndo`, `get_ndo` (resolves update chain), `get_all_ndos` (global anchor traversal), `get_my_ndos` (resolved entries), `update_lifecycle_stage`, `get_ndos_by_lifecycle_stage`, `get_ndos_by_nature`, `get_ndos_by_property_regime` (PR #84)
+- **REQ coverage**: REQ-NDO-L0-01, -02, -03, -04, -06, -07 implemented; not yet enforced: REQ-NDO-L0-05 (EconomicEvent ref on transitions, optional in coordinator), REQ-NDO-LC-02 (governance-as-operator for transition validation), REQ-NDO-LC-03 (automatic EconomicEvent generation per transition), REQ-NDO-LC-05 (EndOfLife challenge period), REQ-NDO-LC-07 (role-based authorization per §5.3)
 
 ### Discovery and Query Patterns ✅
 

--- a/documentation/IMPLEMENTATION_STATUS.md
+++ b/documentation/IMPLEMENTATION_STATUS.md
@@ -117,6 +117,7 @@ Use, Transport, Storage, and Repair process workflows are specified but not impl
 #### Data Structures ✅
 
 16 `ParticipationClaimType` variants are defined in `zome_gouvernance/src/ppr.rs`:
+
 - Genesis: `ResourceCreation`, `ResourceValidation`
 - Custody: `CustodyTransfer`, `CustodyAcceptance`
 - Services: `MaintenanceCommitmentAccepted`, `MaintenanceFulfillmentCompleted`, `StorageCommitmentAccepted`, `StorageFulfillmentCompleted`, `TransportCommitmentAccepted`, `TransportFulfillmentCompleted`, `GoodFaithTransfer`
@@ -190,11 +191,13 @@ No domain-specific UI components exist yet. The following are tracked as open is
 All new tests are written in Sweettest in `dnas/nondominium/tests/src/`.
 
 **Shared setup utilities** (`common::conductors`):
+
 - `setup_two_agents()` — two conductors, nondominium DNA
 - `setup_three_agents()` — three conductors, nondominium DNA
 - `setup_dual_dna_two_agents()` — two conductors, nondominium + hREA DNAs
 
 **Test modules:**
+
 - `misc/mod.rs` — zome connectivity (ping)
 - `person/mod.rs` — person zome + hREA bridge tests
 
@@ -223,38 +226,38 @@ CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
 
 ## Current Status Summary
 
-| Area | Status |
-|---|---|
-| Person management (profiles, roles, capability grants) | ✅ Complete |
-| Resource specifications and economic resources | ✅ Complete |
-| ValueFlows action vocabulary + economic events | ✅ Complete |
-| Commitments and claims | ✅ Complete |
-| PPR data structures + cryptographic auth | ✅ Complete |
-| hREA Phase 1 (Person/ReaAgent bridge) | ✅ Complete |
-| SvelteKit + UnoCSS + Melt UI next-gen setup | ⏳ In Progress |
-| Sweettest scaffold + person tests | ✅ Complete |
-| Economic processes (Use/Transport/Storage/Repair) | ❌ Not started |
-| PPR receipt generation and EOL workflows | ❌ Not started |
-| Governance-as-Operator architecture | ❌ Not started |
-| Agent promotion + role validation workflows | 🔄 Partial |
-| Frontend UI components | ❌ Not started |
-| Effect-TS service layer | ❌ Not started |
-| hREA Phase 2–4 | ❌ Not started |
-| NondominiumIdentity (Layer 0 identity anchor) | ✅ Complete |
+| Area                                                   | Status         |
+| ------------------------------------------------------ | -------------- |
+| Person management (profiles, roles, capability grants) | ✅ Complete    |
+| Resource specifications and economic resources         | ✅ Complete    |
+| ValueFlows action vocabulary + economic events         | ✅ Complete    |
+| Commitments and claims                                 | ✅ Complete    |
+| PPR data structures + cryptographic auth               | ✅ Complete    |
+| hREA Phase 1 (Person/ReaAgent bridge)                  | ✅ Complete    |
+| SvelteKit + UnoCSS + Melt UI next-gen setup            | ⏳ In Progress |
+| Sweettest scaffold + person tests                      | ✅ Complete    |
+| Economic processes (Use/Transport/Storage/Repair)      | ❌ Not started |
+| PPR receipt generation and EOL workflows               | ❌ Not started |
+| Governance-as-Operator architecture                    | ❌ Not started |
+| Agent promotion + role validation workflows            | 🔄 Partial     |
+| Frontend UI components                                 | ❌ Not started |
+| Effect-TS service layer                                | ❌ Not started |
+| hREA Phase 2–4                                         | ❌ Not started |
+| NondominiumIdentity (Layer 0 identity anchor)          | ✅ Complete    |
 
 ---
 
 ## Post-MVP Design Specifications
 
-The following are documented and traceable to REQ-NDO-* in `documentation/requirements/ndo_prima_materia.md` but are not in scope for the current development milestone:
+The following are documented and traceable to REQ-NDO-\* in `documentation/requirements/ndo_prima_materia.md` but are not in scope for the current development milestone:
 
-| Track | Design sources | Implementation status |
-|---|---|---|
-| **NDO Layer 0 (identity anchor)** | `ndo_prima_materia.md` §§4, 8; REQ-NDO-L0-01–07 | **Complete** (#80) — `NondominiumIdentity` entry with lifecycle validation; REQ-NDO-L0-05 (EconomicEvent ref) and -07 (facet anchors) not yet enforced |
-| **NDO Layers 1 & 2** | `ndo_prima_materia.md` §§4, 8, 10; `resources.md` §3 | Not started — Layer 1 (Specification links), Layer 2 (Process links), cross-layer link types pending |
-| **Lifecycle vs operational state split** | `ndo_prima_materia.md` §5, §9.4 (`REQ-NDO-OS-01`–`06`) | Not started — `ResourceState` still conflated (see `zome_resource` TODOs) |
-| **Unyt (EconomicAgreement, RAVE)** | `ndo_prima_materia.md` §6.6, §11.5; `unyt-integration.md`; REQ-NDO-CS-07–CS-11 | Not started — no Unyt cell / RAVE validation in governance zome |
-| **Flowsta (agent linking, IdentityVerification)** | `ndo_prima_materia.md` §6.7, §11.6; `flowsta-integration.md`; REQ-NDO-CS-12–CS-15 | Not started — `flowsta-agent-linking` zomes not bundled |
-| **Person capability slot (G15)** | `agent.md` §3.2; `person_zome.md`; REQ-AGENT-11, REQ-NDO-AGENT-07 | Not started — no `FlowstaIdentity` links on `Person` hash |
+| Track                                             | Design sources                                                                    | Implementation status                                                                                                                                  |
+| ------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **NDO Layer 0 (identity anchor)**                 | `ndo_prima_materia.md` §§4, 8; REQ-NDO-L0-01–07                                   | **Complete** (#80) — `NondominiumIdentity` entry with lifecycle validation; REQ-NDO-L0-05 (EconomicEvent ref) and -07 (facet anchors) not yet enforced |
+| **NDO Layers 1 & 2**                              | `ndo_prima_materia.md` §§4, 8, 10; `resources.md` §3                              | Not started — Layer 1 (Specification links), Layer 2 (Process links), cross-layer link types pending                                                   |
+| **Lifecycle vs operational state split**          | `ndo_prima_materia.md` §5, §9.4 (`REQ-NDO-OS-01`–`06`)                            | Not started — `ResourceState` still conflated (see `zome_resource` TODOs)                                                                              |
+| **Unyt (EconomicAgreement, RAVE)**                | `ndo_prima_materia.md` §6.6, §11.5; `unyt-integration.md`; REQ-NDO-CS-07–CS-11    | Not started — no Unyt cell / RAVE validation in governance zome                                                                                        |
+| **Flowsta (agent linking, IdentityVerification)** | `ndo_prima_materia.md` §6.7, §11.6; `flowsta-integration.md`; REQ-NDO-CS-12–CS-15 | Not started — `flowsta-agent-linking` zomes not bundled                                                                                                |
+| **Person capability slot (G15)**                  | `agent.md` §3.2; `person_zome.md`; REQ-AGENT-11, REQ-NDO-AGENT-07                 | Not started — no `FlowstaIdentity` links on `Person` hash                                                                                              |
 
 See `documentation/implementation_plan.md` Section 12 for a phased checklist aligned with the prima materia.

--- a/documentation/zomes/resource_zome.md
+++ b/documentation/zomes/resource_zome.md
@@ -9,7 +9,6 @@ The Resource zome implements the core resource management infrastructure for the
 > - `NDOToProcess` — Layer 0 identity hash to `Process` (Layer 2 activation)
 > - `NDOToComponent` — Layer 0 identity hash to child NDO identity hash (holonic composition)
 > - `CapabilitySlot` — Layer 0 identity hash to capability targets (stigmergic attachment surface)
-> - `NDOsByLifecycleStage`, `NDOsByNature`, `NDOsByRegime` — facet discovery anchors (REQ-NDO-L0-07)
 >
 > **Unyt (post-MVP):** endorsed economic terms use typed **`EconomicAgreement`** `GovernanceRule` data (`ndo_prima_materia.md` §6.6, REQ-NDO-CS-09–CS-11; `documentation/requirements/post-mvp/unyt-integration.md`).
 
@@ -61,7 +60,7 @@ All other fields are permanently immutable after creation. Delete is always `Inv
 
 **Design note — NDO as identifier, not chronicle**: `lifecycle_stage` at creation reflects the resource's actual state at registration time, not a claim about when it was originally conceived. An existing physical resource registered into the system is created at its true current stage (e.g. `Active`), not forced through a synthetic `Ideation` entry. The NDO identity anchor behaves like a DOI or ISBN: it is assigned at the moment of system registration, which may be well after the resource began its life. Forcing `Ideation`-only initial stages would require fabricating DHT history for brownfield resources and block migration of existing `EconomicResource` entries when Layers 1/2 activate.
 
-**Discovery links**: `AllNdos` (global anchor `"ndo_identities"` path → action hashes), `AgentToNdo` (initiator pubkey → action hashes)
+**Discovery links**: `AllNdos` (global anchor `"ndo_identities"` path → action hashes), `AgentToNdo` (initiator pubkey → action hashes), `NdoByLifecycleStage` / `NdoByNature` / `NdoByPropertyRegime` (categorization anchors — path pattern `"ndo.lifecycle.{Stage:?}"` etc. → action hashes, REQ-NDO-L0-05)
 
 **Lifecycle links**: `NdoToSuccessor` (deprecated NDO → successor NDO, REQ-NDO-LC-06), `NdoToTransitionEvent` (NDO → triggering `EconomicEvent`, REQ-NDO-L0-05)
 
@@ -185,7 +184,7 @@ Creates a new `NondominiumIdentity`. Sets `initiator` from `agent_info` and `cre
 
 **Input**: `NdoInput { name, property_regime, resource_nature, lifecycle_stage, description }`
 **Output**: `NdoOutput { action_hash, entry }` — `action_hash` is the stable Layer 0 identity.
-**Links created**: `AllNdos` (global anchor `"ndo_identities"` → action hash), `AgentToNdo` (initiator pubkey → action hash).
+**Links created**: `AllNdos` (global anchor `"ndo_identities"` → action hash), `AgentToNdo` (initiator pubkey → action hash), `NdoByLifecycleStage` (stage anchor → action hash), `NdoByNature` (nature anchor → action hash), `NdoByPropertyRegime` (regime anchor → action hash). Nature and regime anchors are immutable and never moved.
 **Validation**: name must not be empty.
 **Initial stage**: Any non-terminal stage is valid at creation (`Hibernating`, `Deprecated`, `EndOfLife` are rejected). Use the resource's actual current stage — do not fabricate a synthetic `Ideation` entry for resources that pre-date system registration (see design note above).
 
@@ -213,17 +212,30 @@ UpdateLifecycleStageInput {
 
 **Returns**: new action hash. The `original_action_hash` remains the stable Layer 0 identity.
 
-**Links created** (conditional):
+**Links created / moved** (conditional):
 - `NdoToSuccessor` (`original_action_hash` → `successor_ndo_hash`) — only when `new_stage == Deprecated` (REQ-NDO-LC-06)
 - `NdoToTransitionEvent` (`original_action_hash` → `transition_event_hash`) — when `transition_event_hash` is `Some` (REQ-NDO-L0-05; full cross-zome event validation deferred)
+- `NdoByLifecycleStage` link is **moved**: the old stage's link is deleted and a new link is created at the new stage anchor (only when stage actually changes).
 
 #### `get_all_ndos(_: ()) -> ExternResult<GetAllNdosOutput>`
 
 Returns the latest version of all `NondominiumIdentity` entries via the global `"ndo_identities"` anchor. Entries unavailable on the DHT or failing deserialization are silently skipped (eventual consistency). Output: `GetAllNdosOutput { ndos: Vec<NdoOutput> }`.
 
-#### `get_my_ndos(_: ()) -> ExternResult<Vec<Link>>`
+#### `get_my_ndos(_: ()) -> ExternResult<GetAllNdosOutput>`
 
-Returns raw `AgentToNdo` links for the calling agent. Each link's `target` is an `ActionHash` — the original (stable) Layer 0 identity. Pass each to `get_ndo` to resolve the current entry.
+Returns all `NondominiumIdentity` entries created by the calling agent, resolved to their latest versions. Uses `AgentToNdo` links. Entries unavailable on the DHT or failing deserialization are silently skipped (eventual consistency). Output: `GetAllNdosOutput { ndos: Vec<NdoOutput> }`.
+
+#### `get_ndos_by_lifecycle_stage(stage: LifecycleStage) -> ExternResult<GetAllNdosOutput>`
+
+Returns all NDOs currently at the given `LifecycleStage`. Uses the `NdoByLifecycleStage` categorization anchor (path `"ndo.lifecycle.{stage:?}"`). The anchor is maintained by `create_ndo` and `update_lifecycle_stage`. Entries unavailable on the DHT or failing deserialization are silently skipped. REQ-NDO-L0-05, REQ-NDO-L0-07.
+
+#### `get_ndos_by_nature(nature: ResourceNature) -> ExternResult<GetAllNdosOutput>`
+
+Returns all NDOs of the given `ResourceNature`. Uses the `NdoByNature` categorization anchor (path `"ndo.nature.{nature:?}"`). The anchor is immutable — it is set at creation time and never moved. Entries unavailable on the DHT or failing deserialization are silently skipped. REQ-NDO-L0-05, REQ-NDO-L0-07.
+
+#### `get_ndos_by_property_regime(regime: PropertyRegime) -> ExternResult<GetAllNdosOutput>`
+
+Returns all NDOs under the given `PropertyRegime`. Uses the `NdoByPropertyRegime` categorization anchor (path `"ndo.regime.{regime:?}"`). The anchor is immutable — it is set at creation time and never moved. Entries unavailable on the DHT or failing deserialization are silently skipped. REQ-NDO-L0-05, REQ-NDO-L0-07.
 
 ### Resource Specification Management
 


### PR DESCRIPTION
## Intent

Issues #73 and #74 (PR #80) created `NondominiumIdentity` with two anchor links: `AllNdos` (global) and `AgentToNdo` (per-initiator). This PR adds three **categorization anchors** so agents can query NDOs filtered by lifecycle stage, resource nature, or property regime without scanning the entire DHT. It also adds the corresponding query functions and upgrades `get_my_ndos` to return resolved entries.

## Changes

**Integrity (`zome_resource_integrity`)**

- Add `NdoByLifecycleStage`, `NdoByNature`, `NdoByPropertyRegime` to `LinkTypes` enum
- Anchor path format: `"ndo.lifecycle.{Stage:?}"` / `"ndo.nature.{Nature:?}"` / `"ndo.regime.{Regime:?}"` (Rust Debug variant name)

**Coordinator (`zome_resource_coordinator`)**

- Add private path helpers `lifecycle_stage_path`, `resource_nature_path`, `property_regime_path` — centralise path-string construction
- Extend `create_ndo`: create all three categorization anchor links at creation time (alongside existing `AllNdos` + `AgentToNdo`)
- Extend `update_lifecycle_stage`: when stage changes, delete the old `NdoByLifecycleStage` link (by `create_link_hash`) and create a new one at the updated stage. `NdoByNature` and `NdoByPropertyRegime` never move (immutable fields).
- Add `get_ndos_by_lifecycle_stage`, `get_ndos_by_nature`, `get_ndos_by_property_regime` — all return `GetAllNdosOutput` using the same `resolve_latest_ndo_record` pattern as `get_all_ndos`
- Upgrade `get_my_ndos` return type from `Vec<Link>` → `GetAllNdosOutput` (resolved entries, consistent with the rest of the query surface). No clients exist yet (UI is #77).

**Submodule (`.claude/skills/holochain-agent-skill`)**

- Commit `7eda508` removed a broken gitlink (added in `588d181` without a matching `.gitmodules` entry, which caused CI submodule checkout failures).
- Commit `f0cb609` re-adds the submodule properly via `git submodule add`, registering the URL (`git@github.com:Soushi888/holochain-agent-skill.git`) in `.gitmodules` so CI checkout succeeds.

## Decisions

| Option | Rejected because |
| ------ | ---------------- |
| Store path key as a `LinkTag` instead of a separate Path entry | Path entries are the established pattern in this codebase (`AllNdos`, `AllResourceSpecifications`, etc.) and are DHT-native; link tags are opaque blobs not indexed for efficient lookup |
| Use lowercase path strings (`"ndo.lifecycle.ideation"`) | Rust Debug format gives `"Ideation"` naturally; adding `.to_lowercase()` is extra code for no practical benefit since the format is internal |
| Keep `get_my_ndos` returning `Vec<Link>` | Issue #75 spec requires resolved entries; no clients exist yet, so the type change has zero migration cost |
| Separate function to delete+create stage link | Inline in `update_lifecycle_stage` — it's a single logical operation (link move) tied to this function's mutation; extracting it would obscure the intent |

## How to test

```bash
# Build must pass with no errors
nix develop --command bun run build:zomes

# Run existing Sweettest suite for regressions
nix develop --command bash -c "CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest"
```

Full cross-agent discovery validation (multi-agent DHT sync, `get_ndos_by_lifecycle_stage`, `get_my_ndos` scoping) will land in issue #76.

## Documentation

- `documentation/zomes/resource_zome.md`: updated `get_my_ndos` return type, updated `create_ndo` and `update_lifecycle_stage` link descriptions, added entries for the three new query functions, removed now-implemented items from the TODO list.
- `documentation/API_REFERENCE.md`: added NDO Layer 0 Management section with all eight NDO extern functions.

## Related

Related issues:
- Closes #75
- Part of: #78 ([Epic] NDO Three-Layer Architecture)

- Depends on: #80 (NondominiumIdentity entry type), #82 (hibernation memory state machine)
- Follow-up: #76 ([Sweettest] NDO Layer 0 test suite — now unblocked)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sensorica/nondominium/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->