### PR TITLE
feat(ui): wire Lobby DNA into UI — profile bar, NdoBrowser states, DHT profile sync (#106)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "nondominium-dev",
       "devDependencies": {
+        "@holochain/client": "^0.19.1",
         "@holochain/hc-spin": "^0.600.0",
         "@types/libsodium-wrappers": "^0.7.14",
         "@types/ws": "^8.18.1",

--- a/ui/src/lib/components/lobby/LobbyProfileBar.svelte
+++ b/ui/src/lib/components/lobby/LobbyProfileBar.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { appContext } from '$lib/stores/app.context.svelte';
+
+  interface Props {
+    /** Open the profile setup / edit modal */
+    onOpenProfile: () => void;
+  }
+
+  let { onOpenProfile }: Props = $props();
+
+  const profile = $derived(appContext.lobbyUserProfile);
+</script>
+
+<div
+  class="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-2"
+>
+  {#if profile}
+    <span class="text-sm text-gray-700">
+      Signed in as <span class="font-semibold text-gray-900">{profile.nickname}</span>
+    </span>
+    <button
+      type="button"
+      aria-label="Edit profile"
+      onclick={() => onOpenProfile()}
+      class="rounded px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50"
+    >
+      Edit
+    </button>
+  {:else}
+    <span class="text-sm text-gray-500">No Lobby profile yet</span>
+    <button
+      type="button"
+      aria-label="Open profile setup"
+      onclick={() => onOpenProfile()}
+      class="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700"
+    >
+      Set up your profile
+    </button>
+  {/if}
+</div>

--- a/ui/src/lib/components/lobby/LobbyView.svelte
+++ b/ui/src/lib/components/lobby/LobbyView.svelte
@@ -1,16 +1,30 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { lobbyStore } from '$lib/stores/lobby.store.svelte';
   import { appContext } from '$lib/stores/app.context.svelte';
   import NdoBrowser from './NdoBrowser.svelte';
+  import LobbyProfileBar from './LobbyProfileBar.svelte';
+  import ProfileSetupModal from './ProfileSetupModal.svelte';
 
+  let showProfileModal = $state(false);
+
+  // Keep the Person sync reactive; fetch NDOs once on mount (not on every
+  // reactive dependency change — issue #106 section 2).
   $effect(() => {
     appContext.myPerson = lobbyStore.myPerson;
+  });
+
+  onMount(() => {
     void lobbyStore.loadNdos();
   });
 </script>
 
-<div class="flex min-h-full flex-col p-6">
+<div class="flex min-h-full flex-col">
+  <LobbyProfileBar onOpenProfile={() => (showProfileModal = true)} />
+  <ProfileSetupModal bind:open={showProfileModal} />
+
+  <div class="flex min-h-full flex-col p-6">
   <header class="mb-6">
     <h1 class="text-2xl font-bold text-gray-900">Browse NDOs</h1>
     <p class="mt-1 text-gray-600">All NDOs across your groups.</p>
@@ -28,9 +42,11 @@
     onclearfilters={() => lobbyStore.clearFilters()}
     isLoading={lobbyStore.isLoading}
     errorMessage={lobbyStore.errorMessage}
+    onRetry={() => void lobbyStore.loadNdos()}
     hasGroups={lobbyStore.groups.length > 0}
     showOnboarding={true}
     onCreateGroup={() => goto('/?openCreateGroup=1')}
     onJoinGroup={() => goto('/?openJoinGroup=1')}
   />
+  </div>
 </div>

--- a/ui/src/lib/components/lobby/NdoBrowser.svelte
+++ b/ui/src/lib/components/lobby/NdoBrowser.svelte
@@ -15,6 +15,8 @@
     activeFilters?: ActiveFilters;
     onfilterchange?: (partial: Partial<ActiveFilters>) => void;
     onclearfilters?: () => void;
+    /** Retry the NDO load after a fetch failure */
+    onRetry?: () => void;
     /** Lobby view: distinguish no-groups vs groups-with-no-NDOs */
     hasGroups?: boolean;
     showOnboarding?: boolean;
@@ -29,6 +31,7 @@
     activeFilters = { stages: [], natures: [], regimes: [] },
     onfilterchange,
     onclearfilters,
+    onRetry,
     hasGroups = true,
     showOnboarding = false,
     onCreateGroup,
@@ -185,12 +188,33 @@
     </div>
 
     {#if errorMessage}
-      <p class="mb-3 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
-        {errorMessage}
-      </p>
+      <div
+        role="alert"
+        class="mb-3 flex items-center justify-between gap-3 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700"
+      >
+        <span>{errorMessage}</span>
+        {#if onRetry}
+          <button
+            type="button"
+            onclick={() => onRetry?.()}
+            class="shrink-0 rounded border border-red-300 bg-white px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-100"
+          >
+            Retry
+          </button>
+        {/if}
+      </div>
     {/if}
 
-    {#if descriptors.length === 0 && !isLoading}
+    <div aria-busy={isLoading}>
+    {#if isLoading}
+      <div class="flex items-center justify-center py-10 text-sm text-gray-500">
+        <span
+          class="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"
+          aria-hidden="true"
+        ></span>
+        Loading NDOs…
+      </div>
+    {:else if descriptors.length === 0 && !errorMessage}
       {#if showOnboarding && !hasGroups}
         <div class="rounded-lg border border-dashed border-blue-200 bg-blue-50 p-6 text-center">
           <p class="text-sm font-medium text-gray-800">Create or join a group to see NDOs</p>
@@ -218,13 +242,13 @@
         <p class="text-sm text-gray-500">
           {hasFilters
             ? 'No NDOs match the selected filters.'
-            : 'No NDOs in your groups yet. Open a group and create one.'}
+            : 'No NDOs yet. Create one inside a group to see it here.'}
         </p>
       {:else}
         <p class="text-sm text-gray-500">
           {hasFilters
             ? 'No NDOs match the selected filters.'
-            : 'No NDOs yet. Create one from within a group.'}
+            : 'No NDOs yet. Create one inside a group to see it here.'}
         </p>
       {/if}
     {:else}
@@ -236,5 +260,6 @@
         {/each}
       </ul>
     {/if}
+    </div>
   </div>
 </section>

--- a/ui/src/lib/components/lobby/ProfileSetupModal.svelte
+++ b/ui/src/lib/components/lobby/ProfileSetupModal.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { Dialog } from 'melt/builders';
+  import { Effect as E, pipe } from 'effect';
+  import type { LobbyUserProfile } from '@nondominium/shared-types';
+  import { appContext } from '$lib/stores/app.context.svelte';
+  import { LobbyServiceTag, LobbyServiceResolved } from '$lib/services/zomes/lobby.service';
+  import UserProfileForm from './UserProfileForm.svelte';
+
+  interface Props {
+    /** Whether the modal is open (controlled by the parent). */
+    open: boolean;
+    /** Called when the modal is dismissed without saving. */
+    onclose?: () => void;
+    /** Called with the saved profile. */
+    onsave?: (profile: LobbyUserProfile) => void;
+  }
+
+  let { open = $bindable(), onclose, onsave }: Props = $props();
+
+  // First-launch guard: closing (Escape, outside click, close button) is only
+  // allowed once a nickname has been saved.
+  const hasProfile = $derived(!!appContext.lobbyUserProfile?.nickname);
+
+  const dialog = new Dialog({
+    closeOnEscape: () => hasProfile,
+    closeOnOutsideClick: () => hasProfile,
+    onOpenChange: (value) => {
+      open = value;
+      if (!value) onclose?.();
+    }
+  });
+
+  // Drive the native <dialog> from the controlled `open` prop.
+  $effect(() => {
+    dialog.open = open;
+  });
+
+  // Move focus to the nickname input when the dialog opens (REQ-UI-ID-01).
+  $effect(() => {
+    if (open) {
+      void tick().then(() => {
+        document.getElementById('lup-nickname')?.focus();
+      });
+    }
+  });
+
+  function handleSave(profile: LobbyUserProfile) {
+    // Fire-and-forget DHT write after the localStorage write (D1 in #106):
+    // localStorage (appContext setter inside UserProfileForm) is authoritative for
+    // Level 1 identity; the Lobby DHT profile is best-effort.
+    void E.runPromise(
+      pipe(
+        E.gen(function* () {
+          const lobbySvc = yield* LobbyServiceTag;
+          yield* lobbySvc.upsertLobbyAgentProfile({
+            handle: profile.nickname,
+            ...(profile.bio && { bio: profile.bio })
+          });
+        }),
+        E.provide(LobbyServiceResolved)
+      )
+    ).catch((err) => {
+      console.warn('Lobby DHT profile sync failed (localStorage profile saved):', err);
+    });
+    onsave?.(profile);
+    open = false;
+  }
+</script>
+
+<!-- Native <dialog> carries an implicit role="dialog"; adding it explicitly is
+     flagged as redundant by svelte-check. -->
+<dialog
+  {...dialog.content}
+  aria-modal="true"
+  aria-label={hasProfile ? 'Edit your Lobby profile' : 'Set up your Lobby profile'}
+  class="w-full max-w-md rounded-xl border border-gray-200 bg-white p-0 shadow-xl"
+>
+  {#if open}
+    <div class="px-6 py-6">
+      <UserProfileForm
+        mode="page"
+        onsave={handleSave}
+        onclose={hasProfile ? () => { open = false; } : undefined}
+      />
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  dialog::backdrop {
+    background-color: rgb(0 0 0 / 0.4);
+    backdrop-filter: blur(2px);
+  }
+</style>

--- a/ui/src/lib/errors/error-contexts.ts
+++ b/ui/src/lib/errors/error-contexts.ts
@@ -115,6 +115,14 @@ export const HOLOCHAIN_CLIENT_CONTEXTS = {
   GET_APP_INFO: 'Failed to get app info'
 } as const;
 
+export const LOBBY_CONTEXTS = {
+  ANNOUNCE_GROUP: 'Failed to announce group to Lobby',
+  GET_ALL_GROUP_ANNOUNCEMENTS: 'Failed to get all group announcements',
+  GET_MY_GROUP_ANNOUNCEMENTS: 'Failed to get my group announcements',
+  UPSERT_LOBBY_AGENT_PROFILE: 'Failed to upsert lobby agent profile',
+  GET_LOBBY_AGENT_PROFILE: 'Failed to get lobby agent profile'
+} as const;
+
 export const GROUP_CONTEXTS = {
   CREATE_GROUP: 'Failed to create group',
   GET_GROUP: 'Failed to get group',

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
   import favicon from '$lib/assets/favicon.svg';
   import HolochainProvider from '$lib/components/HolochainProvider.svelte';
   import AppShell from '$lib/components/shell/AppShell.svelte';
-  import UserProfileForm from '$lib/components/lobby/UserProfileForm.svelte';
+  import ProfileSetupModal from '$lib/components/lobby/ProfileSetupModal.svelte';
   import { lobbyStore } from '$lib/stores/lobby.store.svelte';
   import { appContext } from '$lib/stores/app.context.svelte';
   import holochainClientService from '$lib/services/holochain.service.svelte';
@@ -39,13 +39,7 @@
 </svelte:head>
 
 <HolochainProvider autoConnect={true}>
-  {#if showProfileModal}
-    <UserProfileForm
-      mode="modal"
-      onclose={() => { showProfileModal = false; }}
-      onsave={() => { showProfileModal = false; }}
-    />
-  {/if}
+  <ProfileSetupModal bind:open={showProfileModal} />
   <AppShell>
     {@render children()}
   </AppShell>


### PR DESCRIPTION
## Summary

Implements #106 as specced: Lobby profile bar with a Melt UI setup modal, fire-and-forget DHT profile sync, and the NdoBrowser display states. Frontend only; the NdoBrowser data source is unchanged (D2 — that upgrade belongs to #110).

## Changes

- **`ProfileSetupModal.svelte`** (new): Melt UI `Dialog` builder wrapping the existing `UserProfileForm`. `aria-modal`, focus trap via the native `<dialog>`, focus moves to the nickname input on open, and Escape/outside-click close only once a nickname exists (first-launch guard; the form's close affordance is hidden until then).
- **`LobbyProfileBar.svelte`** (new): shows `profile.nickname` or an accessible "Set up your profile" button (`aria-label="Open profile setup"`); edit affordance (`aria-label="Edit profile"`) reopens the modal.
- **`+layout.svelte`**: the raw `UserProfileForm` modal is replaced by `ProfileSetupModal`.
- **DHT profile sync (D1)**: on every profile save, `upsertLobbyAgentProfile({ handle, bio })` fires after the authoritative localStorage write, best-effort with a `console.warn` on failure. Centralised in `ProfileSetupModal` so both the first-launch and edit paths sync.
- **`LobbyView.svelte`**: `loadNdos()` moved from `$effect` to `onMount` (the `myPerson` sync stays reactive); retry callback wired to `NdoBrowser`.
- **`NdoBrowser.svelte`**: loading spinner inside an `aria-busy` container, `role="alert"` error state with a Retry button, unified empty-state copy ("No NDOs yet. Create one inside a group to see it here."); the empty state is never shown while loading. The existing no-groups onboarding CTA path is preserved.
- **`error-contexts.ts`**: `LOBBY_CONTEXTS` registry added.
- `bun.lock`: synced with the `@holochain/client` root devDependency declared in #111.

## Verification

- `bun run --filter ui build` exits 0 (includes `svelte-check`)
- `svelte-check`: 0 errors, 0 warnings
- Acceptance criteria of #106 sections 1 to 3 checked against the post-#111 codebase; criteria already satisfied by #111 (isLoading/errorMessage prop wiring) were verified rather than re-implemented

Closes #106
