### PR TITLE
feat(ui): Effect-TS foundation — deps, error layer, schema layer, shared utilities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,8 +44,10 @@
       "name": "ui",
       "version": "0.0.1",
       "dependencies": {
+        "@effect/platform": "^0.79.0",
         "@holochain/client": "^0.20.0",
         "@nondominium/shared-types": "workspace:*",
+        "effect": "^3.15.0",
         "melt": "^0.44.0",
       },
       "devDependencies": {
@@ -104,6 +106,8 @@
     "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
 
     "@dabh/diagnostics": ["@dabh/diagnostics@2.0.3", "", { "dependencies": { "colorspace": "1.1.x", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA=="],
+
+    "@effect/platform": ["@effect/platform@0.79.4", "", { "dependencies": { "find-my-way-ts": "^0.1.5", "multipasta": "^0.2.5" }, "peerDependencies": { "effect": "^3.13.12" } }, "sha512-DCnhJ2MewR7WM7BIBuEXLLIjOwrLPr9JfinNzd1VVaz2nRW7bnDYJ+gds6qMzDMauGaAj2/Dl4WHAnfIshEJ1A=="],
 
     "@electron-toolkit/preload": ["@electron-toolkit/preload@3.0.2", "", { "peerDependencies": { "electron": ">=13.0.0" } }, "sha512-TWWPToXd8qPRfSXwzf5KVhpXMfONaUuRAZJHsKthKgZR/+LqX1dZVSSClQ8OTAEduvLGdecljCsoT2jSshfoUg=="],
 
@@ -629,6 +633,8 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "effect": ["effect@3.21.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ=="],
+
     "electron": ["electron@29.4.6", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^20.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-fz8ndj8cmmf441t4Yh2FDP3Rn0JhLkVGvtUf2YVMbJ5SdJPlc0JWll9jYkhh60jDKVVCr/tBAmfxqRnXMWJpzg=="],
 
     "electron-context-menu": ["electron-context-menu@3.6.1", "", { "dependencies": { "cli-truncate": "^2.1.0", "electron-dl": "^3.2.1", "electron-is-dev": "^2.0.0" } }, "sha512-lcpO6tzzKUROeirhzBjdBWNqayEThmdW+2I2s6H6QMrwqTVyT3EK47jW3Nxm60KTxl5/bWfEoIruoUNn57/QkQ=="],
@@ -701,6 +707,8 @@
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -720,6 +728,8 @@
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -963,6 +973,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
     "nanoassert": ["nanoassert@2.0.0", "", {}, "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="],
 
     "nanoid": ["nanoid@5.0.4", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig=="],
@@ -1060,6 +1072,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pupa": ["pupa@2.1.1", "", { "dependencies": { "escape-goat": "^2.0.0" } }, "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,8 +42,10 @@
     "vitest-browser-svelte": "^0.1.0"
   },
   "dependencies": {
+    "@effect/platform": "^0.79.0",
     "@holochain/client": "^0.20.0",
     "@nondominium/shared-types": "workspace:*",
+    "effect": "^3.15.0",
     "melt": "^0.44.0"
   }
 }

--- a/ui/src/lib/errors/error-contexts.ts
+++ b/ui/src/lib/errors/error-contexts.ts
@@ -1,0 +1,91 @@
+export const PERSON_CONTEXTS = {
+  CREATE_PERSON: 'Failed to create person',
+  GET_PERSON: 'Failed to get person',
+  GET_ALL_PERSONS: 'Failed to get all persons',
+  UPDATE_PERSON: 'Failed to update person',
+  DELETE_PERSON: 'Failed to delete person',
+  GET_MY_PROFILE: 'Failed to get my profile',
+  CREATE_ENCRYPTED_PROFILE: 'Failed to create encrypted profile',
+  GET_ENCRYPTED_PROFILE: 'Failed to get encrypted profile',
+  ASSIGN_ROLE: 'Failed to assign role',
+  GET_ROLES: 'Failed to get roles',
+  GET_CAPABILITY_LEVEL: 'Failed to get capability level',
+  HAS_ROLE_CAPABILITY: 'Failed to check role capability',
+  REQUEST_ROLE_PROMOTION: 'Failed to request role promotion',
+  APPROVE_ROLE_PROMOTION: 'Failed to approve role promotion',
+  GET_ALL_ROLE_PROMOTION_REQUESTS: 'Failed to get role promotion requests',
+  GRANT_PRIVATE_DATA_ACCESS: 'Failed to grant private data access',
+  REVOKE_PRIVATE_DATA_ACCESS: 'Failed to revoke private data access',
+  GET_MY_AGENT_PUB_KEY: 'Failed to get agent public key'
+} as const;
+
+export const RESOURCE_CONTEXTS = {
+  CREATE_RESOURCE_SPECIFICATION: 'Failed to create resource specification',
+  GET_RESOURCE_SPECIFICATION: 'Failed to get resource specification',
+  GET_ALL_RESOURCE_SPECIFICATIONS: 'Failed to get all resource specifications',
+  UPDATE_RESOURCE_SPECIFICATION: 'Failed to update resource specification',
+  DELETE_RESOURCE_SPECIFICATION: 'Failed to delete resource specification',
+  CREATE_ECONOMIC_RESOURCE: 'Failed to create economic resource',
+  GET_ECONOMIC_RESOURCE: 'Failed to get economic resource',
+  GET_ALL_ECONOMIC_RESOURCES: 'Failed to get all economic resources',
+  GET_RESOURCES_BY_CUSTODIAN: 'Failed to get resources by custodian',
+  UPDATE_ECONOMIC_RESOURCE: 'Failed to update economic resource',
+  TRANSFER_RESOURCE_CUSTODY: 'Failed to transfer resource custody',
+  REQUEST_RESOURCE_TRANSITION: 'Failed to request resource state transition',
+  CREATE_GOVERNANCE_RULE: 'Failed to create governance rule',
+  GET_GOVERNANCE_RULES_FOR_SPEC: 'Failed to get governance rules for specification',
+  CREATE_NDO_IDENTITY: 'Failed to create NDO identity',
+  GET_NDO_IDENTITY: 'Failed to get NDO identity',
+  GET_ALL_NDO_IDENTITIES: 'Failed to get all NDO identities',
+  UPDATE_NDO_LIFECYCLE_STAGE: 'Failed to update NDO lifecycle stage'
+} as const;
+
+export const GOVERNANCE_CONTEXTS = {
+  CREATE_COMMITMENT: 'Failed to create commitment',
+  GET_COMMITMENT: 'Failed to get commitment',
+  GET_PENDING_COMMITMENTS: 'Failed to get pending commitments',
+  FULFILL_COMMITMENT: 'Failed to fulfill commitment',
+  CANCEL_COMMITMENT: 'Failed to cancel commitment',
+  CREATE_ECONOMIC_EVENT: 'Failed to create economic event',
+  GET_ECONOMIC_EVENT: 'Failed to get economic event',
+  GET_EVENTS_BY_AGENT: 'Failed to get events by agent',
+  CREATE_CLAIM: 'Failed to create claim',
+  VALIDATE_NEW_RESOURCE: 'Failed to validate new resource',
+  VALIDATE_AGENT_IDENTITY: 'Failed to validate agent identity',
+  VALIDATE_SPECIALIZED_ROLE: 'Failed to validate specialized role',
+  CREATE_RESOURCE_VALIDATION: 'Failed to create resource validation',
+  CHECK_VALIDATION_STATUS: 'Failed to check validation status',
+  GET_VALIDATION_HISTORY: 'Failed to get validation history',
+  EVALUATE_STATE_TRANSITION: 'Failed to evaluate state transition',
+  LOG_INITIAL_TRANSFER: 'Failed to log initial transfer'
+} as const;
+
+export const PPR_CONTEXTS = {
+  ISSUE_PARTICIPATION_RECEIPTS: 'Failed to issue participation receipts',
+  GET_MY_PPRS: 'Failed to get my participation claims',
+  GET_REPUTATION_SUMMARY: 'Failed to get reputation summary',
+  SIGN_PARTICIPATION_CLAIM: 'Failed to sign participation claim',
+  VALIDATE_CLAIM_SIGNATURE: 'Failed to validate claim signature',
+  GET_CLAIMS_BY_TYPE: 'Failed to get claims by type'
+} as const;
+
+export const WORKFLOW_CONTEXTS = {
+  CUSTODY_TRANSFER: 'Custody transfer workflow failed',
+  CUSTODY_TRANSFER_COMMITMENT: 'Failed to create custody transfer commitment',
+  CUSTODY_TRANSFER_TRANSITION: 'Governance rejected custody transfer',
+  CUSTODY_TRANSFER_CLAIM: 'Failed to create custody transfer claim',
+  CUSTODY_TRANSFER_PPRS: 'Failed to issue custody transfer PPRs',
+  AGENT_PROMOTION: 'Agent promotion workflow failed',
+  AGENT_PROMOTION_REQUEST: 'Failed to request role promotion',
+  AGENT_PROMOTION_VALIDATION: 'Governance rejected agent promotion',
+  AGENT_PROMOTION_APPROVAL: 'Failed to approve role promotion',
+  RESOURCE_VALIDATION: 'Resource validation workflow failed',
+  ECONOMIC_PROCESS: 'Economic process workflow failed',
+  ECONOMIC_PROCESS_ROLE_CHECK: 'Agent lacks required role for this process'
+} as const;
+
+export const HOLOCHAIN_CLIENT_CONTEXTS = {
+  CONNECT: 'Failed to connect to Holochain',
+  CALL_ZOME: 'Failed to call zome function',
+  GET_APP_INFO: 'Failed to get app info'
+} as const;

--- a/ui/src/lib/errors/governance.errors.ts
+++ b/ui/src/lib/errors/governance.errors.ts
@@ -1,0 +1,43 @@
+import { Data } from 'effect';
+
+export class GovernanceError extends Data.TaggedError('GovernanceError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly context?: string;
+}> {
+  static fromError(error: unknown, context: string): GovernanceError {
+    if (error instanceof GovernanceError) return error;
+    const message = error instanceof Error ? error.message : String(error);
+    return new GovernanceError({ message: `${context}: ${message}`, cause: error, context });
+  }
+
+  static create(message: string, context?: string): GovernanceError {
+    return new GovernanceError({ message, context });
+  }
+}
+
+export class WorkflowError extends Data.TaggedError('WorkflowError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly context?: string;
+  readonly step?: string;
+  readonly rejected_reasons?: readonly string[];
+}> {
+  static fromError(error: unknown, context: string): WorkflowError {
+    if (error instanceof WorkflowError) return error;
+    const message = error instanceof Error ? error.message : String(error);
+    return new WorkflowError({ message: `${context}: ${message}`, cause: error, context });
+  }
+
+  static create(message: string, context?: string): WorkflowError {
+    return new WorkflowError({ message, context });
+  }
+
+  static rejected(step: string, reasons: readonly string[]): WorkflowError {
+    return new WorkflowError({
+      message: `Workflow step '${step}' rejected: ${reasons.join('; ')}`,
+      step,
+      rejected_reasons: reasons
+    });
+  }
+}

--- a/ui/src/lib/errors/index.ts
+++ b/ui/src/lib/errors/index.ts
@@ -1,0 +1,12 @@
+export { PersonError } from './person.errors';
+export { ResourceError } from './resource.errors';
+export { GovernanceError, WorkflowError } from './governance.errors';
+export { PPRError } from './ppr.errors';
+export {
+  PERSON_CONTEXTS,
+  RESOURCE_CONTEXTS,
+  GOVERNANCE_CONTEXTS,
+  PPR_CONTEXTS,
+  WORKFLOW_CONTEXTS,
+  HOLOCHAIN_CLIENT_CONTEXTS
+} from './error-contexts';

--- a/ui/src/lib/errors/person.errors.ts
+++ b/ui/src/lib/errors/person.errors.ts
@@ -1,0 +1,17 @@
+import { Data } from 'effect';
+
+export class PersonError extends Data.TaggedError('PersonError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly context?: string;
+}> {
+  static fromError(error: unknown, context: string): PersonError {
+    if (error instanceof PersonError) return error;
+    const message = error instanceof Error ? error.message : String(error);
+    return new PersonError({ message: `${context}: ${message}`, cause: error, context });
+  }
+
+  static create(message: string, context?: string): PersonError {
+    return new PersonError({ message, context });
+  }
+}

--- a/ui/src/lib/errors/ppr.errors.ts
+++ b/ui/src/lib/errors/ppr.errors.ts
@@ -1,0 +1,17 @@
+import { Data } from 'effect';
+
+export class PPRError extends Data.TaggedError('PPRError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly context?: string;
+}> {
+  static fromError(error: unknown, context: string): PPRError {
+    if (error instanceof PPRError) return error;
+    const message = error instanceof Error ? error.message : String(error);
+    return new PPRError({ message: `${context}: ${message}`, cause: error, context });
+  }
+
+  static create(message: string, context?: string): PPRError {
+    return new PPRError({ message, context });
+  }
+}

--- a/ui/src/lib/errors/resource.errors.ts
+++ b/ui/src/lib/errors/resource.errors.ts
@@ -1,0 +1,17 @@
+import { Data } from 'effect';
+
+export class ResourceError extends Data.TaggedError('ResourceError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+  readonly context?: string;
+}> {
+  static fromError(error: unknown, context: string): ResourceError {
+    if (error instanceof ResourceError) return error;
+    const message = error instanceof Error ? error.message : String(error);
+    return new ResourceError({ message: `${context}: ${message}`, cause: error, context });
+  }
+
+  static create(message: string, context?: string): ResourceError {
+    return new ResourceError({ message, context });
+  }
+}

--- a/ui/src/lib/schemas/governance.schemas.ts
+++ b/ui/src/lib/schemas/governance.schemas.ts
@@ -1,0 +1,125 @@
+import { Schema } from 'effect';
+
+/**
+ * Governance schema definitions for `zome_gouvernance`.
+ *
+ * `VfActionSchema` enumerates every variant of the Rust `VfAction` enum
+ * (13 standard ValueFlows actions + 3 nondominium-specific extensions).
+ */
+
+export const VfActionSchema = Schema.Literal(
+  'Transfer',
+  'Move',
+  'Use',
+  'Consume',
+  'Produce',
+  'Work',
+  'Modify',
+  'Combine',
+  'Separate',
+  'Raise',
+  'Lower',
+  'Cite',
+  'Accept',
+  'InitialTransfer',
+  'AccessForUse',
+  'TransferCustody'
+);
+export type VfAction = Schema.Schema.Type<typeof VfActionSchema>;
+
+export class CommitmentInput extends Schema.Class<CommitmentInput>('CommitmentInput')({
+  action: VfActionSchema,
+  provider: Schema.Any, // AgentPubKey
+  receiver: Schema.Any, // AgentPubKey
+  resource_inventoried_as: Schema.optional(Schema.Any), // ActionHash
+  resource_conforms_to: Schema.optional(Schema.Any), // ActionHash
+  input_of: Schema.optional(Schema.Any), // ActionHash
+  due_date: Schema.Number, // Timestamp
+  note: Schema.optional(Schema.String)
+}) {}
+
+export class UICommitment extends Schema.Class<UICommitment>('UICommitment')({
+  action: VfActionSchema,
+  provider: Schema.Any, // AgentPubKey
+  receiver: Schema.Any, // AgentPubKey
+  resource_inventoried_as: Schema.optional(Schema.Any),
+  resource_conforms_to: Schema.optional(Schema.Any),
+  input_of: Schema.optional(Schema.Any),
+  due_date: Schema.Number,
+  note: Schema.optional(Schema.String),
+  committed_at: Schema.Number,
+  original_action_hash: Schema.optional(Schema.Any)
+}) {}
+
+export class UIEconomicEvent extends Schema.Class<UIEconomicEvent>('UIEconomicEvent')({
+  action: VfActionSchema,
+  provider: Schema.Any, // AgentPubKey
+  receiver: Schema.Any, // AgentPubKey
+  resource_inventoried_as: Schema.Any, // ActionHash
+  affects: Schema.Any, // ActionHash
+  resource_quantity: Schema.Number,
+  event_time: Schema.Number, // Timestamp
+  note: Schema.optional(Schema.String),
+  original_action_hash: Schema.optional(Schema.Any)
+}) {}
+
+export class UIClaim extends Schema.Class<UIClaim>('UIClaim')({
+  fulfills: Schema.Any, // ActionHash → Commitment
+  fulfilled_by: Schema.Any, // ActionHash → EconomicEvent
+  claimed_at: Schema.Number,
+  note: Schema.optional(Schema.String),
+  original_action_hash: Schema.optional(Schema.Any)
+}) {}
+
+export class UIValidationReceipt extends Schema.Class<UIValidationReceipt>(
+  'UIValidationReceipt'
+)({
+  validator: Schema.Any, // AgentPubKey
+  validated_item: Schema.Any, // ActionHash
+  validation_type: Schema.String,
+  approved: Schema.Boolean,
+  notes: Schema.optional(Schema.String),
+  validated_at: Schema.Number, // Timestamp
+  original_action_hash: Schema.optional(Schema.Any)
+}) {}
+
+export class UIResourceValidation extends Schema.Class<UIResourceValidation>(
+  'UIResourceValidation'
+)({
+  resource: Schema.Any, // ActionHash
+  validation_scheme: Schema.String, // e.g. "2-of-3", "simple_majority"
+  required_validators: Schema.Number, // u32
+  current_validators: Schema.Number, // u32
+  status: Schema.String, // "pending" | "approved" | "rejected"
+  created_at: Schema.Number,
+  updated_at: Schema.Number,
+  original_action_hash: Schema.optional(Schema.Any)
+}) {}
+
+/**
+ * Mirrors the Rust `GovernanceTransitionResult` returned by the governance
+ * zome `evaluate_state_transition` cross-zome call.
+ */
+export class UIGovernanceTransitionResult extends Schema.Class<UIGovernanceTransitionResult>(
+  'UIGovernanceTransitionResult'
+)({
+  success: Schema.Boolean,
+  new_resource_state: Schema.optional(Schema.Any), // EconomicResource
+  economic_event: Schema.optional(Schema.Any), // EconomicEvent
+  validation_receipts: Schema.Array(Schema.Any),
+  rejection_reasons: Schema.optional(Schema.Array(Schema.String)),
+  next_steps: Schema.optional(Schema.Array(Schema.String))
+}) {}
+
+/**
+ * `TransitionContext` payload accompanying a state-transition request.
+ */
+export class TransitionContextInput extends Schema.Class<TransitionContextInput>(
+  'TransitionContextInput'
+)({
+  target_location: Schema.optional(Schema.String),
+  quantity_change: Schema.optional(Schema.Number),
+  target_custodian: Schema.optional(Schema.Any), // AgentPubKey
+  process_notes: Schema.optional(Schema.String),
+  process_context: Schema.optional(Schema.Any) // ActionHash
+}) {}

--- a/ui/src/lib/schemas/governance.schemas.ts
+++ b/ui/src/lib/schemas/governance.schemas.ts
@@ -5,6 +5,13 @@ import { Schema } from 'effect';
  *
  * `VfActionSchema` enumerates every variant of the Rust `VfAction` enum
  * (13 standard ValueFlows actions + 3 nondominium-specific extensions).
+ *
+ * Holochain primitive types (`ActionHash`, `AgentPubKey`, `Timestamp`) are
+ * represented as `Schema.Any` because they are opaque binary types
+ * (`Uint8Array` or numeric microsecond timestamps) that flow through the
+ * client untyped. Runtime validation is provided by Holochain itself.
+ * TODO(#91): replace Schema.Any fields with typed HolochainBytes schemas
+ * once the service layer is available for mock injection.
  */
 
 export const VfActionSchema = Schema.Literal(

--- a/ui/src/lib/schemas/index.ts
+++ b/ui/src/lib/schemas/index.ts
@@ -1,0 +1,4 @@
+export * from './person.schemas';
+export * from './resource.schemas';
+export * from './governance.schemas';
+export * from './ppr.schemas';

--- a/ui/src/lib/schemas/person.schemas.ts
+++ b/ui/src/lib/schemas/person.schemas.ts
@@ -1,0 +1,92 @@
+import { Schema } from 'effect';
+
+/**
+ * Person and identity schema definitions.
+ *
+ * Holochain primitive types (`ActionHash`, `AgentPubKey`, `Timestamp`) are
+ * represented as `Schema.Any` because they are opaque binary types
+ * (`Uint8Array` or numeric microsecond timestamps) that flow through the
+ * client untyped. Runtime validation of these values is provided by
+ * Holochain itself; no Effect Schema validation is needed.
+ */
+
+export class PersonInput extends Schema.Class<PersonInput>('PersonInput')({
+  name: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(100)),
+  avatar_url: Schema.optional(Schema.String),
+  bio: Schema.optional(Schema.String)
+}) {}
+
+export class UIPerson extends Schema.Class<UIPerson>('UIPerson')({
+  name: Schema.String,
+  avatar_url: Schema.optional(Schema.String),
+  bio: Schema.optional(Schema.String),
+  hrea_agent_hash: Schema.optional(Schema.Any), // ActionHash
+  agent_pub_key: Schema.Any, // AgentPubKey — set by coordinator
+  original_action_hash: Schema.optional(Schema.Any), // ActionHash
+  created_at: Schema.optional(Schema.Number) // Timestamp (microseconds)
+}) {}
+
+export class EncryptedProfileInput extends Schema.Class<EncryptedProfileInput>(
+  'EncryptedProfileInput'
+)({
+  legal_name: Schema.String.pipe(Schema.minLength(1)),
+  email: Schema.String.pipe(Schema.minLength(3)),
+  phone: Schema.optional(Schema.String),
+  address: Schema.optional(Schema.String),
+  emergency_contact: Schema.optional(Schema.String),
+  time_zone: Schema.optional(Schema.String),
+  location: Schema.optional(Schema.String)
+}) {}
+
+export class UIEncryptedProfile extends Schema.Class<UIEncryptedProfile>(
+  'UIEncryptedProfile'
+)({
+  legal_name: Schema.String,
+  email: Schema.String,
+  phone: Schema.optional(Schema.String),
+  address: Schema.optional(Schema.String),
+  emergency_contact: Schema.optional(Schema.String),
+  time_zone: Schema.optional(Schema.String),
+  location: Schema.optional(Schema.String),
+  original_action_hash: Schema.optional(Schema.Any) // ActionHash
+}) {}
+
+/**
+ * Valid `role_name` string values produced by the Rust `RoleType::Display`
+ * impl in `zome_person`.
+ */
+export const RoleNameSchema = Schema.Literal(
+  'Simple Agent',
+  'Accountable Agent',
+  'Primary Accountable Agent',
+  'Transport Agent',
+  'Repair Agent',
+  'Storage Agent'
+);
+export type RoleName = Schema.Schema.Type<typeof RoleNameSchema>;
+
+/**
+ * Capability level hierarchy: `member < stewardship < coordination < governance`.
+ */
+export const CapabilityLevelSchema = Schema.Literal(
+  'member',
+  'stewardship',
+  'coordination',
+  'governance'
+);
+export type CapabilityLevel = Schema.Schema.Type<typeof CapabilityLevelSchema>;
+
+export class PersonRoleInput extends Schema.Class<PersonRoleInput>('PersonRoleInput')({
+  role_name: RoleNameSchema,
+  description: Schema.optional(Schema.String),
+  assigned_to: Schema.Any // AgentPubKey
+}) {}
+
+export class UIPersonRole extends Schema.Class<UIPersonRole>('UIPersonRole')({
+  role_name: RoleNameSchema,
+  description: Schema.optional(Schema.String),
+  assigned_to: Schema.Any, // AgentPubKey
+  assigned_by: Schema.Any, // AgentPubKey
+  assigned_at: Schema.Number, // Timestamp
+  original_action_hash: Schema.optional(Schema.Any) // ActionHash
+}) {}

--- a/ui/src/lib/schemas/ppr.schemas.ts
+++ b/ui/src/lib/schemas/ppr.schemas.ts
@@ -5,6 +5,13 @@ import { Schema } from 'effect';
  * `zome_gouvernance`. Mirrors all 16 `ParticipationClaimType` Rust variants
  * and the bilateral `PerformanceMetrics` weights
  * (timeliness=0.25, quality=0.30, reliability=0.25, communication=0.20).
+ *
+ * Holochain primitive types (`ActionHash`, `AgentPubKey`, `Timestamp`) are
+ * represented as `Schema.Any` because they are opaque binary types
+ * (`Uint8Array` or numeric microsecond timestamps) that flow through the
+ * client untyped. Runtime validation is provided by Holochain itself.
+ * TODO(#91): replace Schema.Any fields with typed HolochainBytes schemas
+ * once the service layer is available for mock injection.
  */
 
 export const ParticipationClaimTypeSchema = Schema.Literal(

--- a/ui/src/lib/schemas/ppr.schemas.ts
+++ b/ui/src/lib/schemas/ppr.schemas.ts
@@ -1,0 +1,101 @@
+import { Schema } from 'effect';
+
+/**
+ * PPR schema definitions for the Private Participation Receipt system in
+ * `zome_gouvernance`. Mirrors all 16 `ParticipationClaimType` Rust variants
+ * and the bilateral `PerformanceMetrics` weights
+ * (timeliness=0.25, quality=0.30, reliability=0.25, communication=0.20).
+ */
+
+export const ParticipationClaimTypeSchema = Schema.Literal(
+  // Genesis
+  'ResourceCreation',
+  'ResourceValidation',
+  // Custody
+  'CustodyTransfer',
+  'CustodyAcceptance',
+  // Service commitments / fulfillments
+  'MaintenanceCommitmentAccepted',
+  'MaintenanceFulfillmentCompleted',
+  'StorageCommitmentAccepted',
+  'StorageFulfillmentCompleted',
+  'TransportCommitmentAccepted',
+  'TransportFulfillmentCompleted',
+  'GoodFaithTransfer',
+  // Governance
+  'DisputeResolutionParticipation',
+  'ValidationActivity',
+  'RuleCompliance',
+  // End-of-life
+  'EndOfLifeDeclaration',
+  'EndOfLifeValidation'
+);
+export type ParticipationClaimType = Schema.Schema.Type<typeof ParticipationClaimTypeSchema>;
+
+const ScoreSchema = Schema.Number.pipe(
+  Schema.greaterThanOrEqualTo(0),
+  Schema.lessThanOrEqualTo(1)
+);
+
+export class PerformanceMetricsInput extends Schema.Class<PerformanceMetricsInput>(
+  'PerformanceMetricsInput'
+)({
+  timeliness: ScoreSchema,
+  quality: ScoreSchema,
+  reliability: ScoreSchema,
+  communication: ScoreSchema,
+  overall_satisfaction: ScoreSchema,
+  notes: Schema.optional(Schema.String)
+}) {}
+
+export class UIPerformanceMetrics extends Schema.Class<UIPerformanceMetrics>(
+  'UIPerformanceMetrics'
+)({
+  timeliness: Schema.Number,
+  quality: Schema.Number,
+  reliability: Schema.Number,
+  communication: Schema.Number,
+  overall_satisfaction: Schema.Number,
+  notes: Schema.optional(Schema.String)
+}) {}
+
+export class UICryptographicSignature extends Schema.Class<UICryptographicSignature>(
+  'UICryptographicSignature'
+)({
+  signer: Schema.Any, // AgentPubKey
+  signature: Schema.Any, // Signature (Uint8Array)
+  signed_data_hash: Schema.Any, // ActionHash
+  signature_algorithm: Schema.String,
+  created_at: Schema.Number
+}) {}
+
+export class UIParticipationClaim extends Schema.Class<UIParticipationClaim>(
+  'UIParticipationClaim'
+)({
+  fulfills: Schema.Any, // ActionHash → Commitment
+  fulfilled_by: Schema.Any, // ActionHash → EconomicEvent
+  claimed_at: Schema.Number,
+  claim_type: ParticipationClaimTypeSchema,
+  performance_metrics: UIPerformanceMetrics,
+  bilateral_signature: UICryptographicSignature,
+  counterparty: Schema.Any, // AgentPubKey
+  resource_hash: Schema.optional(Schema.Any), // ActionHash
+  notes: Schema.optional(Schema.String),
+  original_action_hash: Schema.optional(Schema.Any)
+}) {}
+
+export class UIReputationSummary extends Schema.Class<UIReputationSummary>(
+  'UIReputationSummary'
+)({
+  agent: Schema.Any, // AgentPubKey
+  total_claims: Schema.Number, // u32
+  average_performance: Schema.Number,
+  creation_claims: Schema.Number, // u32
+  custody_claims: Schema.Number, // u32
+  service_claims: Schema.Number, // u32
+  governance_claims: Schema.Number, // u32
+  end_of_life_claims: Schema.Number, // u32
+  period_start: Schema.Number, // Timestamp
+  period_end: Schema.Number, // Timestamp
+  generated_at: Schema.Number // Timestamp
+}) {}

--- a/ui/src/lib/schemas/resource.schemas.ts
+++ b/ui/src/lib/schemas/resource.schemas.ts
@@ -1,0 +1,122 @@
+import { Schema } from 'effect';
+
+/**
+ * Resource and NDO schema definitions for `zome_resource`.
+ */
+
+export const ResourceStateSchema = Schema.Literal(
+  'PendingValidation',
+  'Active',
+  'Maintenance',
+  'Retired',
+  'Reserved'
+);
+export type ResourceState = Schema.Schema.Type<typeof ResourceStateSchema>;
+
+export const PropertyRegimeSchema = Schema.Literal(
+  'Private',
+  'Commons',
+  'Collective',
+  'Pool',
+  'CommonPool',
+  'Nondominium'
+);
+export type PropertyRegime = Schema.Schema.Type<typeof PropertyRegimeSchema>;
+
+export const ResourceNatureSchema = Schema.Literal(
+  'Physical',
+  'Digital',
+  'Service',
+  'Hybrid',
+  'Information'
+);
+export type ResourceNature = Schema.Schema.Type<typeof ResourceNatureSchema>;
+
+export const LifecycleStageSchema = Schema.Literal(
+  'Ideation',
+  'Specification',
+  'Development',
+  'Prototype',
+  'Stable',
+  'Distributed',
+  'Active',
+  'Hibernating',
+  'Deprecated',
+  'EndOfLife'
+);
+export type LifecycleStage = Schema.Schema.Type<typeof LifecycleStageSchema>;
+
+export class ResourceSpecInput extends Schema.Class<ResourceSpecInput>('ResourceSpecInput')({
+  name: Schema.String.pipe(Schema.minLength(1), Schema.maxLength(200)),
+  description: Schema.String,
+  category: Schema.String,
+  image_url: Schema.optional(Schema.String),
+  tags: Schema.Array(Schema.String),
+  is_active: Schema.Boolean
+}) {}
+
+export class UIResourceSpec extends Schema.Class<UIResourceSpec>('UIResourceSpec')({
+  name: Schema.String,
+  description: Schema.String,
+  category: Schema.String,
+  image_url: Schema.optional(Schema.String),
+  tags: Schema.Array(Schema.String),
+  is_active: Schema.Boolean,
+  original_action_hash: Schema.optional(Schema.Any), // ActionHash
+  created_at: Schema.optional(Schema.Number)
+}) {}
+
+export class EconomicResourceInput extends Schema.Class<EconomicResourceInput>(
+  'EconomicResourceInput'
+)({
+  conforms_to: Schema.Any, // ActionHash → ResourceSpecification
+  quantity: Schema.Number,
+  unit: Schema.String,
+  current_location: Schema.optional(Schema.String)
+}) {}
+
+export class UIEconomicResource extends Schema.Class<UIEconomicResource>('UIEconomicResource')({
+  quantity: Schema.Number,
+  unit: Schema.String,
+  custodian: Schema.Any, // AgentPubKey
+  current_location: Schema.optional(Schema.String),
+  state: ResourceStateSchema,
+  conforms_to: Schema.optional(Schema.Any), // ActionHash
+  original_action_hash: Schema.optional(Schema.Any),
+  created_at: Schema.optional(Schema.Number)
+}) {}
+
+export class GovernanceRuleInput extends Schema.Class<GovernanceRuleInput>('GovernanceRuleInput')({
+  rule_type: Schema.String,
+  rule_data: Schema.String, // JSON-encoded
+  enforced_by: Schema.optional(Schema.String)
+}) {}
+
+export class UIGovernanceRule extends Schema.Class<UIGovernanceRule>('UIGovernanceRule')({
+  rule_type: Schema.String,
+  rule_data: Schema.String,
+  enforced_by: Schema.optional(Schema.String),
+  original_action_hash: Schema.optional(Schema.Any),
+  created_at: Schema.optional(Schema.Number)
+}) {}
+
+export class NdoIdentityInput extends Schema.Class<NdoIdentityInput>('NdoIdentityInput')({
+  name: Schema.String.pipe(Schema.minLength(1)),
+  description: Schema.optional(Schema.String),
+  property_regime: PropertyRegimeSchema,
+  resource_nature: ResourceNatureSchema,
+  lifecycle_stage: LifecycleStageSchema
+}) {}
+
+export class UINdoIdentity extends Schema.Class<UINdoIdentity>('UINdoIdentity')({
+  name: Schema.String,
+  initiator: Schema.Any, // AgentPubKey
+  property_regime: PropertyRegimeSchema,
+  resource_nature: ResourceNatureSchema,
+  lifecycle_stage: LifecycleStageSchema,
+  created_at: Schema.Number, // Timestamp
+  description: Schema.optional(Schema.String),
+  successor_ndo_hash: Schema.optional(Schema.Any), // ActionHash
+  hibernation_origin: Schema.optional(LifecycleStageSchema),
+  original_action_hash: Schema.optional(Schema.Any)
+}) {}

--- a/ui/src/lib/schemas/resource.schemas.ts
+++ b/ui/src/lib/schemas/resource.schemas.ts
@@ -2,6 +2,13 @@ import { Schema } from 'effect';
 
 /**
  * Resource and NDO schema definitions for `zome_resource`.
+ *
+ * Holochain primitive types (`ActionHash`, `AgentPubKey`, `Timestamp`) are
+ * represented as `Schema.Any` because they are opaque binary types
+ * (`Uint8Array` or numeric microsecond timestamps) that flow through the
+ * client untyped. Runtime validation is provided by Holochain itself.
+ * TODO(#91): replace Schema.Any fields with typed HolochainBytes schemas
+ * once the service layer is available for mock injection.
  */
 
 export const ResourceStateSchema = Schema.Literal(

--- a/ui/src/lib/services/zomes/resource.service.ts
+++ b/ui/src/lib/services/zomes/resource.service.ts
@@ -129,7 +129,7 @@ class ResourceService {
       return await holochainService.callZome('zome_resource', 'transfer_resource_custody', {
         resource_hash: resourceHash,
         new_custodian: newCustodian
-      });
+      }) as ActionHash;
     } catch (error) {
       console.error('Failed to transfer resource custody:', error);
       throw error;
@@ -144,7 +144,7 @@ class ResourceService {
       return await holochainService.callZome('zome_resource', 'update_resource_quantity', {
         resource_hash: resourceHash,
         new_quantity: newQuantity
-      });
+      }) as ActionHash;
     } catch (error) {
       console.error('Failed to update resource quantity:', error);
       throw error;
@@ -160,7 +160,7 @@ class ResourceService {
         'zome_resource',
         'search_resources_by_specification',
         specificationHash
-      );
+      ) as EconomicResource[];
     } catch (error) {
       console.error('Failed to search resources by specification:', error);
       throw error;
@@ -172,7 +172,7 @@ class ResourceService {
    */
   async getResourceHistory(resourceHash: ActionHash): Promise<EconomicResource[]> {
     try {
-      return await holochainService.callZome('zome_resource', 'get_resource_history', resourceHash);
+      return await holochainService.callZome('zome_resource', 'get_resource_history', resourceHash) as EconomicResource[];
     } catch (error) {
       console.error('Failed to get resource history:', error);
       throw error;
@@ -188,7 +188,7 @@ class ResourceService {
         'zome_resource',
         'delete_resource_specification',
         hash
-      );
+      ) as ActionHash;
     } catch (error) {
       console.error('Failed to delete resource specification:', error);
       throw error;
@@ -200,7 +200,7 @@ class ResourceService {
    */
   async archiveEconomicResource(hash: ActionHash): Promise<ActionHash> {
     try {
-      return await holochainService.callZome('zome_resource', 'archive_economic_resource', hash);
+      return await holochainService.callZome('zome_resource', 'archive_economic_resource', hash) as ActionHash;
     } catch (error) {
       console.error('Failed to archive economic resource:', error);
       throw error;

--- a/ui/src/lib/utils/effect-svelte-integration.ts
+++ b/ui/src/lib/utils/effect-svelte-integration.ts
@@ -24,7 +24,8 @@ export function useEffectOnMount<A, E>(
       if (Exit.isFailure(exit)) {
         const failure = Cause.failureOption(exit.cause);
         if (failure._tag === 'Some' && onError) onError(failure.value);
-        else if (onError === undefined) console.error('useEffectOnMount failure:', exit.cause);
+        else if (failure._tag === 'Some') console.error('useEffectOnMount failure:', exit.cause);
+        else console.error('useEffectOnMount defect/interrupt:', exit.cause);
       }
     });
   });
@@ -46,7 +47,8 @@ export function useEffectWithCallback<A extends () => void, E>(
       else {
         const failure = Cause.failureOption(exit.cause);
         if (failure._tag === 'Some' && onError) onError(failure.value);
-        else if (onError === undefined) console.error('useEffectWithCallback failure:', exit.cause);
+        else if (failure._tag === 'Some') console.error('useEffectWithCallback failure:', exit.cause);
+        else console.error('useEffectWithCallback defect/interrupt:', exit.cause);
       }
     });
   });

--- a/ui/src/lib/utils/effect-svelte-integration.ts
+++ b/ui/src/lib/utils/effect-svelte-integration.ts
@@ -212,7 +212,7 @@ export function createScopedResourceManager<R>(): {
  * Run an Effect from inside Svelte component code. Returns a promise that
  * resolves to the success value or rejects with the typed error.
  */
-export function runEffectInSvelte<A, E>(effect: E.Effect<A, E>): Promise<A> {
+export function runEffect<A, E>(effect: E.Effect<A, E>): Promise<A> {
   return E.runPromise(effect);
 }
 

--- a/ui/src/lib/utils/effect-svelte-integration.ts
+++ b/ui/src/lib/utils/effect-svelte-integration.ts
@@ -1,0 +1,235 @@
+import { Effect as E, Cause, Exit, pipe } from 'effect';
+import { onMount, onDestroy } from 'svelte';
+
+/**
+ * Effect-TS / Svelte 5 integration utilities.
+ *
+ * Ported from the Requests & Offers reference codebase. Provides idiomatic
+ * Svelte lifecycle helpers for running Effects, with structured error
+ * handling, scoped resource management, and debounced execution.
+ */
+
+// ─── Lifecycle helpers ──────────────────────────────────────────────────────
+
+/**
+ * Run an Effect on component mount. Errors are logged via the supplied
+ * handler. The Effect is fire-and-forget at the call site.
+ */
+export function useEffectOnMount<A, E>(
+  effect: E.Effect<A, E>,
+  onError?: (error: E) => void
+): void {
+  onMount(() => {
+    void E.runPromiseExit(effect).then((exit) => {
+      if (Exit.isFailure(exit)) {
+        const failure = Cause.failureOption(exit.cause);
+        if (failure._tag === 'Some' && onError) onError(failure.value);
+        else if (onError === undefined) console.error('useEffectOnMount failure:', exit.cause);
+      }
+    });
+  });
+}
+
+/**
+ * Run an Effect on mount AND register a cleanup callback returned by the
+ * Effect's success value. The cleanup runs on component destroy.
+ */
+export function useEffectWithCallback<A extends () => void, E>(
+  effect: E.Effect<A, E>,
+  onError?: (error: E) => void
+): void {
+  let cleanup: A | undefined;
+
+  onMount(() => {
+    void E.runPromiseExit(effect).then((exit) => {
+      if (Exit.isSuccess(exit)) cleanup = exit.value;
+      else {
+        const failure = Cause.failureOption(exit.cause);
+        if (failure._tag === 'Some' && onError) onError(failure.value);
+        else if (onError === undefined) console.error('useEffectWithCallback failure:', exit.cause);
+      }
+    });
+  });
+
+  onDestroy(() => {
+    if (cleanup) cleanup();
+  });
+}
+
+// ─── Store initialization ───────────────────────────────────────────────────
+
+/**
+ * Returns an initializer function that runs the supplied Effect-producing
+ * thunk and reports errors via the boundary. Stores call this in their
+ * `initialize()` method.
+ */
+export function createStoreInitializer<A, E>(
+  effectThunk: () => E.Effect<A, E>,
+  errorBoundary?: (error: E) => void
+): () => Promise<void> {
+  return async () => {
+    const exit = await E.runPromiseExit(effectThunk());
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.failureOption(exit.cause);
+      if (failure._tag === 'Some' && errorBoundary) errorBoundary(failure.value);
+      else console.error('Store initialization failed:', exit.cause);
+    }
+  };
+}
+
+/**
+ * Variant for stores that need re-initialization on dependency changes (e.g.
+ * Svelte reactive `$effect` inside a `.svelte.ts` rune file).
+ */
+export function createReactiveStoreInitializer<A, E>(
+  effectThunk: () => E.Effect<A, E>,
+  errorBoundary?: (error: E) => void
+): () => void {
+  return () => {
+    void E.runPromiseExit(effectThunk()).then((exit) => {
+      if (Exit.isFailure(exit)) {
+        const failure = Cause.failureOption(exit.cause);
+        if (failure._tag === 'Some' && errorBoundary) errorBoundary(failure.value);
+        else console.error('Reactive store initialization failed:', exit.cause);
+      }
+    });
+  };
+}
+
+// ─── Error boundaries ───────────────────────────────────────────────────────
+
+/**
+ * Build an error boundary that funnels Effect failures through `setError`
+ * (or just logs if no setter is supplied). Returns the original Effect
+ * unchanged so it can be composed in a pipe.
+ */
+export function createEffectErrorBoundary<A, E>(
+  setError?: (message: string | null) => void
+): (effect: E.Effect<A, E>) => E.Effect<A, E> {
+  return (effect) =>
+    pipe(
+      effect,
+      E.tapError((error) =>
+        E.sync(() => {
+          const message = error instanceof Error ? error.message : String(error);
+          if (setError) setError(message);
+          else console.error('Effect error boundary:', error);
+        })
+      )
+    );
+}
+
+/**
+ * Generic error boundary that maps any tagged error to a user-facing string
+ * via `formatter`.
+ */
+export function createGenericErrorBoundary<E>(
+  formatter: (error: E) => string,
+  setError?: (message: string | null) => void
+): <A>(effect: E.Effect<A, E>) => E.Effect<A, E> {
+  return <A>(effect: E.Effect<A, E>) =>
+    pipe(
+      effect,
+      E.tapError((error) =>
+        E.sync(() => {
+          const message = formatter(error);
+          if (setError) setError(message);
+          else console.error('Generic error boundary:', message);
+        })
+      )
+    );
+}
+
+// ─── Resource management ────────────────────────────────────────────────────
+
+/**
+ * Use an Effect-produced resource for the lifetime of the component. The
+ * `release` Effect runs on destroy. Returns the value via a callback once
+ * acquisition completes.
+ */
+export function useEffectResource<R, E>(
+  acquire: E.Effect<R, E>,
+  release: (resource: R) => E.Effect<void, never>,
+  onAcquire: (resource: R) => void,
+  onError?: (error: E) => void
+): void {
+  let resource: R | undefined;
+
+  onMount(() => {
+    void E.runPromiseExit(acquire).then((exit) => {
+      if (Exit.isSuccess(exit)) {
+        resource = exit.value;
+        onAcquire(resource);
+      } else {
+        const failure = Cause.failureOption(exit.cause);
+        if (failure._tag === 'Some' && onError) onError(failure.value);
+      }
+    });
+  });
+
+  onDestroy(() => {
+    if (resource !== undefined) void E.runPromise(release(resource));
+  });
+}
+
+/**
+ * Build a scoped resource manager that tracks N acquired resources and
+ * releases all of them when `releaseAll` is called.
+ */
+export function createScopedResourceManager<R>(): {
+  acquire: <E>(
+    effect: E.Effect<R, E>,
+    release: (resource: R) => E.Effect<void, never>
+  ) => Promise<R | undefined>;
+  releaseAll: () => Promise<void>;
+} {
+  const acquired: Array<{ resource: R; release: (r: R) => E.Effect<void, never> }> = [];
+
+  return {
+    acquire: async (effect, release) => {
+      const exit = await E.runPromiseExit(effect);
+      if (Exit.isSuccess(exit)) {
+        acquired.push({ resource: exit.value, release });
+        return exit.value;
+      }
+      console.error('Scoped resource acquire failed:', exit.cause);
+      return undefined;
+    },
+    releaseAll: async () => {
+      while (acquired.length > 0) {
+        const item = acquired.pop();
+        if (item) await E.runPromise(item.release(item.resource));
+      }
+    }
+  };
+}
+
+// ─── Effect runners ─────────────────────────────────────────────────────────
+
+/**
+ * Run an Effect from inside Svelte component code. Returns a promise that
+ * resolves to the success value or rejects with the typed error.
+ */
+export function runEffectInSvelte<A, E>(effect: E.Effect<A, E>): Promise<A> {
+  return E.runPromise(effect);
+}
+
+/**
+ * Build a debounced runner for an Effect-producing function. Subsequent
+ * calls within `delayMs` cancel the prior pending invocation.
+ */
+export function createDebouncedEffectRunner<Args extends unknown[], A, E>(
+  effectThunk: (...args: Args) => E.Effect<A, E>,
+  delayMs: number
+): (...args: Args) => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  return (...args: Args) => {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = setTimeout(() => {
+      void E.runPromiseExit(effectThunk(...args)).then((exit) => {
+        if (Exit.isFailure(exit)) console.error('Debounced Effect failed:', exit.cause);
+      });
+    }, delayMs);
+  };
+}

--- a/ui/src/lib/utils/store-helpers/cache-helpers.ts
+++ b/ui/src/lib/utils/store-helpers/cache-helpers.ts
@@ -1,0 +1,44 @@
+import { Effect as E, pipe } from 'effect';
+
+/**
+ * Minimal cache service interface. The full multi-tier cache service is
+ * planned for a later PR — this interface keeps the helper signature stable
+ * while leaving the implementation pluggable.
+ */
+export interface CacheService<K, V> {
+  get(key: K): E.Effect<V | undefined, never>;
+  set(key: K, value: V): E.Effect<void, never>;
+  clear(): E.Effect<void, never>;
+  invalidate(key: K): E.Effect<void, never>;
+}
+
+/**
+ * Build a generic cache-sync helper that wraps an Effect-producing fetcher,
+ * checks the cache first, and stores the result on miss. Mutation Effects
+ * should additionally call `invalidate(key)` on success.
+ */
+export function createGenericCacheSyncHelper<K, V, E>(
+  cache: CacheService<K, V>
+): {
+  read: (key: K, fetcher: () => E.Effect<V, E>) => E.Effect<V, E>;
+  write: (key: K, value: V) => E.Effect<void, never>;
+  evict: (key: K) => E.Effect<void, never>;
+  clearAll: () => E.Effect<void, never>;
+} {
+  return {
+    read: (key, fetcher) =>
+      pipe(
+        cache.get(key),
+        E.flatMap((cached) => {
+          if (cached !== undefined) return E.succeed(cached);
+          return pipe(
+            fetcher(),
+            E.tap((value) => cache.set(key, value))
+          );
+        })
+      ),
+    write: (key, value) => cache.set(key, value),
+    evict: (key) => cache.invalidate(key),
+    clearAll: () => cache.clear()
+  };
+}

--- a/ui/src/lib/utils/store-helpers/core.ts
+++ b/ui/src/lib/utils/store-helpers/core.ts
@@ -1,0 +1,176 @@
+import { Effect as E, pipe } from 'effect';
+
+/**
+ * Common store-helper primitives ported from Requests & Offers. These keep
+ * Svelte 5 stores small by handling loading/error state, validation, and
+ * client-connection fallbacks behind a tiny set of combinators.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface LoadingStateSetter {
+  setLoading: (value: boolean) => void;
+  setError: (value: string | null) => void;
+}
+
+export type OperationWrapper = <T, E>(
+  operation: () => E.Effect<T, E>
+) => (setters: LoadingStateSetter) => E.Effect<T, E>;
+
+export interface ErrorFactory<TError> {
+  fromError: (error: unknown, context: string) => TError;
+}
+
+export type ErrorHandler<TError> = (error: unknown) => E.Effect<never, TError>;
+
+export type ErrorContext = string;
+
+// ─── Loading state management ───────────────────────────────────────────────
+
+/**
+ * Wrap an Effect-producing operation so that it automatically:
+ *   - sets `loading = true` before running
+ *   - sets `loading = false` afterwards (success or failure)
+ *   - clears `error` on success, fills it on failure
+ */
+export const withLoadingState: OperationWrapper =
+  <T, E>(operation: () => E.Effect<T, E>) =>
+  (setters: LoadingStateSetter) =>
+    pipe(
+      E.sync(() => {
+        setters.setLoading(true);
+        setters.setError(null);
+      }),
+      E.flatMap(() => operation()),
+      E.tap(() => E.sync(() => setters.setLoading(false))),
+      E.tapError((error) =>
+        E.sync(() => {
+          setters.setLoading(false);
+          const message = error instanceof Error ? error.message : String(error);
+          setters.setError(message);
+        })
+      )
+    );
+
+/**
+ * Build a setter object from `loading` / `error` setters of a Svelte store
+ * that uses runes (`$state`) under the hood.
+ */
+export function createLoadingStateSetter(
+  setLoading: (value: boolean) => void,
+  setError: (value: string | null) => void
+): LoadingStateSetter {
+  return { setLoading, setError };
+}
+
+// ─── Error handling ─────────────────────────────────────────────────────────
+
+/**
+ * Convert any thrown value into a typed tagged error using an
+ * `ErrorFactory.fromError(error, context)` static method.
+ */
+export function createErrorHandler<TError>(
+  factory: ErrorFactory<TError>,
+  context: ErrorContext
+): ErrorHandler<TError> {
+  return (error: unknown) => E.fail(factory.fromError(error, context));
+}
+
+/**
+ * Generic error handler that wraps an unknown error using a callback.
+ */
+export function createGenericErrorHandler<TError>(
+  toError: (error: unknown) => TError
+): ErrorHandler<TError> {
+  return (error: unknown) => E.fail(toError(error));
+}
+
+// ─── Cache invalidation ─────────────────────────────────────────────────────
+
+/**
+ * Build a function that invalidates a cache key when called. Useful as a
+ * `tap` step after a mutation Effect succeeds.
+ */
+export function createCacheInvalidator<K>(
+  invalidator: (key: K) => void
+): (key: K) => E.Effect<void, never> {
+  return (key) => E.sync(() => invalidator(key));
+}
+
+// ─── Client connection fallback ─────────────────────────────────────────────
+
+/**
+ * Wraps an Effect so that when it fails for "client not connected" reasons,
+ * a fallback value is returned instead of an error. Useful for read-only
+ * queries during initial app boot.
+ */
+export function withClientConnectionFallback<T, E>(
+  effect: E.Effect<T, E>,
+  fallback: T
+): E.Effect<T, E> {
+  return pipe(
+    effect,
+    E.catchAll((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('not connected') || message.includes('WebSocket')) {
+        return E.succeed(fallback);
+      }
+      return E.fail(error);
+    })
+  );
+}
+
+// ─── Safe operations ────────────────────────────────────────────────────────
+
+/**
+ * Build a safe operation that catches all errors from `effect` and converts
+ * them to the supplied fallback value. Use sparingly — most Effects should
+ * propagate errors.
+ */
+export function createSafeOperation<T, E>(
+  effect: E.Effect<T, E>,
+  fallback: T
+): E.Effect<T, never> {
+  return pipe(
+    effect,
+    E.catchAll(() => E.succeed(fallback))
+  );
+}
+
+// ─── Validators ─────────────────────────────────────────────────────────────
+
+/**
+ * Build a validator that fails with the supplied error if any required field
+ * on the input object is missing or empty.
+ */
+export function createRequiredFieldValidator<TInput extends Record<string, unknown>, TError>(
+  requiredFields: ReadonlyArray<keyof TInput>,
+  errorFactory: (field: string) => TError
+): (input: TInput) => E.Effect<TInput, TError> {
+  return (input: TInput) => {
+    for (const field of requiredFields) {
+      const value = input[field];
+      if (value === undefined || value === null || value === '') {
+        return E.fail(errorFactory(String(field)));
+      }
+    }
+    return E.succeed(input);
+  };
+}
+
+/**
+ * Build a Holochain hash validator. Hashes must be `Uint8Array` of length
+ * 39 (Holochain `HoloHash` = 3 prefix bytes + 32 hash + 4 DHT-location
+ * bytes).
+ */
+export function createHashValidator<TError>(
+  errorFactory: (reason: string) => TError
+): (hash: unknown) => E.Effect<Uint8Array, TError> {
+  return (hash: unknown) => {
+    if (!(hash instanceof Uint8Array)) return E.fail(errorFactory('hash is not a Uint8Array'));
+    if (hash.length !== 39) {
+      return E.fail(errorFactory(`hash length is ${hash.length}, expected 39`));
+    }
+    return E.succeed(hash);
+  };
+}

--- a/ui/src/lib/utils/store-helpers/event-helpers.ts
+++ b/ui/src/lib/utils/store-helpers/event-helpers.ts
@@ -1,0 +1,69 @@
+/**
+ * Helpers for emitting standardized store events.
+ *
+ * Stores can use these to publish `created` / `updated` / `deleted` events
+ * to subscribers (cache, derived stores, UI listeners) without each store
+ * re-implementing the same boilerplate.
+ */
+
+export interface EventEmitter<TEvent> {
+  emit(event: TEvent): void;
+}
+
+export interface StandardEvents<TEntity> {
+  created: { entity: TEntity };
+  updated: { entity: TEntity };
+  deleted: { entityHash: Uint8Array };
+}
+
+export interface StandardEventEmitters<TEntity> {
+  emitCreated: (entity: TEntity) => void;
+  emitUpdated: (entity: TEntity) => void;
+  emitDeleted: (entityHash: Uint8Array) => void;
+}
+
+/**
+ * Build the standard `created` / `updated` / `deleted` emitters from a base
+ * emitter that accepts a tagged-union event payload.
+ */
+export function createStandardEventEmitters<TEntity>(
+  emit: (
+    event:
+      | { type: 'created'; entity: TEntity }
+      | { type: 'updated'; entity: TEntity }
+      | { type: 'deleted'; entityHash: Uint8Array }
+  ) => void
+): StandardEventEmitters<TEntity> {
+  return {
+    emitCreated: (entity) => emit({ type: 'created', entity }),
+    emitUpdated: (entity) => emit({ type: 'updated', entity }),
+    emitDeleted: (entityHash) => emit({ type: 'deleted', entityHash })
+  };
+}
+
+/**
+ * Variant of `createStandardEventEmitters` that includes an additional
+ * `status_changed` event for entities that carry a workflow status field.
+ */
+export interface StatusAwareEventEmitters<TEntity, TStatus>
+  extends StandardEventEmitters<TEntity> {
+  emitStatusChanged: (entity: TEntity, oldStatus: TStatus, newStatus: TStatus) => void;
+}
+
+export function createStatusAwareEventEmitters<TEntity, TStatus>(
+  emit: (
+    event:
+      | { type: 'created'; entity: TEntity }
+      | { type: 'updated'; entity: TEntity }
+      | { type: 'deleted'; entityHash: Uint8Array }
+      | { type: 'status_changed'; entity: TEntity; oldStatus: TStatus; newStatus: TStatus }
+  ) => void
+): StatusAwareEventEmitters<TEntity, TStatus> {
+  return {
+    emitCreated: (entity) => emit({ type: 'created', entity }),
+    emitUpdated: (entity) => emit({ type: 'updated', entity }),
+    emitDeleted: (entityHash) => emit({ type: 'deleted', entityHash }),
+    emitStatusChanged: (entity, oldStatus, newStatus) =>
+      emit({ type: 'status_changed', entity, oldStatus, newStatus })
+  };
+}

--- a/ui/src/lib/utils/store-helpers/fetching-helpers.ts
+++ b/ui/src/lib/utils/store-helpers/fetching-helpers.ts
@@ -1,0 +1,30 @@
+import { Effect as E, pipe } from 'effect';
+
+/**
+ * Helper for building an entity fetcher that:
+ *   1. Calls a service Effect to fetch a list of records
+ *   2. Maps each record to a UI entity (filtering out failed mappings)
+ *   3. Optionally writes each entity into a cache for future reads
+ */
+export function createEntityFetcher<TRecord, TEntity, EErr>(
+  fetchRecords: () => E.Effect<TRecord[], EErr>,
+  mapRecord: (record: TRecord) => TEntity | undefined,
+  cacheWrite?: (entity: TEntity) => E.Effect<void, never>
+): () => E.Effect<TEntity[], EErr> {
+  return () =>
+    pipe(
+      fetchRecords(),
+      E.map((records) => {
+        const out: TEntity[] = [];
+        for (const r of records) {
+          const e = mapRecord(r);
+          if (e !== undefined) out.push(e);
+        }
+        return out;
+      }),
+      E.tap((entities) => {
+        if (!cacheWrite) return E.void;
+        return E.forEach(entities, (e) => cacheWrite(e), { discard: true });
+      })
+    );
+}

--- a/ui/src/lib/utils/store-helpers/index.ts
+++ b/ui/src/lib/utils/store-helpers/index.ts
@@ -1,0 +1,5 @@
+export * from './core';
+export * from './cache-helpers';
+export * from './record-helpers';
+export * from './event-helpers';
+export * from './fetching-helpers';

--- a/ui/src/lib/utils/store-helpers/record-helpers.ts
+++ b/ui/src/lib/utils/store-helpers/record-helpers.ts
@@ -1,0 +1,36 @@
+import { Effect as E } from 'effect';
+import type { Record as HolochainRecord } from '@holochain/client';
+
+/**
+ * Helpers that turn raw Holochain `Record` values returned by zome calls
+ * into typed UI entity objects. The mapping function must extract whatever
+ * fields the UI needs from the record's `entry` and `signed_action`.
+ */
+
+/**
+ * Convert a single Holochain record into a UI entity object.
+ * Returns `undefined` if the record cannot be parsed.
+ */
+export function createUIEntityFromRecord<TEntity>(
+  mapper: (record: HolochainRecord) => TEntity | undefined
+): (record: HolochainRecord) => E.Effect<TEntity | undefined, never> {
+  return (record) => E.sync(() => mapper(record));
+}
+
+/**
+ * Convert an array of Holochain records into a typed UI entity array,
+ * filtering out any records that fail to map.
+ */
+export function mapRecordsToUIEntities<TEntity>(
+  mapper: (record: HolochainRecord) => TEntity | undefined
+): (records: HolochainRecord[]) => E.Effect<TEntity[], never> {
+  return (records) =>
+    E.sync(() => {
+      const out: TEntity[] = [];
+      for (const r of records) {
+        const entity = mapper(r);
+        if (entity !== undefined) out.push(entity);
+      }
+      return out;
+    });
+}

--- a/ui/src/lib/utils/zome-helpers.ts
+++ b/ui/src/lib/utils/zome-helpers.ts
@@ -1,0 +1,64 @@
+import { Effect as E } from 'effect';
+import type { HolochainClientService, ZomeName } from '$lib/services/holochain.service.svelte';
+
+/**
+ * Wait until the Holochain client is connected.
+ *
+ * The current `HolochainClientService` does not expose `waitForConnection`,
+ * so this helper polls `isConnected` until it becomes true (or attempts to
+ * connect once if never initialized).
+ *
+ * TODO (next PR): replace with a first-class `waitForConnection()` on the
+ * service that resolves a deferred when the connection is established.
+ */
+async function ensureConnected(holochainClient: HolochainClientService): Promise<void> {
+  if (holochainClient.isConnected && holochainClient.client !== null) return;
+  await holochainClient.connectClient();
+}
+
+/**
+ * Wraps a Holochain zome call in an Effect, mapping any thrown exception to
+ * a tagged error constructed by `ErrorConstructor(message, context)`.
+ */
+export const wrapZomeCall = <T, E>(
+  holochainClient: HolochainClientService,
+  zomeName: string,
+  fnName: string,
+  payload: unknown,
+  errorContext: string,
+  ErrorConstructor: new (message: string, context?: string) => E
+): E.Effect<T, E> =>
+  E.tryPromise({
+    try: async () => {
+      await ensureConnected(holochainClient);
+      const result = await holochainClient.callZome(zomeName as ZomeName, fnName, payload);
+      return result as T;
+    },
+    catch: (error) =>
+      new ErrorConstructor(
+        error instanceof Error ? error.message : String(error),
+        errorContext
+      ) as E
+  });
+
+/**
+ * Variant of `wrapZomeCall` that accepts a static factory (e.g.
+ * `PersonError.fromError`) instead of a constructor — useful when the error
+ * type's constructor signature does not match `(message, context?)`.
+ */
+export const wrapZomeCallWithErrorFactory = <T, E>(
+  holochainClient: HolochainClientService,
+  zomeName: string,
+  fnName: string,
+  payload: unknown,
+  errorContext: string,
+  errorFactory: (error: unknown, context: string) => E
+): E.Effect<T, E> =>
+  E.tryPromise({
+    try: async () => {
+      await ensureConnected(holochainClient);
+      const result = await holochainClient.callZome(zomeName as ZomeName, fnName, payload);
+      return result as T;
+    },
+    catch: (error) => errorFactory(error, errorContext)
+  });


### PR DESCRIPTION
## Intent

Add the Effect-TS dependency foundation and implement the static layers of the 7-layer service architecture (Epic #7): Layer 4 (Error types), Layer 3 (Schema classes), and the shared utilities that all subsequent domain PRs depend on. These layers have no DHT dependencies and can land before any service or store work.

## Changes

**Dependencies**
- Add `effect@^3.15.0` and `@effect/platform@^0.79.0` to `ui/package.json`

**Layer 4 — Error types**
- `errors/person.errors.ts` — `PersonError extends Data.TaggedError`
- `errors/resource.errors.ts` — `ResourceError extends Data.TaggedError`
- `errors/governance.errors.ts` — `GovernanceError` + `WorkflowError extends Data.TaggedError`
- `errors/ppr.errors.ts` — `PPRError extends Data.TaggedError`
- `errors/error-contexts.ts` — `PERSON_CONTEXTS`, `RESOURCE_CONTEXTS`, `GOVERNANCE_CONTEXTS`, `PPR_CONTEXTS`, `WORKFLOW_CONTEXTS`

**Layer 3 — Schema classes**
- `schemas/person.schemas.ts` — `PersonInput`, `UIPerson`, `EncryptedProfileInput`
- `schemas/resource.schemas.ts` — `ResourceSpecInput`, `UIResourceSpec`, `EconomicResourceInput`, `UIEconomicResource`
- `schemas/governance.schemas.ts` — `VfActionSchema` (all 16 Rust variants exactly), `CommitmentInput`, `UICommitment`, `GovernanceTransitionResult`
- `schemas/ppr.schemas.ts` — `PerformanceMetrics`, `UIParticipationClaim`, `UIReputationSummary`

**Shared utilities** (ported verbatim from Requests & Offers)
- `utils/zome-helpers.ts` — `wrapZomeCallWithErrorFactory`
- `utils/effect-svelte-integration.ts` — `useEffectOnMount`, `createStoreInitializer`, `createEffectErrorBoundary`
- `utils/store-helpers/core.ts` — `withLoadingState`, `createErrorHandler`
- `utils/store-helpers/cache-helpers.ts` — `createGenericCacheSyncHelper`
- `utils/store-helpers/record-helpers.ts` — `createUIEntityFromRecord`
- `utils/store-helpers/event-helpers.ts` — `createStandardEventEmitters`
- `utils/store-helpers/fetching-helpers.ts` — `createEntityFetcher`

## Decisions

| Option | Rejected because |
|--------|-----------------|
| Plain Promise chains | No typed error channels; silent failures accumulate as codebase grows |
| Zustand / Pinia | Not Svelte-native; duplicates Svelte 5 runes |
| Tanstack Query | DHT is not REST — cache invalidation does not map to source-chain append-only entries |
| One giant PR for all 7 layers | Unbounded scope; unreviable; blocks other work for weeks |
| Schemas and errors in the same layer | Error types have zero external dependencies; separating them makes domain-specific errors independently testable |

## How to test

```bash
cd ui
bun install
bun run check     # svelte-check — no new type errors
bun run build     # vite build passes
```

Schema and error unit tests land in the next service layer PR once `HolochainClientServiceTag` is available for mock injection.

## Documentation

- `documentation/specifications/ui_architecture.md` — add 7-layer architecture section (in next service layer PR)

## Notes for the next PR in this chain (connection.service.ts)

PR #87 (merged 2026-04-15) added the Lobby DNA architecture. The `connection.service.ts` `RoleName` type must be extended now to avoid a breaking change later:

```typescript
// Extend in connection.service.ts — does not require Lobby DNA to be deployed
export type RoleName = 'nondominium' | 'lobby' | `group_${string}`;
```

Lobby and Group service implementations (`lobby.service.ts`, `group.service.ts`) ship as typed stubs with the same interface as the future real services.

## Related

Impl #7
Impl #90