### PR TITLE
feat(ui): NDO Layer 0 UI — Lobby-first architecture with group-scoped NDO management

### DIFF
--- a/dnas/nondominium/tests/src/nondominium/ndo_layer0/mod.rs
+++ b/dnas/nondominium/tests/src/nondominium/ndo_layer0/mod.rs
@@ -198,6 +198,52 @@ async fn ndo_create_and_get() {
     assert_eq!(entry.lifecycle_stage, LifecycleStage::Ideation);
 }
 
+/// Create NDO with `Stable` lifecycle at registration (mature/tool-style anchor).
+#[tokio::test(flavor = "multi_thread")]
+async fn ndo_create_at_stable_stage() {
+    let (conductors, alice, _bob) = setup_two_agents().await;
+
+    let output: NdoOutput = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "create_ndo",
+            ndo_input(
+                "Stable Tool NDO",
+                PropertyRegime::Commons,
+                ResourceNature::Physical,
+                LifecycleStage::Stable,
+            ),
+        )
+        .await;
+
+    assert_eq!(output.entry.lifecycle_stage, LifecycleStage::Stable);
+    assert!(output.entry.hibernation_origin.is_none());
+}
+
+/// `Hibernating` is not a valid initial stage — must enter via transition after create.
+#[tokio::test(flavor = "multi_thread")]
+async fn ndo_create_rejects_hibernating_initial_stage() {
+    let (conductors, alice, _bob) = setup_two_agents().await;
+
+    let result: Result<NdoOutput, _> = conductors[0]
+        .call_fallible(
+            &alice.zome("zome_resource"),
+            "create_ndo",
+            ndo_input(
+                "Invalid Hibernating",
+                PropertyRegime::Commons,
+                ResourceNature::Digital,
+                LifecycleStage::Hibernating,
+            ),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "create_ndo must reject Hibernating at registration (integrity REQ-NDO-LC-01)"
+    );
+}
+
 /// Advance a NondominiumIdentity through multiple lifecycle stages and verify
 /// that the original action hash remains the stable Layer 0 identity.
 ///

--- a/documentation/Applications/digitaldairychain.md
+++ b/documentation/Applications/digitaldairychain.md
@@ -1,0 +1,208 @@
+# Digital Dairy Chain (DDC): Deep Dive and Nondominium Fit
+
+This document synthesizes public materials (project sites, consortium pages, press, funding portals, and the open **farm-twin** repository) with the **Nondominium** project so we can reason about collaboration, farmer value, ecosystem role, and sustainable revenue.
+
+---
+
+## 1. Nondominium context (brief)
+
+**Nondominium** is a Holochain hApp aligned with **ValueFlows**: agents, resource specifications and instances, embedded **GovernanceRules**, **Commitments** / **EconomicEvents** / **Claims**, and **Private Participation Receipts (PPRs)** for cryptographically grounded, selectively disclosable accountability. It targets **organization-agnostic**, **capture-resistant** coordination: peer validation, role and custody progression, process-aware flows (use, transport, storage, repair), and a roadmap toward richer identity, digital-asset integrity, and optional settlement integrations.
+
+---
+
+## 2. What the Digital Dairy Chain is
+
+The **Digital Dairy Chain** is a **UKRI Strength in Places** programme (**£21 million**, **five years**) led by **SRUC**, aimed at transforming the **dairy sector** in **Cumbria** and **South and West Scotland**—described as covering the **largest milk field in the UK**. It is **not** a single product: it is a **regional innovation hub** combining **grants**, **R&D access**, **accelerators**, **maker spaces**, **workforce planning**, **STEM outreach**, and **open-source tooling** (notably **farm-twin**).
+
+**Public economic framing (CENSIS / partner materials):** the programme is associated with ambitions on the order of **600+ new jobs** and **~£60 million** added to **annual** regional output, alongside **renewal and decarbonisation** of a sector producing on the order of **1.9 billion litres of milk** per year in the area (figures as stated on partner pages—use for strategic context, not as audited forecasts).
+
+**Lead and consortium (SRUC page):** SRUC (lead), University of Strathclyde, University of the West of Scotland, **CENSIS**, First Milk Ltd, Lactalis McLelland Ltd, Kendal Nutricare Ltd, Cows and Co Group Ltd, National Milk Records Plc, **SmartSTEMs**—**10 grant-drawing partners**.
+
+---
+
+## 3. Strategic pillars and eight initiatives
+
+SRUC’s programme summary groups delivery into overlapping initiatives:
+
+
+| Initiative                          | Role                                                                                                             |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Supply chain digitisation**       | “Digitalisation Demonstrator”; **grass-to-glass** connectivity; sensing and data-handling tech.                  |
+| **Innovation Brokers**              | Match businesses to solutions; **Innovation Vouchers** for novel university–business projects.                   |
+| **Collaborative R&D and growth**    | Large innovation grants for eligible businesses .                                                                |
+| **Transformational dairy research** | **Dairy Nexus** co-innovation hub at **SRUC Barony**; on-farm and processing innovation; energy/waste reduction. |
+| **Maker Spaces**                    | **Cumbria** and **Ayrshire** facilities for **NPD**, scale-up from kitchen to commercial, mentorship.            |
+| **Milk Round Accelerator**          | CENSIS-led multi-year accelerator; proof-of-concept → demonstration/testing; net-zero and efficiency focus.      |
+| **STEM engagement**                 | SmartSTEMs-led schools/events (see §8).                                                                          |
+| **Workforce for the future**        | **10–25 year** skills needs review across the value chain; links education and industry.                         |
+
+
+The public website adds cross-cutting themes: **cyber security** content (“farm to fork”), **Think Dairy Careers**, **events**, and **case studies**.
+
+---
+
+## 4. farm-twin: open-source digital twin (verified)
+
+**Official repository:** [https://github.com/digitaldairychain/farm-twin](https://github.com/digitaldairychain/farm-twin)
+
+**License:** **GNU Affero General Public License v3.0 (AGPL-3.0)** (confirmed from repository `LICENSE`). Implication for integrators: network-facing deployments may trigger **source-offer obligations**; any **Nondominium** integration should be reviewed with legal/compliance if farm-twin is offered **as a service**.
+
+**What it does (DDC announcement + BBC + GitHub blurb):**
+
+- **Unified model** of the **whole farm system** (animals to infrastructure) using **real-time** sensor/telemetry and other digital inputs.
+- **Multi-vendor data integration** (e.g. health records, milk, feed, environment).
+- **Dashboards** and **predictive** signals for health/productivity issues; examples include combining milk trends with health data, **alerts**, and **automated** responses (e.g. shedding gate to isolate an animal) with farmer notification.
+- **Simulations** and **legacy** data import for backward compatibility.
+- Positioned as **scalable** across farm sizes and tech maturity.
+
+**Funding attribution (public copy):** Digital Dairy Chain / UKRI Strength in Places; additional mentions (e.g. **Borderlands Inclusive Growth Deal**) appear in third-party summaries—verify in SRUC/DDC primary sources for any formal claim.
+
+---
+
+## 5. Role in the farming and food ecosystem
+
+DDC sits at the **regional systems** level:
+
+
+| Stakeholder                       | How DDC engages                                                                                                                                      |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Dairy farmers**                 | Digitisation demonstrator, farm-twin, brokers, vouchers, accelerators, research access; eligibility in some competitions for **farming businesses**. |
+| **Processors & manufacturers**    | Consortium includes major processors; NPD via Maker Space; decarbonisation and high-value products.                                                  |
+| **Tech / sensor / robotics SMEs** | Accelerator, R&D competitions, CENSIS IoT/engineering strength.                                                                                      |
+| **Academia**                      | SRUC, Strathclyde, UWS, CENSIS; translation to commercial impact.                                                                                    |
+| **Skills pipeline**               | SmartSTEMs scale; workforce review; careers narrative.                                                                                               |
+| **Policy / place**                | Strength in Places = **place-based** industrial strategy; aligns with Scottish/Cumbrian **natural economy** and **net zero** narratives.             |
+
+
+DDC is **public–private R&D infrastructure** with **strong industry and university** governance—not a membership co-op, though **farmers can lead or collaborate** on funded innovation projects.
+
+---
+
+## 6. Collaborative R&D portal (Innovate UK Business Connect)
+
+The page archived below described a **Digital Dairy Chain** competition administered with **Innovate UK**: up to **£2m** in the round described, individual project grants **£50k–£350k**, **70%** funding rate (subject to rules), duration **6–24 months**, regional work and exploitation in **Cumbria / South / West Scotland**, themes including **novel products**, **decarbonisation**, **waste and circularity**, **environment** (biodiversity, soil, air, water), **sensors and digitisation**, **animal and staff welfare**, **value addition**. **Plant-based milk alternatives** and **purely routine installs** were out of scope in that call.
+
+**Note:** The published **open/close** dates on that page are **historical** (2023). Treat as **evidence of programme shape**; current calls require checking [Digital Dairy Chain](https://www.digitaldairychain.co.uk/) and Innovate UK live competitions.
+
+---
+
+## 7. Third-party and research links
+
+**BBC (Oct 2025):** [Virtual dairy farm aims to transform industry](https://www.bbc.co.uk/news/articles/cj972rdnj2eo) — farm-twin as **free to download**, SRUC Barony, near–real-time multi-source aggregation, automation potential; contextual mention of satellite/wildlife tooling (separate firm).
+
+**A** **closely related** open record is Queen’s University Belfast **Pure** entry for *Digital-twin enabled dairy farming for greenhouse gas emission tracking* (AICS 2023):  
+
+
+---
+
+## 8. SmartSTEMs partnership (scale)
+
+Per SmartSTEMs’ project page: **8,000+** pupils in DDC-themed STEM activities; **1,325+** schools (farm visits, workshops, Think Dairy events); **136+** organisations, **313+** volunteer days. This quantifies **social licence** and **talent pipeline** work adjacent to farm-twin and digitisation.
+
+---
+
+## 9. Compatibility: DDC and Nondominium
+
+### 9.1 Strong alignment
+
+
+| DDC theme                              | Nondominium angle                                                                                                                                                            |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Traceable, integrated supply chain** | Auditable **commitment → event → claim** chains; future **digital resource integrity** slots for attestations.                                                               |
+| **Multi-party R&D and grants**         | **ValidationReceipt** / **ResourceValidation** patterns; PPRs for **delivery** and **collaboration** quality.                                                                |
+| **Data from many vendors**             | Farm-twin aggregates upstream; Nondominium could record **who attested what** and **under which governance rule** without replacing the twin’s analytics layer.              |
+| **Cyber security narrative**           | Holochain **local-first** and **capability** model reduces single-vault honeypots; complements organisational security training (not a substitute).                          |
+| **Net zero / emissions**               | Economic events can anchor **MRV hand-offs** (meter readings, management actions) as **mutually signed** claims between farmer, verifier, and buyer—subject to scheme rules. |
+
+
+### 9.2 Tensions and design notes
+
+- **Architecture split:** **farm-twin** is a **Python** digital-twin stack; Nondominium is a **Rust/Holochain** coordination layer. Pragmatic pattern: **event bus or signed export** from farm-twin (or lab systems) into **EconomicEvents** / **PPRs**, not a monolith.
+- **AGPL:** Offering farm-twin **as a hosted service** may require **AGPL compliance** (source offer, etc.). A **“Nondominium attestation sidecar”** that is separate AGPL-wise still needs review if bundled.
+- **Processor power asymmetry:** Consortium includes large processors; Nondominium’s **uncapturable** narrative must be **configured** so **farmer-generated data** and **claims** are not structurally subordinated—e.g. explicit **custody** and **governance rules** on resource specs for **farm-origin attestations**.
+
+**Overall:** Compatibility is **complementary**. DDC solves **integration, simulation, and regional capacity**; Nondominium can solve **portable trust, mutual accountability, and less platform lock-in** for the **contracts and attestations** that sit *around* the twin.
+
+---
+
+## 10. Where Nondominium can help DDC add farmer value
+
+1. **Innovation project integrity** — Voucher and CR&D projects get **tamper-evident** milestones: deliverables, data handovers, and **IP/contributions** traced as **events** where parties agree.
+2. **Milk field data dignity** — Farmers retain **agent-centric** records of what they shared, to whom, and for which **purpose** (important next to **NMR**-class data flows).
+3. **Processor–farmer alignment** — **Commitments** for sustainability premiums or **collection windows** with **claims** on fulfilment reduce dispute cost.
+4. **Accelerator outcomes** — Startups ship **integrations** with a **standard attestation hook** (PPR-friendly), improving **due diligence** for follow-on funders.
+5. **Regional brand** — “**Digitally connected and cryptographically accountable**” strengthens the **South Scotland / Cumbria** cluster story for export and retail narratives.
+
+---
+
+## 11. How DDC can strengthen its value proposition and ecosystem role
+
+1. **Publish a “trust stack” reference architecture** — **farm-twin** (observation) + **governance/attestation layer** (Nondominium-class or other VC/ledger tech) + **scheme/regulatory** exports—so SMEs know where to plug in.
+2. **Farmer data governance playbook** — Template **data-sharing agreements** tied to **technical enforcement** (capabilities, expiry, scope)—aligned with existing **cyber** content.
+3. **Co-op and farmer-led pilots** — Balance **processor-led** digitisation with **first-mile** pilots where **farmers lead** grant applications (already allowed in competition rules).
+4. **Open metrics for the programme** — Jobs/GVA claims should trend toward **auditable** public reporting; even partial transparency builds **credibility** vs generic “innovation washing.”
+5. **Interoperability, not monoculture** — Encourage **adapters** in farm-twin for **export** to open standards; avoids the twin becoming the **only** gatekeeper.
+6. **Post-UKRI sustainability plan** — Strength in Places ends; **hosted services**, **certification**, or **consortium fees** for maintained infrastructure should be designed **without** capturing farmer data rents.
+
+---
+
+## 12. How Nondominium can serve farmers who participate through DDC
+
+- **Proof of participation:** Workshops, trials, and **demonstrator** deployments recorded as **reputation-relevant** participation without exposing commercial secrets.
+- **Portability:** If a farmer switches **tech vendor** or **processor**, **cryptographic history** of **their** contributions and **validations** can remain with **their** agent identity (subject to integration maturity).
+- **Fair dispute memory:** Bilateral **PPRs** on **loading**, **quality**, or **service visits** support **small operators** in asymmetric supply chains.
+- **Selective disclosure to schemes:** **SFI**-style or **carbon** narratives backed by **summaries** derived from structured events, not **raw** full-farm dumps.
+
+---
+
+## 13. How DDC (and partners) can improve financial returns from offering Nondominium-class infrastructure
+
+*Strategic patterns only—not tax, legal, or investment advice.*
+
+1. **B2B “trust module”** — Charge processors and tech vendors for **reference integration** and **support** while keeping **core** Nondominium-style tooling **FOSS** or **low fee** for farmers.
+2. **Verification services** — Regional **economy of scope**: package **farm-twin analytics** + **attested event packs** for **retailer** audits at lower **marginal** cost than ad hoc consultants.
+3. **Follow-on funding** — Use **audited** impact traces to unlock **place-based** finance and **green** bonds; SRUC/CENSIS can capture **legitimate** facilitation fees.
+4. **Training and certification** — Paid **courses** for developers and agronomists on **building adapters** and **interpreting** attested graphs.
+5. **Reduced programme risk** — Better **project accounting** lowers **fraud** and **under-delivery** exposure in large grants, protecting **future** UKRI competitiveness.
+6. **Premium regional products** — **Provable** low-carbon or high-welfare **batches** support **price premium** capture shared back to **farmers** (contract design, not tech alone).
+
+---
+
+## 14. Suggested next steps (for the Nondominium project)
+
+1. **Pick one DDC pathway** (e.g. Milk Round winner, Maker Space cohort, or farm-twin adapter) and map **three** bilateral **PPR** stories end-to-end.
+2. **Prototype export** from a **mock** farm-twin event stream into **EconomicEvent** + **Claim** (file-based or API stub).
+3. **Engage SRUC/CENSIS** on **non-capturing farmer data** as a **design constraint** for any joint demo.
+4. **Legal review** of **AGPL** + Holochain hApp **distribution** if farm-twin and Nondominium are **shipped together**.
+
+---
+
+## 15. Original desk summary (archived)
+
+The Digital Dairy Chain (DDC) is a large-scale, UK-funded initiative focused on regional economic transformation rather than a single software product. Unlike farmer-owned mutuals that act primarily as a program-based service layer, the DDC has explicitly released **open-source** digital infrastructure (**farm-twin**) to support its mission.
+
+**Digital Infrastructure & Open Source:** Farm-twin is a free, open-source platform developed by SRUC agri-tech scientists. It enables farmers to build a **digital model** of their farming system by integrating data from animal health, milk yields, feed, environment, and more.
+
+**Architecture & Design:** Public materials describe a **three-layer** mental model for digital twins: **physical** (IoT/sensors), **digital** (knowledge graphs/simulations), **application** (insights)—Nondominium fits best as an **accountability and agreement** layer adjacent to the application/strategy tier, not as a replacement for the twin’s simulation core.
+
+**Repository status:** The official GitHub organisation is `**digitaldairychain`**; the canonical repo is `**farm-twin`**. Unrelated hobby repos should be ignored for diligence.
+
+---
+
+## 16. Official and reference links
+
+
+| Resource                                                       | URL                                                                                                                                                                                                                  |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DDC official site                                              | [https://www.digitaldairychain.co.uk/](https://www.digitaldairychain.co.uk/)                                                                                                                                         |
+| SRUC major projects page                                       | [https://www.sruc.ac.uk/connect/about-sruc/major-projects/digital-dairy-chain/](https://www.sruc.ac.uk/connect/about-sruc/major-projects/digital-dairy-chain/)                                                       |
+| CENSIS Strength in Places overview                             | [https://censis.tech/censis_projects/strength-in-places-digital-dairy-project/](https://censis.tech/censis_projects/strength-in-places-digital-dairy-project/)                                                       |
+| Innovate UK Business Connect (example competition page)        | [https://iuk-business-connect.org.uk/opportunities/digital-dairy-chain-collaborative-rd-and-growth/](https://iuk-business-connect.org.uk/opportunities/digital-dairy-chain-collaborative-rd-and-growth/)             |
+| BBC: Virtual dairy farm / farm-twin                            | [https://www.bbc.co.uk/news/articles/cj972rdnj2eo](https://www.bbc.co.uk/news/articles/cj972rdnj2eo)                                                                                                                 |
+| DDC: World’s first open-source digital twin announcement       | [https://www.digitaldairychain.co.uk/worlds-first-open-source-digital-twin-for-dairy-farming/](https://www.digitaldairychain.co.uk/worlds-first-open-source-digital-twin-for-dairy-farming/)                         |
+| farm-twin source code                                          | [https://github.com/digitaldairychain/farm-twin](https://github.com/digitaldairychain/farm-twin)                                                                                                                     |
+| SmartSTEMs × DDC                                               | [https://smartstems.org/project/digital-dairy-chain/](https://smartstems.org/project/digital-dairy-chain/)                                                                                                           |
+| QUB Pure (GHG / DT–ML dairy, AICS 2023)                        | [https://pure.qub.ac.uk/en/publications/digital-twin-enabled-dairy-farming-for-greenhouse-gas-emission-tr](https://pure.qub.ac.uk/en/publications/digital-twin-enabled-dairy-farming-for-greenhouse-gas-emission-tr) |
+| PMC (computational architectures article; may require browser) | [https://pmc.ncbi.nlm.nih.gov/articles/PMC12390163/](https://pmc.ncbi.nlm.nih.gov/articles/PMC12390163/)                                                                                                             |
+
+

--- a/documentation/Applications/regen_farming.md
+++ b/documentation/Applications/regen_farming.md
@@ -1,0 +1,182 @@
+# Regen Farmers Mutual: Deep Dive and Nondominium Fit
+
+This document synthesizes public materials, partner handbooks, and the Nondominium project requirements so we can reason about collaboration, farmer value, and business model alignment.
+
+---
+
+## 1. Nondominium project context (for this analysis)
+
+**Nondominium** is a Holochain hApp implementing **ValueFlows**-aligned resource economics: agents, resources, commitments, economic events, embedded governance rules, and **Private Participation Receipts (PPRs)** for cryptographically grounded, privacy-preserving accountability and reputation.
+
+At a product level it targets **organization-agnostic, capture-resistant resources**.
+
+**Relevance to land and environmental markets:** the roadmap explicitly contemplates **traceability**, **verifiable digital assets**, **DID-style identity slots** , and settlement-oriented integrations, not as a single vendor stack, but as **portable accountability** that can attach to landscape-scale, multi-stakeholder transactions.
+
+---
+
+## 2. Regen Farmers Mutual (RFM): what it is
+
+**Legal form:** Company limited by guarantee; **farmer-governed** mutual (one member, one vote; Member Council; constitution with co-designed principles). Public materials emphasize **no ordinary shareholders** and alignment with member interests rather than external equity maximization.
+
+**Formation:** Co-designed by a large founding cohort.
+
+**Mission (consistent across sources):** Help Australian farmers **aggregate market power** and **landscape impact**; engage **environmental and investment markets** with **credible, verifiable** transactions; reduce reliance on **non-aligned intermediaries**.
+
+**Core service pillars (from site + case studies):**
+
+1. **Discovery and structuring** — Grants, carbon, biodiversity, philanthropy, supply chains, local economic networks; landscape-scale “investment-ready” framing.
+2. **Digital infrastructure — “Regen Digital”** — Farm-level **digital twin** / environmental farm assessment: mapping, environmental value metrics, scenario modelling (“what if” actions and income effects), support for compliance and market narratives.
+3. **Collective / landscape programs** — Structured engagement of farmers and landcare networks (e.g. **Landscape Impact Program**), **Land Management Units (LMUs)**, pilot landholder cohorts, stakeholder mapping, theory of change, pools of capital, investor conversations.
+4. **Human infrastructure** — **Regen Advisors** (capacity building, onboarding, regional delivery); collaboration with Landcare, NRM, universities, Traditional Owner groups (esp. in handbook narrative).
+5. **Governance and economics of the broker function** — Farmer-owned structure; public case study material describes a **80% / 10% / 10%** revenue split (farmer / supporting farmer group / mutual overheads)—use as indicative of design intent, not as legal advice.
+
+**Public positioning:** “Good for the farm, good for the farmer”; regenerative practices tied to **soil, carbon, biodiversity, water, drought resilience**; examples include **Box Gum Grassy Woodland** restoration and linked carbon/planting projects (e.g. STAR / Southern Tablelands narrative on the homepage).
+
+**Scale signals (media):** Reporting around a **$5M raise** (2022) to scale Regen Digital; references to **500+ waitlist** for digital property readings and rapid growth in assessment demand; earlier **equity crowdfunding** (~$500k) noted in press coverage.
+
+**Traceability / standards:** National traceability strategy materials and **GS1 / distributed identity** directions; RFM’s public story fits a broader move toward **supply-chain and natural-capital attestations**. Nondominium’s post-MVP digital-integrity and identity-slot work is directionally compatible with that ecosystem without requiring RFM to adopt any one chain or vendor.
+
+---
+
+## 3. Role in the farming ecosystem
+
+RFM sits at a **junction** between:
+
+
+| Layer                     | RFM’s role                                                                                                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Farm practice**         | Onboarding farmers to regen and natural-capital thinking; farm assessments; advisor network.                                               |
+| **Landscape & community** | Partner in landcare-led landscape action planning; “Pilot 10” style engagement; Working Group facilitation; regional aggregation.          |
+| **Markets & finance**     | Broker / structurer for carbon, biodiversity, and blended finance; tests landscape-scale transactions; connects to investors and programs. |
+| **Data & platforms**      | Regen Digital as the system of record for farm environmental narrative and, increasingly, transaction support.                             |
+
+
+Compared with **commercial brokers**, RFM stresses **member ownership**, **surpluses returned as rebates** (per case studies), and **redirecting value** to farmers and local farmer-support groups. Compared with **industry associations**, it is more **market- and instrument-facing** and **digital-product-centric**.
+
+---
+
+## 4. Deep dive: New Futures handbook
+
+**Landcare Victoria “Landscape Action Plan Handbook”** (New Futures for Victorian Landcare), authored/published in connection with Landcare Victoria Inc. It is primary evidence for how RFM plugs into **formal landscape methodology**.
+
+**Partners named:** Landcare Victoria, **Regen Farmers Mutual**, ANU Sustainable Farms, **Landscape Finance Lab**; funders include Ian Potter Foundation, Natural Resources Conservation Trust, and Landcare Victoria.
+
+**Methodology blend:**
+
+- **4 Returns Framework** (inspiration, natural, social, financial returns) with a **20+ year** horizon emphasis.
+- **Regen Farmers Mutual Landscape Impact Program** integrated into landcare’s grassroots, self-organising model.
+- **Landscape Finance Lab** incubation guidance—stakeholder workshops, field trips, path to **investment-ready** propositions.
+
+**Operational pattern:**
+
+- **Working Group** (diverse roles: engagement, finance, local knowledge broker, **Landscape Impact Advisor**, pilot landholder advocate).
+- **Landscape Coordinator** (paid, ≥2 days/week) and **Workshop Facilitator**.
+- **Pilot 10 landholders** — representative farmers; receive **farm assessment** (emissions estimate, **LMU** assessment, opportunities dialogue).
+- **Modules** spanning onboarding, environmental markets 101, stakeholder mapping, LMUs, mapping and “farm–landscape story,” theory of change, pools of capital, investor session, financial model, plan launch, learning and improvement.
+
+**Scale of the pilot program (as stated in handbook):** 1300+ people engaged; four co-designed Landscape Action Plans; ~**1.75 million hectares** across pilot landscapes; evaluation input from ANU Sustainable Farms.
+
+**Implication for Nondominium:** the handbook describes a **repeatable multi-stakeholder process** with explicit **farm-to-landscape linkage**, **assessment artefacts**, and **capital formation** steps. That is exactly the kind of process that generates **many bilateral and collective commitments**—a fit for structured **economic events**, **validation workflows**, and **PPR-style attestations** once product maturity allows.
+
+---
+
+## 5. Source notes and link hygiene
+
+- [https://www.regenfarmersmutual.com/](https://www.regenfarmersmutual.com/)
+- [https://www.regenfarmersmutual.com/about](https://www.regenfarmersmutual.com/about)
+- [https://www.sustainabletable.org.au/journal/case-study-regen-farmers-mutual](https://www.sustainabletable.org.au/journal/case-study-regen-farmers-mutual)
+- [https://farmingtogether.com.au/regen-farmers-mutual-case-study/](https://farmingtogether.com.au/regen-farmers-mutual-case-study/)
+- [https://www.businessnewsaustralia.com/articles/regen-farmers-mutual-launches--5m-raise.html](https://www.businessnewsaustralia.com/articles/regen-farmers-mutual-launches--5m-raise.html)
+
+National traceability PDF:  
+[https://www.agriculture.gov.au/sites/default/files/documents/national-agricultural-traceability-strategy-implementation-plan-2023-2028.pdf](https://www.agriculture.gov.au/sites/default/files/documents/national-agricultural-traceability-strategy-implementation-plan-2023-2028.pdf)
+
+---
+
+## 6. Compatibility: RFM and Nondominium
+
+### 6.1 Strong alignment
+
+
+| Theme                         | RFM need                                                                      | Nondominium capability (directional)                                                                                               |
+| ----------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Verifiability**             | Credible environmental transactions; due diligence for investors and schemes. | Signed participation receipts, validation schemes, auditable commitment/event chains on Holochain.                                 |
+| **Multi-party landscapes**    | Landcare networks, farmers, advisors, investors, Traditional Owners.          | Agent-centric model; federation/holonic constructs; process-aware resources.                                                       |
+| **Anti-extraction narrative** | Farmer-owned mutual; limit middleman capture.                                 | **Organization-agnostic** resources and explicit governance-as-data; reduces platform lock-in *if* adopted as open protocol layer. |
+| **Data dignity**              | Farmers sensitive to surveillance and misuse of farm data.                    | Local-first Holochain; private entries; selective disclosure via reputation summaries (PPR design intent).                         |
+| **From assessment to market** | Digital twin → instruments → payments.                                        | ValueFlows lifecycle from specification through commitments/events; future settlement hooks (per integration stubs).               |
+
+
+### 6.2 Tensions and gaps to plan for
+
+- **Product maturity:** Nondominium is still in development; RFM already operates a live **Regen Digital** stack. A pragmatic path is **hybrid**: Nondominium as **attestation and contract graph** alongside existing GIS/analytics tools—not a rip-and-replace GIS.
+- **Regulatory reporting:** Carbon and biodiversity markets require compliance with **scheme rules** (methodologies, auditors). Nondominium can anchor **what was agreed and performed between parties**; scheme submission may still export to PDF/registries maintained by regulators.
+- **Many-to-many economics:** Landscape pools may need **N-ary** flows. Early pilots should model **pairwise** attestations (farmer–advisor, farmer–buyer, landcare–farmer) until many-to-many is fully developed on nondominium.
+- **Adoption cost:** Mutual’s advantage is **shared cost** of compliance; any new layer must **reduce** total transaction cost, not add another silo.
+
+**Overall:** Compatibility is **strategic and architectural**, not a claim that the current Nondominium repo replaces Regen Digital today. The mutual’s **theory of change** (aggregate trust and verification without extractive intermediaries) is **conceptually isomorphic** to Nondominium’s **uncapturable resource** thesis.
+
+---
+
+## 7. Where Nondominium can help RFM add farmer value
+
+1. **Mutual accountability for services** — Transport, storage, advisory visits, and monitoring jobs become **commitments and events** with **PPRs**, improving dispute resolution and **Regen Advisor** quality signals without exposing raw farm data.
+2. **Landscape-scale provenance** — Link **Pilot 10** assessments to **non-repudiable** records of who contributed data, who validated, and what changed over time—supporting **investor-grade** transparency without central data hoarding.
+3. **Member governance in the same ledger as economics** — Votes and mandates can eventually align with **governance events** (per OVN/REA parallel in Nondominium's `governance`), reinforcing “farmer-owned” with **inspectable** alignment—not just marketing.
+4. **Composable “natural capital” artefacts** — Treat methodologies, LMU definitions, and project recipes as **resource specifications** with embedded rules, enabling **forking** and regional adaptation (hard-to-clone through network effects and validation, not secrecy).
+5. **Buyer and scheme confidence** — Selective disclosure of **reputation summaries** and validation outcomes can shorten **due diligence** for landscape transactions RFM already pilots.
+
+---
+
+## 8. How RFM can strengthen its value proposition and ecosystem position
+
+1. **Own the “trust layer” explicitly** — Position Regen Digital as **measurement + narrative**, and a partner-agnostic **attestation layer** (potentially Nondominium-class tech) as **integrity + contracts**—clear buyer story.
+2. **Standardize the Landscape Impact Program outputs** — Export **machine-readable** project graphs (even if internal first) so every handbook iteration produces comparable **LMU + intervention + capital** objects.
+3. **Double down on farmer-group economics** — The 80/10/10 story is compelling; publish **auditable examples** of rebates and group distributions to differentiate from brokers.
+4. **Deeper landcare + finance co-design** — The handbook proves the model; scaling is **templates + coordinators + honoraria**—productize the **role pack** (Working Group job descriptions are already specified).
+5. **Interoperability leadership** — Map RFM data once to **national traceability** and **GS1** directions so farmers are not re-keying for every scheme.
+6. **Indigenous and ecological co-stewardship** — The handbook foregrounds Traditional Owner rights; operationalize **consent, benefit-sharing, and governance** as first-class programme modules (Nondominium could later record **agreements** with appropriate privacy).
+
+---
+
+## 9. How Nondominium can serve farmers who are RFM clients
+
+- **Clearer rights:** Custody and role semantics for **who controls farm-derived attestations** when advisors, schemes, and buyers interact.
+- **Portability:** If a farmer changes broker or scheme, **cryptographic history** of commitments and validations can move with **agent identity** (subject to integration maturity), weakening lock-in.
+- **Fair dispute memory:** Bilateral receipts mean **both sides** attest to what happened—reducing “he said, she said” in service failures or payment disagreements.
+- **Reputation without doxxing:** Performance in **delivery of plantings, monitoring, logistics** can accumulate as **summaries** farmers choose to show buyers.
+- **Local resilience:** Holochain’s offline-friendly posture can suit **patchy connectivity** in rural field work better than purely cloud SaaS—when implemented with deliberate UX.
+
+---
+
+## 10. How RFM can improve financial returns by offering Nondominium-class infrastructure
+
+**Important:** This is strategic analysis, not tax or securities advice.
+
+1. **New fee line: “integrity and contracts”** — Charge a modest **per-hectare or per-transaction** fee for **attested workflows** layered on assessments—complementing, not replacing, existing advisory and brokerage revenue.
+2. **Reduce churn and support costs** — Fewer disputes and clearer **event history** lower manual case work; savings drop to **mutual surplus** or **lower member prices**.
+3. **Premium landscape deals** — Investors pay for **lower diligence friction**; RFM captures **structuring fees** or **success fees** on larger pooled transactions where **verification depth** is the differentiator.
+4. **Partnership revenue** — License **methodology packs** to other landcare peaks or regional NRMs with **shared attestation standards**—RFM becomes **standards + capacity** hub.
+5. **Data *without* surveillance capitalism** — Offer **trusted analytics** on **aggregated, opt-in** graphs; farmers pay for insights, buyers pay for **confidence**, RFM avoids selling raw farm surveillance as the product.
+6. **Retention of the 80% farmer share** — If integrity tooling trims broker-like leakage in the wider market, RFM’s **economic story** strengthens membership growth—top-line scales with **trust**, not only with **headcount**.
+
+---
+
+## 11. Suggested next steps (for the Nondominium team)
+
+1. **Map one end-to-end RFM workflow** (e.g. Pilot 10 assessment → carbon project commitment → annual monitoring) to **ValueFlows** primitives and identify **minimum PPR types** needed.
+2. **Prototype selective disclosure** for a **buyer diligence packet** derived from on-DHT events (mock UI acceptable).
+3. **Engage RFM technically** on whether **Regen Digital** APIs could emit **signed events** Nondominium can reference (even before full hApp integration).
+4. **Track many-to-many flows**—landscape pools will hit limits of pairwise modelling; align roadmap to **landscape finance** use cases early.
+
+---
+
+## 12. Original link list (archived)
+
+- Regen Farmers Mutual about: [https://www.regenfarmersmutual.com/about](https://www.regenfarmersmutual.com/about)  
+- Main website: [https://www.regenfarmersmutual.com](https://www.regenfarmersmutual.com)  
+- Case study (Sustainable Table): [https://www.sustainabletable.org.au/journal/case-study-regen-farmers-mutual](https://www.sustainabletable.org.au/journal/case-study-regen-farmers-mutual)  
+- Farming Together case study: [https://farmingtogether.com.au/regen-farmers-mutual-case-study/](https://farmingtogether.com.au/regen-farmers-mutual-case-study/)  
+- Business News Australia (raise / Regen Digital): [https://www.businessnewsaustralia.com/articles/regen-farmers-mutual-launches--5m-raise.html](https://www.businessnewsaustralia.com/articles/regen-farmers-mutual-launches--5m-raise.html)  
+- National agricultural traceability strategy (implementation plan PDF): [https://www.agriculture.gov.au/sites/default/files/documents/national-agricultural-traceability-strategy-implementation-plan-2023-2028.pdf](https://www.agriculture.gov.au/sites/default/files/documents/national-agricultural-traceability-strategy-implementation-plan-2023-2028.pdf)
+

--- a/documentation/requirements/agent.md
+++ b/documentation/requirements/agent.md
@@ -112,13 +112,13 @@ The MVP UI introduces three distinct identity layers that reflect the Lobby → 
 
 - Stored alongside the `GroupDescriptor` in `localStorage` under `ndo_groups_v1`.
 - Prompted via `GroupProfileModal.svelte` on first entry to each group.
-- No consensus or DHT record required; this is a purely local choice.
+- No consensus or DHT record required; this is a purely local choice. 
 
 #### Level 3 — NDO / Agent (DHT, `zome_person`)
 
-**`Person`** is the public, on-chain agent profile. It is created when the agent performs their first DHT-active action — creating an NDO or accepting a commitment. This layer corresponds to the "person-type identity" described in §1.3.
+**`Person`** is the public, on-chain agent profile. It is created when the agent performs their first DHT-active action — creating an NDO, joining an NDO, or accepting a commitment. This layer corresponds to the "person-type identity" described in §1.3.
 
-- Written to the DHT via `create_person` in `zome_person`.
+- Written to the NDO's DHT via `create_person` in `zome_person`.
 - Linked to the agent's `AgentPubKey` through Holochain's source chain.
 - Required for governance participation, custodianship, and specialised service provision.
 - Discoverable by other agents via the `all_persons` anchor.
@@ -285,7 +285,7 @@ When a collective does have an associated NDO, the NDO's three-layer structure (
 - NDO **Specification layer** = the collective's documented form (mission, assets, governance rules for how agents interact with it)
 - NDO **Process layer** = the economic activity *around* the collective as a resource (contributions, agreements, events involving the collective-as-resource)
 
-The NDO may use a subset of `LifecycleStage` values — a working group does not go through `Prototype` or `Distributed`. The `PropertyRegime` and `ResourceNature` fields on `NondominiumIdentity` remain applicable to the collective's resource face: a working group's shared knowledge base is a `Commons`/`Digital` NDO; a collectively owned workshop is a `Collective`/`Physical` NDO.
+The **`LifecycleStage`** at registration can be any non-suspend, non-terminal stage (**Ideation** through **Active**) so the resource face can anchor an already mature or in-use NDO (e.g. a stable shared tool), not only an emerging project. Profiles or wizards may **suggest** a narrower subset for specific organisation types — for example a short-lived working group often stays in emergence — but that is UX guidance, not an ontology constraint on `NondominiumIdentity`. **Hibernating**, **Deprecated**, and **EndOfLife** remain transition-only after creation. The `PropertyRegime` and `ResourceNature` fields on `NondominiumIdentity` remain applicable to the collective's resource face: a working group's shared knowledge base is a `Commons`/`Digital` NDO; a collectively owned workshop maps to a commons-style physical NDO in the UI's four-regime model.
 
 ### 3.2 CapabilitySlot on Agent Identity
 

--- a/documentation/requirements/governance.md
+++ b/documentation/requirements/governance.md
@@ -37,23 +37,23 @@ The most important governance concept for the NDO is **embedded governance**: en
 
 The OVN wiki describes this precisely: "Embedded governance (or immanent governance) is about engineering the environment in which actions are deployed to direct, channel or shape action, to take away the possibility of undesirable or less desirable action alternatives."
 
-In practice: instead of writing a rule "you must not transfer a resource without a validated custodian," make it technically impossible to record a custody transfer without a prior commitment accepted by an accountable agent. The rule is in the architecture, not in a policy document that humans can ignore.
+In practice: instead of writing a rule "you must not transfer a resource without a validated custodian," make it technically impossible to record a *custody transfer* without a prior *commitment* accepted by an *accountable agent*, based on *enbedded rules*, following *validation*. The rule is in the architecture, not in a policy document that humans can ignore.
 
-This is also stigmergy in the complexity economics sense: governance through environmental modification. Ants do not follow written rules — their collective behaviour emerges from pheromone trails (environmental signals) that individual agents respond to locally. The NDO's capability slot surface (Layer 0 stigmergic attachment) is exactly this: governance emerges from what agents choose to attach to resources, without central coordination.
+This is also *stigmergy* in the complexity economics sense: governance through environmental modification. Ants do not follow written rules — their collective behaviour emerges from pheromone trails (environmental signals) that individual agents respond to locally. The NDO's capability slot surface (Layer 0 stigmergic attachment) is exactly this: governance emerges from what agents choose to attach to resources, without central coordination.
 
 The same stigmergic attachment pattern applies to **agent** identity anchors: a `FlowstaIdentity` capability slot on the agent's `Person` entry hash (`ndo_prima_materia.md` **Section 6.5** defines the Person attachment surface; **Section 6.7** specifies Flowsta). **Tier 1** is permissionless at the DHT level; **Tier 2** is when a community turns that signal into a **hard governance precondition** via typed `GovernanceRule` mechanisms (Flowsta Phase 3).
 
-The distinction between soft and hard embedded governance matters:
+The distinction between *soft* and *hard* embedded governance matters:
 - **Hard embedded**: cryptographic impossibility of the prohibited action (Holochain validation rules, capability tokens)
 - **Soft embedded**: social norms encoded as discoverable defaults (GovernanceRules marked as required, reputation consequences)
 
-The NDO primarily uses hard embedded governance (Holochain integrity zomes are cryptographic) with soft embedded governance at the application layer (GovernanceRules are data that agents must choose to enforce in their coordinator logic).
+The NDO primarily uses *hard embedded governance* (Holochain integrity zomes are cryptographic) with *soft embedded governance* at the application layer (GovernanceRules are data that agents must choose to enforce in their coordinator logic).
 
 ### 1.3 Governance as Signal Processing, Not Rule Enforcement
 
 The OVN wiki makes a critical distinction: OVN governance is not "rules-based, but rather signal-based, as norms emerge in real time from agent preferences, in context." Rules assume a known, closed world. Signals are the governance of complex, open, evolving systems.
 
-In complexity economics terms: the adjacent possible (Kauffman) is never fully knowable. Rules written today cannot anticipate tomorrow's edge cases. The governance architecture must support emergence — agents should be able to propose and enact new norms through their behaviour, not just comply with pre-written rules.
+In complexity economics terms: the *adjacent possible* (Kauffman) is never fully knowable. Rules written today cannot anticipate tomorrow's edge cases. The governance architecture must support emergence — agents should be able to propose and enact new norms through their behaviour, not just comply with pre-written rules.
 
 This has direct implications for NDO design: the governance layer should expose proposing, voting, and adapting mechanisms as first-class capabilities, not just enforcement mechanisms. The current MVP focuses almost entirely on enforcement. Adaptation is barely present. Proposal is absent.
 
@@ -61,9 +61,9 @@ This has direct implications for NDO design: the governance layer should expose 
 
 The OVN wiki makes a structural proposal with deep implications: "Architecture governance in a way that it becomes compatible with the organizational and economic model architecture. REA is used to model the economic reality of the network, use the same structure to describe governance."
 
-This means: governance events are EconomicEvents. Governance policies are Resources. Governance actors are Agents. The Policy/Scheduling/Accountability layers of REA are the governance architecture, not just the economic architecture.
+This means: governance *events* are EconomicEvents. Governance *policies* are Resources. Governance *actors* are Agents. The Policy/Scheduling/Accountability layers of REA are the governance architecture, not just the economic architecture.
 
-The implication: the NDO's `zome_gouvernance` — which already models EconomicEvents, Commitments, and Claims — should be the natural home for governance events as well. A decision to grant a role is a governance EconomicEvent. A governance proposal is a Commitment. The decision outcome is a Claim. This unification is not complete in the current codebase but is architecturally supported.
+The implication: the NDO's `zome_gouvernance` — which already models *EconomicEvents*, *Commitments*, and *Claims* — should be the natural home for governance events as well. A decision to grant a *role* is a governance EconomicEvent. A governance proposal is a *Commitment*. The decision outcome is a *Claim*. This unification is not complete in the current codebase but is architecturally supported.
 
 ### 1.5 Holonic Multi-Scale Governance
 
@@ -74,7 +74,7 @@ The OVN wiki defines three governance layers:
 - **Network** (commons community): shared resources, roles, benefit distribution
 - **Venture** (project): specific work, specific benefit distribution
 
-Currently the NDO implements only venture-level governance (single resource interactions, agent roles, process validation). Network and federation-level governance are absent.
+Currently the NDO implements only resource-level governance (single resource interactions, agent roles, process validation). Network and federation-level governance are absent.
 
 ### 1.6 Ostrom's Principles as NDO Architecture
 
@@ -126,7 +126,7 @@ Commitment (intent + obligation)
        └─ Claim (link: this event fulfills that commitment)
 ```
 
-This is the **planning → observation** bridge. Commitments are governance artifacts: they are the declared intent of an agent, time-bound, linking provider and receiver for a specific VfAction on a specific resource. The claim verifies fulfillment. The entire chain is auditable on the DHT.
+This is the **planning → observation** bridge. *Commitments* are governance artifacts: they are the declared *intent of an agent*, time-bound, linking provider and receiver for a specific VfAction on a specific resource. The claim verifies *fulfillment*. The entire chain is auditable on the DHT.
 
 This cycle is both governance and economics — consistent with the OVN wiki's REA governance parallel.
 
@@ -147,7 +147,11 @@ The validation system implements the monitoring and graduated sanction aspects o
 
 ### 2.5 The PPR System: 16 Categories, Bilateral Cryptographic Signatures
 
-The Private Participation Receipt (PPR) system is the most complete governance mechanism in the MVP. It generates cryptographically signed, private, bilateral records of every economic interaction.
+The Private Participation Receipt (PPR) system is the most complete governance mechanism in the MVP. It generates **cryptographically signed, private receipts** grounded in ValueFlows commitments and events.
+
+In the MVP, each recorded economic interaction uses a **single provider** and a **single receiver** on the DHT (one-to-one ValueFlows pattern). For that interaction, the PPR model is **pairwise bilateral**: each party holds a receipt that names the other as `counterparty`, and **two coordinated receipts** capture the same underlying event from both sides (`private-participation-receipt.md` — “two receipts per action”). This is bilateral accountability **per interacting pair**, not a single shared “group receipt.”
+
+Broader participation topologies (**one-to-many**, **many-to-one**, and **many-to-many** custody transfers, shared co-custodianship, resource pools, and delegation among co-custodians) are specified as **post-MVP** extensions to EconomicEvent / Commitment and to **how PPRs are issued and attributed** when several providers or receivers are involved (`post-mvp/many-to-many-flows.md` §1–2, Phase 5, REQ-MMF-19–22). Until that work lands, interactions that socially involve more than two agents must still be represented as sequences or combinations of **one-to-one** events and **pairwise** PPRs, or omitted from structured monitoring (see gaps in Sections 2.8 and 6 of this document and `implementation_plan.md` (many-to-many / `AgentContext`)).
 
 **`PrivateParticipationClaim` entry structure**:
 ```rust
@@ -181,7 +185,7 @@ pub struct PrivateParticipationClaim {
 - `communication` (weight 0.20)
 - `overall_satisfaction` (additional signal)
 
-**Bilateral cryptographic signatures**: both the recipient and the counterparty sign the PPR. This is not just authentication — it is **mutual accountability**. Neither party can unilaterally issue a PPR; both must sign. This prevents false claims and creates bilateral commitment to the record.
+**Bilateral cryptographic signatures**: for each pairwise PPR, the issuing agent's view and the counterparty's agreement are both reflected in the receipt design (mutual attestation to the claim). This is not merely authentication — it is **mutual accountability** for that **two-party** slice of the interaction. Multi-party flows will need extended signing and distribution rules (see `many-to-many-flows.md` Phase 3 and §4.5).
 
 **`ReputationSummary`**: a derived, privacy-preserving aggregate that agents can selectively share. Counts by category, average performance, time period. The agent controls what they reveal; the summary proves they have a track record without revealing individual interactions.
 
@@ -210,7 +214,7 @@ This is the access control layer of the deontic ontology: permissions are crypto
 
 - **Governance-as-operator** is the correct architectural pattern: clear separation of data model and governance logic, enabling swappable governance
 - **VfAction semantics** — typed actions with governance implications — are a principled approach to deontic governance encoding
-- **Bilateral cryptographic PPRs** are a novel and strong accountability mechanism; stronger than reputation systems that rely on one-sided ratings
+- **Pairwise bilateral cryptographic PPRs** are a novel and strong accountability mechanism; stronger than reputation systems that rely on one-sided ratings
 - **Multi-scheme validation** (`"2-of-3"`, `"N-of-M"`) supports configurable collective decisions at the resource validation level
 - **Graduated role tiers** implement Ostrom's "clearly defined boundaries" principle
 - **Private-yet-derivable reputation** (PPR → ReputationSummary) correctly addresses the privacy/accountability tension
@@ -487,7 +491,7 @@ The NDO has no formal governance surface. Rule changes require developer interve
 | Deontic permission system | Capability tokens + role-gated validation | ✅ Implemented |
 | Deontic obligation system | `Commitment` entries with due dates | ✅ Implemented |
 | Access from Permission | Role-gated VfAction execution | ✅ Implemented |
-| Monitoring and accountability | PPR system (16 categories, bilateral signatures) | ✅ Implemented |
+| Monitoring and accountability | PPR system (16 categories; pairwise bilateral for MVP one-to-one events; multi-party issuance post-MVP per post-mvp/many-to-many-flows.md) | ✅ Implemented |
 | Graduated trust / bounded membership | SimpleAgent → Accountable → Primary tiers | ✅ Implemented |
 | Multi-scheme collective validation | ResourceValidation with `"2-of-3"`, `"N-of-M"` | ✅ Implemented |
 | Governance equation (contribution → access) | PPR → role promotion; Unyt credit limit feedback | ✅ Partial (promotion path); 🔄 Planned (credit/weight) |

--- a/documentation/requirements/ui_design.md
+++ b/documentation/requirements/ui_design.md
@@ -49,7 +49,7 @@ NDOs can only be created from within a Group. The "Create NDO" button in a Group
 | `name` | text input | required; uniqueness warning shown if name already exists in the lobby |
 | `property_regime` | select | 4 variants: **Private**, **Commons**, **Nondominium**, **CommonPool**; tooltip per option |
 | `resource_nature` | select | 5 variants: Physical, Digital, Service, Hybrid, Information; tooltip per option |
-| `lifecycle_stage` | select | restricted to initial stages: Ideation, Specification, Development, Stable, Hibernating |
+| `lifecycle_stage` | select | **seven** creatable-at-registration stages: Ideation, Specification, Development, Prototype, Stable, Distributed, Active (matches `create_ndo` validation); Hibernating and terminal stages (Deprecated, EndOfLife) are **not** selectable here — only via lifecycle transitions after registration |
 | `description` | textarea | optional |
 
 > Note: the original spec listed 6 property-regime variants (including Collective and Pool) and 4 initial lifecycle stages (including Prototype). Both have been revised — see the Rust `PropertyRegime` enum and `LifecycleStage` for current canonical values.

--- a/packages/shared-types/src/lobby.types.ts
+++ b/packages/shared-types/src/lobby.types.ts
@@ -39,7 +39,7 @@ export interface AnnounceNdoInput {
   description?: string;
 }
 
-export interface GroupDescriptor {
+export interface GroupDescriptorStub {
   id: string;
   name: string;
   description?: string;

--- a/packages/shared-types/src/resource.types.ts
+++ b/packages/shared-types/src/resource.types.ts
@@ -189,6 +189,19 @@ export type LifecycleStage =
   | "Deprecated"
   | "EndOfLife";
 
+/** Stages allowed when registering a new NDO via `create_ndo` (UI + coordinator). */
+export const CREATABLE_NDO_LIFECYCLE_STAGES = [
+  'Ideation',
+  'Specification',
+  'Development',
+  'Prototype',
+  'Stable',
+  'Distributed',
+  'Active'
+] as const satisfies readonly LifecycleStage[];
+
+export type CreatableNdoLifecycleStage = (typeof CREATABLE_NDO_LIFECYCLE_STAGES)[number];
+
 export interface NondominiumIdentity {
   name: string;
   initiator: AgentPubKey;

--- a/ui/src/lib/components/group/GroupProfileModal.svelte
+++ b/ui/src/lib/components/group/GroupProfileModal.svelte
@@ -66,7 +66,7 @@
           </p>
           <div class="space-y-1.5">
             {#each optionalFields as f}
-              {#if (lobby as Record<string, unknown>)[f]}
+              {#if (lobby as unknown as Record<string, unknown>)[f]}
                 <label class="flex items-center gap-3 cursor-pointer">
                   <input
                     type="checkbox"
@@ -75,7 +75,7 @@
                     class="h-4 w-4 rounded"
                   />
                   <span class="text-sm text-gray-700">
-                    {fieldLabels[f]}: <span class="font-medium">{(lobby as Record<string, unknown>)[f]}</span>
+                    {fieldLabels[f]}: <span class="font-medium">{(lobby as unknown as Record<string, unknown>)[f]}</span>
                   </span>
                 </label>
               {/if}

--- a/ui/src/lib/components/group/NdoCreateModal.svelte
+++ b/ui/src/lib/components/group/NdoCreateModal.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import type {
-    LifecycleStage,
+    CreatableNdoLifecycleStage,
     NdoDescriptor,
     NdoInput,
     PropertyRegime,
     ResourceNature
   } from '@nondominium/shared-types';
+  import { CREATABLE_NDO_LIFECYCLE_STAGES } from '@nondominium/shared-types';
   import { goto } from '$app/navigation';
   import { groupStore } from '$lib/stores/group.store.svelte';
   import { lobbyStore } from '$lib/stores/lobby.store.svelte';
@@ -17,14 +18,13 @@
 
   let { groupId, onclose }: Props = $props();
 
-  const initialStages: LifecycleStage[] = ['Ideation', 'Specification', 'Development', 'Prototype'];
   const allRegimes: PropertyRegime[] = ['Private', 'Commons', 'Nondominium', 'CommonPool'];
   const allNatures: ResourceNature[] = ['Physical', 'Digital', 'Service', 'Hybrid', 'Information'];
 
   let name = $state('');
   let property_regime = $state<PropertyRegime>('Commons');
   let resource_nature = $state<ResourceNature>('Physical');
-  let lifecycle_stage = $state<LifecycleStage>('Ideation');
+  let lifecycle_stage = $state<CreatableNdoLifecycleStage>('Ideation');
   let description = $state('');
   let isSubmitting = $state(false);
   let errorMessage = $state('');
@@ -152,11 +152,18 @@
           bind:value={lifecycle_stage}
           class="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
         >
-          {#each initialStages as s}
+          {#each CREATABLE_NDO_LIFECYCLE_STAGES as s}
             <option value={s}>{s}</option>
           {/each}
         </select>
-        <p class="mt-1 text-xs text-gray-500">New NDOs start in early stages of maturity.</p>
+        <p class="mt-1 text-xs text-gray-500">
+          Choose emergence (Ideation–Prototype) for something still forming, or
+          <span class="font-medium">Stable</span> / <span class="font-medium">Distributed</span> /
+          <span class="font-medium">Active</span> for an already mature or in-use resource (e.g. a stable
+          shared tool).
+          <span class="font-medium">Hibernating</span>, terminal stages, and deprecation are set only after
+          creation via lifecycle transitions.
+        </p>
       </div>
 
       <!-- Description -->

--- a/ui/src/lib/services/cell.manager.ts
+++ b/ui/src/lib/services/cell.manager.ts
@@ -7,9 +7,10 @@ import type { AppClient, CellId } from '@holochain/client';
 export async function getLobbyCellHandle(client: AppClient): Promise<CellId | null> {
   try {
     const appInfo = await client.appInfo();
-    const lobbyCell = appInfo?.cell_info?.['lobby']?.[0];
+    const lobbyCell = appInfo?.cell_info?.['lobby']?.[0] as Record<string, unknown> | undefined;
     if (lobbyCell && 'provisioned' in lobbyCell) {
-      return lobbyCell.provisioned.cell_id;
+      const provisioned = lobbyCell.provisioned as { cell_id: CellId };
+      return provisioned.cell_id;
     }
     return null;
   } catch {

--- a/ui/src/lib/services/holochain.service.svelte.ts
+++ b/ui/src/lib/services/holochain.service.svelte.ts
@@ -76,6 +76,7 @@ function createHolochainClientService(): HolochainClientService {
    */
   async function getMyAgentPubKey(): Promise<AgentPubKey> {
     const info = await getAppInfo();
+    if (!info) throw new Error('App info not available');
     return info.agent_pub_key;
   }
 

--- a/ui/src/lib/services/index.ts
+++ b/ui/src/lib/services/index.ts
@@ -17,7 +17,6 @@ export {
   GovernanceServiceResolved
 } from './zomes/governance.service';
 export { NdoServiceTag, NdoServiceLive, NdoServiceResolved } from './zomes/ndo.service';
-export { LobbyServiceTag, LobbyServiceLive, LobbyServiceResolved } from './zomes/lobby.service';
 export { GroupServiceTag, GroupServiceLive, GroupServiceResolved } from './zomes/group.service';
 export {
   getLobbyCellHandle,

--- a/ui/src/lib/services/zomes/lobby.service.ts
+++ b/ui/src/lib/services/zomes/lobby.service.ts
@@ -70,7 +70,8 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
           fnName,
           payload,
           context,
-          LobbyError.fromError
+          LobbyError.fromError,
+          'lobby'
         );
 
       return {
@@ -104,7 +105,7 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
               saveGroupsToStorage([...groups, { ...groupData, ndoHashes: groupData.ndoHashes ?? [] }]);
               return groupData;
             },
-            catch: (e) => LobbyError.fromError(new Error(`Invalid invite code: ${String(e)}`))
+            catch: (e) => LobbyError.fromError(new Error(`Invalid invite code: ${String(e)}`), 'JOIN_GROUP')
           }),
 
         generateInviteLink: (groupId) =>

--- a/ui/src/lib/stores/group.store.svelte.ts
+++ b/ui/src/lib/stores/group.store.svelte.ts
@@ -1,12 +1,12 @@
 import { Effect as E, Exit, pipe } from 'effect';
 import type { GroupDescriptor, NdoDescriptor, NdoInput } from '@nondominium/shared-types';
 import { NdoServiceTag, NdoServiceResolved } from '../services/zomes/ndo.service';
-import { LobbyServiceTag, LobbyServiceLive } from '../services/zomes/lobby.service';
+import { LobbyServiceTag, LobbyServiceResolved } from '../services/zomes/lobby.service';
 import { Layer } from 'effect';
 
 const GROUPS_KEY = 'ndo_groups_v1';
 
-const GroupStoreServicesResolved = Layer.mergeAll(NdoServiceResolved, LobbyServiceLive);
+const GroupStoreServicesResolved = Layer.mergeAll(NdoServiceResolved, LobbyServiceResolved);
 
 function loadGroups(): GroupDescriptor[] {
   try {

--- a/ui/src/lib/stores/lobby.store.svelte.ts
+++ b/ui/src/lib/stores/lobby.store.svelte.ts
@@ -8,7 +8,7 @@ import type {
   PropertyRegime,
   ResourceNature
 } from '@nondominium/shared-types';
-import { LobbyServiceTag, LobbyServiceLive } from '../services/zomes/lobby.service';
+import { LobbyServiceTag, LobbyServiceResolved } from '../services/zomes/lobby.service';
 import { PersonServiceTag, PersonServiceResolved } from '../services/zomes/person.service';
 import { NdoServiceTag, NdoServiceResolved } from '../services/zomes/ndo.service';
 import { withLoadingState, createLoadingStateSetter } from '$lib/utils/store-helpers/core';
@@ -19,9 +19,8 @@ export interface ActiveFilters {
   regimes: PropertyRegime[];
 }
 
-/** Lobby store: resolved zome layers only (no duplicate `HolochainClientServiceTag`). */
 const LobbyStoreServicesResolved = Layer.mergeAll(
-  LobbyServiceLive,
+  LobbyServiceResolved,
   NdoServiceResolved,
   PersonServiceResolved
 );
@@ -157,8 +156,8 @@ const createLobbyStore = (): E.Effect<
             )
           )
         ]);
-        const failed = [groupsExit, ndosExit, personExit].filter(Exit.isFailure);
-        if (failed.length > 0) {
+        const hasFailed = [groupsExit, ndosExit, personExit].some((e) => e._tag === 'Failure');
+        if (hasFailed) {
           errorMessage = 'Failed to load lobby data. Please try again.';
         }
       } finally {

--- a/ui/src/lib/utils/zome-helpers.ts
+++ b/ui/src/lib/utils/zome-helpers.ts
@@ -1,5 +1,5 @@
 import { Effect as E } from 'effect';
-import type { HolochainClientService, ZomeName } from '$lib/services/holochain.service.svelte';
+import type { HolochainClientService, RoleName, ZomeName } from '$lib/services/holochain.service.svelte';
 
 /**
  * Wait until the Holochain client is connected.
@@ -26,12 +26,13 @@ export const wrapZomeCall = <T, E>(
   fnName: string,
   payload: unknown,
   errorContext: string,
-  ErrorConstructor: new (message: string, context?: string) => E
+  ErrorConstructor: new (message: string, context?: string) => E,
+  roleName?: RoleName
 ): E.Effect<T, E> =>
   E.tryPromise({
     try: async () => {
       await ensureConnected(holochainClient);
-      const result = await holochainClient.callZome(zomeName as ZomeName, fnName, payload);
+      const result = await holochainClient.callZome(zomeName as ZomeName, fnName, payload, undefined, roleName);
       return result as T;
     },
     catch: (error) =>
@@ -52,12 +53,13 @@ export const wrapZomeCallWithErrorFactory = <T, E>(
   fnName: string,
   payload: unknown,
   errorContext: string,
-  errorFactory: (error: unknown, context: string) => E
+  errorFactory: (error: unknown, context: string) => E,
+  roleName?: RoleName
 ): E.Effect<T, E> =>
   E.tryPromise({
     try: async () => {
       await ensureConnected(holochainClient);
-      const result = await holochainClient.callZome(zomeName as ZomeName, fnName, payload);
+      const result = await holochainClient.callZome(zomeName as ZomeName, fnName, payload, undefined, roleName);
       return result as T;
     },
     catch: (error) => errorFactory(error, errorContext)


### PR DESCRIPTION
## Intent

Implements the MVP UI for NDO Layer 0 (issue #102): a Lobby-first navigation hierarchy where agents browse a federation-wide NDO registry, create and join Groups, and manage NDOs scoped to a Group. Integrates the Lobby DNA (#103) service layer into the frontend for the first time.

## Changes

**Lobby DNA integration**
- `lobby.service`: replaced localStorage stub with real `zome_lobby` calls (`get_all_ndo_announcements`, `announce_ndo`, `upsert_lobby_agent_profile`, `get_lobby_agent_profile`); all calls explicitly route to the `lobby` DNA role
- `zome-helpers`: added optional `roleName` parameter to both `wrapZomeCall` helpers so services can target non-default DNA roles
- `lobby.store`, `group.store`: switched from `LobbyServiceLive` to `LobbyServiceResolved` so `HolochainClientServiceTag` is satisfied at `E.runSync` time
- `services/index.ts`: removed duplicate `LobbyService*` re-export

**NDO lifecycle — seven creatable stages**
- Creation form restricts `lifecycle_stage` to the seven stages valid at registration (`Ideation` → `Active`), sourced from the new `CREATABLE_NDO_LIFECYCLE_STAGES` constant in shared-types

**shared-types package**
- Renamed `GroupDescriptor` → `GroupDescriptorStub` in `lobby.types.ts` to match the Rust type name and eliminate the duplicate export that was shadowing the full `GroupDescriptor` (with `ndoHashes`, `createdBy`, `memberProfile`) in `resource.types.ts`

**Miscellaneous type fixes**
- `holochain.service`: null guard on `appInfo()` return value
- `cell.manager`: narrowed `unknown` for `lobbyCell.provisioned`
- `GroupProfileModal`: double-cast `LobbyUserProfile` for dynamic field access

## Decisions

| Option | Rejected because |
| ------ | ---------------- |
| Keep `LobbyServiceLive` unresolved in store | Requires exposing `HolochainClientServiceTag` through `mergeAll`, which leaks an unsatisfied dependency and crashes `E.runSync` at module load |
| Default `roleName` to `'nondominium'` for lobby calls | The Lobby DNA is a separate cell; calling `zome_lobby` on the `nondominium` cell returns HTTP 500 from the conductor |
| Keep `GroupDescriptor` name in lobby.types | Conflicts with the localStorage `GroupDescriptor` in resource.types; the Rust type is already named `GroupDescriptorStub` |

## How to test

```bash
# Inside nix shell
bun run start
```

1. App loads without console errors
2. Lobby view displays — NDO browser and group sidebar visible
3. Create a Group → creates successfully and appears in sidebar
4. Create an NDO within the group → NDO appears in the group view
5. Lifecycle transition button works for own NDOs
6. Lobby profile modal appears on first visit

## Documentation

- `packages/shared-types/src/lobby.types.ts`: `GroupDescriptor` → `GroupDescriptorStub` (rename tracked in source)

## Related

- Closes #102
- Depends on: #103 (Lobby DNA — merged)
- Follow-up: #101 (Group DNA — in progress)