### PR TITLE
feat(dna): NDO DNA role, per-NDO cell cloning, NdoAnchor in zome_group (#112)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8294,6 +8294,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "holochain_serialized_bytes",
+ "nondominium_shared",
  "serde",
 ]
 

--- a/dnas/group/tests/Cargo.toml
+++ b/dnas/group/tests/Cargo.toml
@@ -20,3 +20,7 @@ holochain_serialized_bytes = { workspace = true }
 [[test]]
 name = "group"
 path = "src/group/mod.rs"
+
+[[test]]
+name = "ndo_anchor"
+path = "src/ndo_anchor/mod.rs"

--- a/dnas/group/tests/src/common/conductors.rs
+++ b/dnas/group/tests/src/common/conductors.rs
@@ -8,6 +8,13 @@ pub const GROUP_DNA_PATH: &str = concat!(
     "/../workdir/group.dna"
 );
 
+/// Path to the compiled NDO DNA bundle (one clone per NDO, ADR-010/ADR-012).
+/// Bundles the existing zome_resource and zome_gouvernance WASMs.
+pub const NDO_DNA_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../ndo/workdir/ndo.dna"
+);
+
 // Each test invocation gets a unique monotonic ID. Combined with the process PID this
 // guarantees distinct network seeds even when multiple test processes run in parallel.
 static TEST_INSTANCE: AtomicU64 = AtomicU64::new(0);
@@ -15,6 +22,24 @@ static TEST_INSTANCE: AtomicU64 = AtomicU64::new(0);
 pub fn unique_seed() -> NetworkSeed {
     let id = TEST_INSTANCE.fetch_add(1, Ordering::SeqCst);
     format!("test-{}-{}", std::process::id(), id).into()
+}
+
+/// Load the NDO DNA with explicit clone coordinates: a network seed plus the
+/// serialized immutable Layer 0 properties. The same `(seed, properties)` pair
+/// always derives the same DnaHash — that hash IS the NDO's permanent identity
+/// (ADR-010). Different properties yield a different network by construction.
+pub async fn ndo_dna_with_coordinates(
+    seed: NetworkSeed,
+    properties: SerializedBytes,
+) -> DnaFile {
+    SweetDnaFile::from_bundle_with_overrides(
+        std::path::Path::new(NDO_DNA_PATH),
+        DnaModifiersOpt::none()
+            .with_network_seed(seed)
+            .with_properties(properties),
+    )
+    .await
+    .expect("Failed to load ndo DNA bundle. Did you run `bun run build:happ`?")
 }
 
 /// Spin up two conductors, each with the group DNA installed.

--- a/dnas/group/tests/src/ndo_anchor/mod.rs
+++ b/dnas/group/tests/src/ndo_anchor/mod.rs
@@ -1,0 +1,536 @@
+//! NDO-per-cell Sweettest integration tests (issue #112, ADR-010/ADR-011/ADR-012).
+//!
+//! Covers: DNA-hash-as-identity derivation, NDO cell genesis identity,
+//! NdoAnchor round trip in the group cell, cached descriptor sync, and the
+//! full join-via-anchor-coordinates flow.
+//!
+//! Prerequisites (runtime — not compile-time):
+//!   bun run build:happ   # builds group.dna and ndo.dna
+//!
+//! Run:
+//!   CARGO_TARGET_DIR=target/native-tests cargo test --package group_sweettest --test ndo_anchor
+
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use holochain_serialized_bytes::prelude::SerializedBytes;
+use serde::{Deserialize, Serialize};
+
+use group_sweettest::common::*;
+
+// ---------------------------------------------------------------------------
+// Local mirror types
+//
+// The test binary cannot import WASM-compiled zome crates. These types must
+// match the serialized form of their counterparts in the zomes.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum LifecycleStage {
+    Ideation,
+    Active,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum PropertyRegime {
+    Nondominium,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum ResourceNature {
+    Physical,
+}
+
+/// Immutable Layer 0 fields bound into the NDO clone's DNA properties (ADR-010).
+/// Changing any field yields a different DnaHash, i.e. a different network —
+/// immutability enforced by hash physics, not validation code.
+#[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
+struct NdoCellProperties {
+    pub name: String,
+    pub initiator: AgentPubKey,
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+    pub created_at: Timestamp,
+}
+
+/// Mirrors `zome_resource_coordinator::NdoInput`.
+#[derive(Debug, Serialize, Deserialize)]
+struct NdoInput {
+    pub name: String,
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+    pub lifecycle_stage: LifecycleStage,
+    pub description: Option<String>,
+}
+
+/// Mirrors `zome_resource_integrity::NondominiumIdentity`.
+#[derive(Debug, Serialize, Deserialize)]
+struct NdoEntry {
+    pub name: String,
+    pub initiator: AgentPubKey,
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+    pub lifecycle_stage: LifecycleStage,
+    pub created_at: Timestamp,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub successor_ndo_hash: Option<ActionHash>,
+    #[serde(default)]
+    pub hibernation_origin: Option<LifecycleStage>,
+}
+
+/// Mirrors `zome_resource_coordinator::NdoOutput`.
+#[derive(Debug, Serialize, Deserialize)]
+struct NdoOutput {
+    pub action_hash: ActionHash,
+    pub entry: NdoEntry,
+}
+
+/// Mirrors `zome_group_coordinator::NdoAnchorInput`.
+#[derive(Debug, Serialize, Deserialize)]
+struct NdoAnchorInput {
+    pub group_hash: ActionHash,
+    pub name: String,
+    pub description: Option<String>,
+    pub ndo_dna_hash: DnaHash,
+    pub network_seed: String,
+    pub identity_action_hash: ActionHash,
+    pub initiator: AgentPubKey,
+    pub ndo_created_at: Timestamp,
+    pub lifecycle_stage: LifecycleStage,
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+}
+
+/// Mirrors `zome_group_integrity::NdoAnchor`.
+#[derive(Debug, Serialize, Deserialize)]
+struct NdoAnchorEntry {
+    pub group_hash: ActionHash,
+    pub name: String,
+    pub description: Option<String>,
+    pub ndo_dna_hash: DnaHash,
+    pub network_seed: String,
+    pub identity_action_hash: ActionHash,
+    pub initiator: AgentPubKey,
+    pub ndo_created_at: Timestamp,
+    pub lifecycle_stage: LifecycleStage,
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+}
+
+/// Mirrors `zome_group_coordinator::UpdateNdoAnchorInput`.
+#[derive(Debug, Serialize, Deserialize)]
+struct UpdateNdoAnchorInput {
+    pub original_action_hash: ActionHash,
+    pub previous_action_hash: ActionHash,
+    pub updated_name: String,
+    pub updated_description: Option<String>,
+    pub updated_lifecycle_stage: LifecycleStage,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct GroupProfileInput {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn decode_record_entry<T: serde::de::DeserializeOwned + std::fmt::Debug>(record: &Record) -> T {
+    match record.entry().as_option() {
+        Some(Entry::App(app_bytes)) => {
+            holochain_serialized_bytes::decode(app_bytes.bytes())
+                .expect("entry deserialization failed")
+        }
+        _ => panic!("expected Present App entry"),
+    }
+}
+
+fn sample_properties(initiator: AgentPubKey) -> NdoCellProperties {
+    NdoCellProperties {
+        name: "Community 3D Printer".to_string(),
+        initiator,
+        property_regime: PropertyRegime::Nondominium,
+        resource_nature: ResourceNature::Physical,
+        created_at: Timestamp::from_micros(1_752_900_000_000_000),
+    }
+}
+
+fn properties_bytes(props: &NdoCellProperties) -> SerializedBytes {
+    SerializedBytes::try_from(props.clone()).expect("properties serialization failed")
+}
+
+async fn create_group(conductor: &SweetConductor, cell: &SweetCell, name: &str) -> ActionHash {
+    let record: Record = conductor
+        .call(
+            &cell.zome("zome_group"),
+            "create_group",
+            GroupProfileInput {
+                name: name.to_string(),
+                description: None,
+            },
+        )
+        .await;
+    record.action_address().clone()
+}
+
+fn anchor_input_from(
+    group_hash: ActionHash,
+    dna_hash: DnaHash,
+    seed: &str,
+    identity_action_hash: ActionHash,
+    props: &NdoCellProperties,
+) -> NdoAnchorInput {
+    NdoAnchorInput {
+        group_hash,
+        name: props.name.clone(),
+        description: None,
+        ndo_dna_hash: dna_hash,
+        network_seed: seed.to_string(),
+        identity_action_hash,
+        initiator: props.initiator.clone(),
+        ndo_created_at: props.created_at,
+        lifecycle_stage: LifecycleStage::Ideation,
+        property_regime: props.property_regime.clone(),
+        resource_nature: props.resource_nature.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// ADR-010 identity by physics: the same (seed, properties) coordinates always
+/// derive the same DnaHash; different properties derive a different one.
+#[tokio::test(flavor = "multi_thread")]
+async fn same_coordinates_derive_same_dna_hash() {
+    let seed = unique_seed();
+    let fake_initiator = AgentPubKey::from_raw_36(vec![7; 36]);
+    let props = sample_properties(fake_initiator.clone());
+
+    let dna_a = ndo_dna_with_coordinates(seed.clone(), properties_bytes(&props)).await;
+    let dna_b = ndo_dna_with_coordinates(seed.clone(), properties_bytes(&props)).await;
+    assert_eq!(
+        dna_a.dna_hash(),
+        dna_b.dna_hash(),
+        "identical coordinates must derive identical DNA hashes"
+    );
+
+    let mut other_props = props.clone();
+    other_props.name = "A Different NDO".to_string();
+    let dna_c = ndo_dna_with_coordinates(seed, properties_bytes(&other_props)).await;
+    assert_ne!(
+        dna_a.dna_hash(),
+        dna_c.dna_hash(),
+        "changing an immutable Layer 0 property must yield a different network"
+    );
+}
+
+/// The NDO cell hosts the existing zome_resource code: the genesis
+/// NondominiumIdentity is created inside the cell and both members of the
+/// NDO network can read it.
+#[tokio::test(flavor = "multi_thread")]
+async fn ndo_cell_genesis_identity_round_trip() {
+    let mut conductors =
+        SweetConductorBatch::from_config_rendezvous(2, SweetConductorConfig::standard()).await;
+
+    let fake_initiator = AgentPubKey::from_raw_36(vec![9; 36]);
+    let props = sample_properties(fake_initiator);
+    let dna = ndo_dna_with_coordinates(unique_seed(), properties_bytes(&props)).await;
+
+    let apps = conductors
+        .setup_app("ndo", &[dna])
+        .await
+        .expect("Failed to install ndo app on conductors");
+    conductors.exchange_peer_info().await;
+    let ((cell_alice,), (cell_bob,)) = apps.into_tuples();
+
+    let created: NdoOutput = conductors[0]
+        .call(
+            &cell_alice.zome("zome_resource"),
+            "create_ndo",
+            NdoInput {
+                name: "Community 3D Printer".to_string(),
+                property_regime: PropertyRegime::Nondominium,
+                resource_nature: ResourceNature::Physical,
+                lifecycle_stage: LifecycleStage::Ideation,
+                description: None,
+            },
+        )
+        .await;
+
+    await_consistency_20_s([&cell_alice, &cell_bob])
+        .await
+        .unwrap();
+
+    let fetched: Option<NdoEntry> = conductors[1]
+        .call(
+            &cell_bob.zome("zome_resource"),
+            "get_ndo",
+            created.action_hash.clone(),
+        )
+        .await;
+
+    let fetched = fetched.expect("bob should read the genesis identity from the NDO cell");
+    assert_eq!(fetched.name, "Community 3D Printer");
+    assert_eq!(fetched.lifecycle_stage, LifecycleStage::Ideation);
+}
+
+/// Anchor round trip: alice anchors an NDO in the group cell; bob reads the
+/// anchor with the full clone coordinates, without joining any NDO cell.
+#[tokio::test(flavor = "multi_thread")]
+async fn ndo_anchor_round_trip() {
+    let (conductors, cell_alice, cell_bob) = setup_two_agents().await;
+    let group_hash = create_group(&conductors[0], &cell_alice, "Fablab").await;
+
+    let seed = unique_seed();
+    let props = sample_properties(cell_alice.agent_pubkey().clone());
+    let dna = ndo_dna_with_coordinates(seed.clone(), properties_bytes(&props)).await;
+    let fake_identity_hash = ActionHash::from_raw_36(vec![1; 36]);
+
+    let created: Record = conductors[0]
+        .call(
+            &cell_alice.zome("zome_group"),
+            "create_ndo_anchor",
+            anchor_input_from(
+                group_hash.clone(),
+                dna.dna_hash().clone(),
+                seed.as_ref(),
+                fake_identity_hash.clone(),
+                &props,
+            ),
+        )
+        .await;
+    let created_entry: NdoAnchorEntry = decode_record_entry(&created);
+    assert_eq!(created_entry.name, "Community 3D Printer");
+
+    await_consistency_20_s([&cell_alice, &cell_bob])
+        .await
+        .unwrap();
+
+    let anchors: Vec<Record> = conductors[1]
+        .call(
+            &cell_bob.zome("zome_group"),
+            "get_ndo_anchors",
+            group_hash.clone(),
+        )
+        .await;
+    assert_eq!(anchors.len(), 1, "bob should see exactly one anchor");
+
+    let anchor: NdoAnchorEntry = decode_record_entry(&anchors[0]);
+    assert_eq!(anchor.group_hash, group_hash);
+    assert_eq!(anchor.ndo_dna_hash, dna.dna_hash().clone());
+    assert_eq!(anchor.network_seed, String::from(seed.clone()));
+    assert_eq!(anchor.identity_action_hash, fake_identity_hash);
+    assert_eq!(anchor.lifecycle_stage, LifecycleStage::Ideation);
+}
+
+/// update_ndo_anchor refreshes the cached descriptor (lifecycle stage) while
+/// the identity coordinates stay immutable, and get_ndo_anchors resolves the
+/// update chain to the latest version.
+#[tokio::test(flavor = "multi_thread")]
+async fn ndo_anchor_update_refreshes_cache() {
+    let (conductors, cell_alice, cell_bob) = setup_two_agents().await;
+    let group_hash = create_group(&conductors[0], &cell_alice, "Fablab").await;
+
+    let seed = unique_seed();
+    let props = sample_properties(cell_alice.agent_pubkey().clone());
+    let dna = ndo_dna_with_coordinates(seed.clone(), properties_bytes(&props)).await;
+
+    let created: Record = conductors[0]
+        .call(
+            &cell_alice.zome("zome_group"),
+            "create_ndo_anchor",
+            anchor_input_from(
+                group_hash.clone(),
+                dna.dna_hash().clone(),
+                seed.as_ref(),
+                ActionHash::from_raw_36(vec![2; 36]),
+                &props,
+            ),
+        )
+        .await;
+    let original_hash = created.action_address().clone();
+
+    let _updated: Record = conductors[0]
+        .call(
+            &cell_alice.zome("zome_group"),
+            "update_ndo_anchor",
+            UpdateNdoAnchorInput {
+                original_action_hash: original_hash.clone(),
+                previous_action_hash: original_hash.clone(),
+                updated_name: "Community 3D Printer".to_string(),
+                updated_description: Some("Now in active use".to_string()),
+                updated_lifecycle_stage: LifecycleStage::Active,
+            },
+        )
+        .await;
+
+    await_consistency_20_s([&cell_alice, &cell_bob])
+        .await
+        .unwrap();
+
+    let anchors: Vec<Record> = conductors[1]
+        .call(
+            &cell_bob.zome("zome_group"),
+            "get_ndo_anchors",
+            group_hash,
+        )
+        .await;
+    assert_eq!(anchors.len(), 1);
+
+    let anchor: NdoAnchorEntry = decode_record_entry(&anchors[0]);
+    assert_eq!(
+        anchor.lifecycle_stage,
+        LifecycleStage::Active,
+        "get_ndo_anchors must resolve to the latest cached descriptor"
+    );
+    assert_eq!(anchor.description, Some("Now in active use".to_string()));
+    assert_eq!(
+        anchor.ndo_dna_hash,
+        dna.dna_hash().clone(),
+        "identity coordinates must survive cache updates unchanged"
+    );
+}
+
+/// Integrity validation rejects an anchor with an empty name.
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic]
+async fn ndo_anchor_validation_rejects_empty_name() {
+    let (conductors, cell_alice, _cell_bob) = setup_two_agents().await;
+    let group_hash = create_group(&conductors[0], &cell_alice, "Fablab").await;
+
+    let seed = unique_seed();
+    let props = sample_properties(cell_alice.agent_pubkey().clone());
+    let dna = ndo_dna_with_coordinates(seed.clone(), properties_bytes(&props)).await;
+
+    let mut input = anchor_input_from(
+        group_hash,
+        dna.dna_hash().clone(),
+        seed.as_ref(),
+        ActionHash::from_raw_36(vec![3; 36]),
+        &props,
+    );
+    input.name = "   ".to_string();
+
+    // Sweettest panics on zome-call error — the Invalid validation result.
+    let _record: Record = conductors[0]
+        .call(&cell_alice.zome("zome_group"), "create_ndo_anchor", input)
+        .await;
+}
+
+/// The full fractal flow (design doc section 4.4): alice provisions an NDO
+/// cell, writes the genesis identity inside, and anchors it in the group cell.
+/// Bob reads the anchor, re-derives the clone from the anchor's coordinates,
+/// verifies the DnaHash pinning check, joins the NDO network, and reads the
+/// genesis identity — proving the anchor alone is sufficient to engage an NDO.
+#[tokio::test(flavor = "multi_thread")]
+async fn second_agent_joins_ndo_via_anchor_coordinates() {
+    let (mut conductors, cell_alice, cell_bob) = setup_two_agents().await;
+    let group_hash = create_group(&conductors[0], &cell_alice, "Fablab").await;
+
+    // Alice provisions the NDO cell with immutable Layer 0 fields in DNA properties.
+    let seed = unique_seed();
+    let props = sample_properties(cell_alice.agent_pubkey().clone());
+    let ndo_dna = ndo_dna_with_coordinates(seed.clone(), properties_bytes(&props)).await;
+    let ndo_dna_hash = ndo_dna.dna_hash().clone();
+
+    let alice_ndo_app = conductors
+        .iter_mut()
+        .next()
+        .unwrap()
+        .setup_app("ndo-alice", &[ndo_dna])
+        .await
+        .expect("alice failed to install the NDO cell");
+    let (alice_ndo_cell,) = alice_ndo_app.into_tuple();
+
+    // Genesis identity inside the NDO cell (existing zome_resource code path).
+    let genesis: NdoOutput = conductors[0]
+        .call(
+            &alice_ndo_cell.zome("zome_resource"),
+            "create_ndo",
+            NdoInput {
+                name: props.name.clone(),
+                property_regime: props.property_regime.clone(),
+                resource_nature: props.resource_nature.clone(),
+                lifecycle_stage: LifecycleStage::Ideation,
+                description: None,
+            },
+        )
+        .await;
+
+    // Anchor in the group cell, carrying the full clone coordinates.
+    let _anchor: Record = conductors[0]
+        .call(
+            &cell_alice.zome("zome_group"),
+            "create_ndo_anchor",
+            anchor_input_from(
+                group_hash.clone(),
+                ndo_dna_hash.clone(),
+                seed.as_ref(),
+                genesis.action_hash.clone(),
+                &props,
+            ),
+        )
+        .await;
+
+    await_consistency_20_s([&cell_alice, &cell_bob])
+        .await
+        .unwrap();
+
+    // Bob reads the anchor from the group cell.
+    let anchors: Vec<Record> = conductors[1]
+        .call(&cell_bob.zome("zome_group"), "get_ndo_anchors", group_hash)
+        .await;
+    let anchor: NdoAnchorEntry = decode_record_entry(&anchors[0]);
+
+    // Bob reconstructs the DNA properties from the anchor fields and re-derives
+    // the clone. The pinning check: the derived DnaHash must equal the anchored one.
+    let reconstructed = NdoCellProperties {
+        name: anchor.name.clone(),
+        initiator: anchor.initiator.clone(),
+        property_regime: anchor.property_regime.clone(),
+        resource_nature: anchor.resource_nature.clone(),
+        created_at: anchor.ndo_created_at,
+    };
+    let bob_ndo_dna = ndo_dna_with_coordinates(
+        anchor.network_seed.clone().into(),
+        properties_bytes(&reconstructed),
+    )
+    .await;
+    assert_eq!(
+        bob_ndo_dna.dna_hash().clone(),
+        anchor.ndo_dna_hash,
+        "pinning check failed: derived DnaHash does not match the anchored identity"
+    );
+
+    let bob_ndo_app = conductors
+        .iter_mut()
+        .nth(1)
+        .unwrap()
+        .setup_app("ndo-bob", &[bob_ndo_dna])
+        .await
+        .expect("bob failed to join the NDO cell from anchor coordinates");
+    let (bob_ndo_cell,) = bob_ndo_app.into_tuple();
+
+    conductors.exchange_peer_info().await;
+    await_consistency_20_s([&alice_ndo_cell, &bob_ndo_cell])
+        .await
+        .unwrap();
+
+    // Bob reads the genesis identity inside the NDO network he joined.
+    let fetched: Option<NdoEntry> = conductors[1]
+        .call(
+            &bob_ndo_cell.zome("zome_resource"),
+            "get_ndo",
+            anchor.identity_action_hash.clone(),
+        )
+        .await;
+    let fetched = fetched.expect("bob should read the genesis identity via anchor coordinates");
+    assert_eq!(fetched.name, props.name);
+    // Sweettest generates a fresh agent key per installed app, so the genesis
+    // initiator is the NDO cell's agent, not the group cell's. In production the
+    // clone shares the app's agent key, so both would be the same key.
+    assert_eq!(fetched.initiator, *alice_ndo_cell.agent_pubkey());
+}

--- a/dnas/group/zomes/coordinator/zome_group/src/lib.rs
+++ b/dnas/group/zomes/coordinator/zome_group/src/lib.rs
@@ -3,11 +3,13 @@ pub use nondominium_shared::GroupError;
 
 pub mod group_profile;
 pub mod membership;
+pub mod ndo_anchor;
 pub mod soft_link;
 pub mod work_log;
 
 pub use group_profile::*;
 pub use membership::*;
+pub use ndo_anchor::*;
 pub use soft_link::*;
 pub use work_log::*;
 

--- a/dnas/group/zomes/coordinator/zome_group/src/ndo_anchor.rs
+++ b/dnas/group/zomes/coordinator/zome_group/src/ndo_anchor.rs
@@ -1,0 +1,152 @@
+use crate::GroupError;
+use hdk::prelude::*;
+use nondominium_shared::LifecycleStage;
+use zome_group_integrity::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NdoAnchorInput {
+  pub group_hash: ActionHash,
+  pub name: String,
+  pub description: Option<String>,
+  pub ndo_dna_hash: DnaHash,
+  pub network_seed: String,
+  pub identity_action_hash: ActionHash,
+  pub initiator: AgentPubKey,
+  pub ndo_created_at: Timestamp,
+  pub lifecycle_stage: LifecycleStage,
+  pub property_regime: nondominium_shared::PropertyRegime,
+  pub resource_nature: nondominium_shared::ResourceNature,
+}
+
+/// Anchors an NDO cell in this group's DHT (ADR-011: anchors in Group DHTs,
+/// not a global registry). The anchor is the authoritative group-to-NDO pointer;
+/// its `(ndo_dna_hash, network_seed, properties)` coordinates let any group member
+/// derive, verify, and join the NDO network. Anchor author and timestamp come
+/// from the action header.
+#[hdk_extern]
+pub fn create_ndo_anchor(input: NdoAnchorInput) -> ExternResult<Record> {
+  let anchor = NdoAnchor {
+    group_hash: input.group_hash.clone(),
+    name: input.name,
+    description: input.description,
+    ndo_dna_hash: input.ndo_dna_hash,
+    network_seed: input.network_seed,
+    identity_action_hash: input.identity_action_hash,
+    initiator: input.initiator,
+    ndo_created_at: input.ndo_created_at,
+    lifecycle_stage: input.lifecycle_stage,
+    property_regime: input.property_regime,
+    resource_nature: input.resource_nature,
+  };
+
+  let anchor_hash = create_entry(&EntryTypes::NdoAnchor(anchor))?;
+  let record = get(anchor_hash.clone(), GetOptions::default())?.ok_or(
+    GroupError::EntryOperationFailed("Failed to retrieve created NDO anchor".to_string()),
+  )?;
+
+  create_link(
+    input.group_hash,
+    anchor_hash,
+    LinkTypes::GroupToNdoAnchors,
+    (),
+  )?;
+
+  Ok(record)
+}
+
+/// Returns the latest Record for every NdoAnchor in a group, resolving the
+/// NdoAnchorUpdates chain so cached descriptor fields reflect the most recent
+/// sync. Browsing NDOs never requires joining their cells — anchors carry
+/// enough cached data to render cards.
+#[hdk_extern]
+pub fn get_ndo_anchors(group_hash: ActionHash) -> ExternResult<Vec<Record>> {
+  let link_query = LinkQuery::try_new(group_hash, LinkTypes::GroupToNdoAnchors)?;
+  let links = get_links(link_query, GetStrategy::default())?;
+
+  let mut anchors = Vec::new();
+  for link in links {
+    let Some(original_hash) = link.target.into_action_hash() else {
+      continue;
+    };
+    let Some(record) = latest_anchor_record(original_hash)? else {
+      continue;
+    };
+    anchors.push(record);
+  }
+
+  Ok(anchors)
+}
+
+/// Resolves an anchor's original action hash to its most recent version by
+/// following NdoAnchorUpdates links (latest by action timestamp).
+fn latest_anchor_record(original_hash: ActionHash) -> ExternResult<Option<Record>> {
+  let update_links = get_links(
+    LinkQuery::try_new(original_hash.clone(), LinkTypes::NdoAnchorUpdates)?,
+    GetStrategy::default(),
+  )?;
+
+  let latest_hash = update_links
+    .into_iter()
+    .max_by_key(|link| link.timestamp)
+    .and_then(|link| link.target.into_action_hash())
+    .unwrap_or(original_hash);
+
+  get(latest_hash, GetOptions::default())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateNdoAnchorInput {
+  /// Action hash of the very first create action — used as the stable link source.
+  pub original_action_hash: ActionHash,
+  /// Action hash of the create (or previous update) action to be superseded.
+  pub previous_action_hash: ActionHash,
+  pub updated_name: String,
+  pub updated_description: Option<String>,
+  pub updated_lifecycle_stage: LifecycleStage,
+}
+
+/// Refreshes an anchor's cached descriptor fields (name, description, lifecycle
+/// stage). The NDO identity coordinates (ndo_dna_hash, network_seed,
+/// identity_action_hash, initiator, ndo_created_at, regime, nature) are copied
+/// from the original entry — they are immutable by construction, matching the
+/// immutability the DNA properties enforce inside the NDO cell.
+#[hdk_extern]
+pub fn update_ndo_anchor(input: UpdateNdoAnchorInput) -> ExternResult<Record> {
+  let original_record = must_get_valid_record(input.original_action_hash.clone())?;
+
+  let original: NdoAnchor = original_record
+    .entry()
+    .to_app_option()
+    .map_err(|e| wasm_error!(WasmErrorInner::Serialize(e)))?
+    .ok_or_else(|| {
+      GroupError::EntryOperationFailed("Failed to decode NdoAnchor entry".to_string())
+    })?;
+
+  let updated = NdoAnchor {
+    group_hash: original.group_hash,
+    name: input.updated_name,
+    description: input.updated_description,
+    ndo_dna_hash: original.ndo_dna_hash,
+    network_seed: original.network_seed,
+    identity_action_hash: original.identity_action_hash,
+    initiator: original.initiator,
+    ndo_created_at: original.ndo_created_at,
+    lifecycle_stage: input.updated_lifecycle_stage,
+    property_regime: original.property_regime,
+    resource_nature: original.resource_nature,
+  };
+
+  let updated_hash = update_entry(input.previous_action_hash, &updated)?;
+  let record = get(updated_hash.clone(), GetOptions::default())?.ok_or(
+    GroupError::EntryOperationFailed("Failed to retrieve updated NDO anchor".to_string()),
+  )?;
+
+  create_link(
+    input.original_action_hash,
+    updated_hash,
+    LinkTypes::NdoAnchorUpdates,
+    (),
+  )?;
+
+  Ok(record)
+}

--- a/dnas/group/zomes/integrity/zome_group_integrity/Cargo.toml
+++ b/dnas/group/zomes/integrity/zome_group_integrity/Cargo.toml
@@ -11,3 +11,4 @@ name = "zome_group_integrity"
 hdi = { workspace = true }
 serde = { workspace = true }
 holochain_serialized_bytes = { workspace = true }
+nondominium_shared = { workspace = true }

--- a/dnas/group/zomes/integrity/zome_group_integrity/src/lib.rs
+++ b/dnas/group/zomes/integrity/zome_group_integrity/src/lib.rs
@@ -1,6 +1,9 @@
 use hdi::prelude::*;
+use nondominium_shared::{LifecycleStage, PropertyRegime, ResourceNature};
 // AgentPubKey and Timestamp are not stored in entries — identity and timestamps
 // come from action headers (record.action().author() / record.action().timestamp()).
+// Exception: NdoAnchor carries the referenced NDO's initiator and created_at — those
+// describe the NDO (DNA property inputs), not the anchor's author.
 
 /// Public profile for a group within a cloned cell.
 /// Identity (initiator) and timestamp come from the action header — not stored in the entry.
@@ -42,6 +45,30 @@ pub struct SoftLink {
     pub description: Option<String>,
 }
 
+/// Authoritative pointer from a group to an NDO cell (one NDO = one cloned DHT cell).
+/// Fixes the bare-ActionHash weakness of SoftLink: the anchor carries the full
+/// `(ndo_dna_hash, network_seed)` coordinates plus the DNA property inputs
+/// (name, initiator, ndo_created_at, regime, nature), so any reader can re-derive
+/// the clone, verify `ndo_dna_hash` as a pinning check, and join the NDO network.
+/// `lifecycle_stage`, `name`, and `description` are best-effort caches for browsing;
+/// the source of truth is the NondominiumIdentity genesis entry inside the NDO cell.
+/// Anchor author and anchoring timestamp come from the action header.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct NdoAnchor {
+    pub group_hash: ActionHash,
+    pub name: String,                     // cached from DNA properties
+    pub description: Option<String>,
+    pub ndo_dna_hash: DnaHash,            // THE permanent NDO identity (ADR-010)
+    pub network_seed: String,             // needed to clone/join the cell
+    pub identity_action_hash: ActionHash, // Layer 0 genesis entry inside the NDO cell
+    pub initiator: AgentPubKey,           // DNA property input — the NDO's initiator
+    pub ndo_created_at: Timestamp,        // DNA property input — the NDO's creation time
+    pub lifecycle_stage: LifecycleStage,  // cached, best-effort synced
+    pub property_regime: PropertyRegime,  // immutable classification (DNA property)
+    pub resource_nature: ResourceNature,  // immutable classification (DNA property)
+}
+
 #[hdk_entry_types]
 #[unit_enum(UnitEntryTypes)]
 pub enum EntryTypes {
@@ -49,6 +76,7 @@ pub enum EntryTypes {
     GroupMembership(GroupMembership),
     WorkLog(WorkLog),
     SoftLink(SoftLink),
+    NdoAnchor(NdoAnchor),
 }
 
 #[hdk_link_types]
@@ -60,6 +88,8 @@ pub enum LinkTypes {
     GroupToWorkLogs, // GroupProfile → WorkLog
     AgentToWorkLogs, // AgentPubKey → WorkLog
     GroupToSoftLinks, // GroupProfile → SoftLink
+    GroupToNdoAnchors, // GroupProfile → NdoAnchor
+    NdoAnchorUpdates,  // NdoAnchor → NdoAnchor (cached descriptor sync)
 }
 
 #[hdk_extern]
@@ -92,6 +122,9 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                     }
                     EntryTypes::SoftLink(soft_link) => {
                         return validate_soft_link(soft_link);
+                    }
+                    EntryTypes::NdoAnchor(ndo_anchor) => {
+                        return validate_ndo_anchor(ndo_anchor);
                     }
                 }
             }
@@ -140,5 +173,27 @@ pub fn validate_work_log(work_log: WorkLog) -> ExternResult<ValidateCallbackResu
 pub fn validate_soft_link(_soft_link: SoftLink) -> ExternResult<ValidateCallbackResult> {
     // ActionHash is always 39 bytes; existence cannot be verified from the integrity
     // context. Semantic validation happens in the coordinator.
+    Ok(ValidateCallbackResult::Valid)
+}
+
+pub fn validate_ndo_anchor(ndo_anchor: NdoAnchor) -> ExternResult<ValidateCallbackResult> {
+    if ndo_anchor.name.trim().is_empty() {
+        return Ok(ValidateCallbackResult::Invalid(
+            "NdoAnchor name cannot be empty".to_string(),
+        ));
+    }
+    if ndo_anchor.name.len() > 100 {
+        return Ok(ValidateCallbackResult::Invalid(
+            "NdoAnchor name too long (max 100 characters)".to_string(),
+        ));
+    }
+    if ndo_anchor.network_seed.trim().is_empty() {
+        return Ok(ValidateCallbackResult::Invalid(
+            "NdoAnchor network_seed cannot be empty".to_string(),
+        ));
+    }
+    // The (ndo_dna_hash, network_seed, properties) coordinates cannot be verified from
+    // the integrity context — cross-cell verification is the reader's pinning check:
+    // re-derive the clone from the anchor fields and compare the resulting DnaHash.
     Ok(ValidateCallbackResult::Valid)
 }

--- a/dnas/ndo/workdir/dna.yaml
+++ b/dnas/ndo/workdir/dna.yaml
@@ -1,0 +1,25 @@
+---
+manifest_version: "0"
+name: ndo
+integrity:
+  network_seed: ~
+  properties: ~
+  zomes:
+    - name: zome_resource_integrity
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/zome_resource_integrity.wasm"
+    - name: zome_gouvernance_integrity
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/zome_gouvernance_integrity.wasm"
+coordinator:
+  zomes:
+    - name: zome_resource
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/zome_resource_coordinator.wasm"
+      dependencies:
+        - name: zome_resource_integrity
+    - name: zome_gouvernance
+      hash: ~
+      path: "../../../target/wasm32-unknown-unknown/release/zome_gouvernance_coordinator.wasm"
+      dependencies:
+        - name: zome_gouvernance_integrity

--- a/documentation/zomes/architecture_overview.md
+++ b/documentation/zomes/architecture_overview.md
@@ -22,7 +22,11 @@ Nondominium is a **multi-DNA Holochain hApp** implementing ValueFlows-compliant 
 
 **Group DNA** (cloned cell, `deferred: true`, `clone_limit: 64`)
 
-- **[`zome_group`](./group_zome.md)**: Per-group coordination with network isolation. Each group occupies its own cloned DHT provisioned via `clone_cell`. Entry types: `GroupProfile`, `GroupMembership`, `WorkLog`, `SoftLink`. See PR #107.
+- **[`zome_group`](./group_zome.md)**: Per-group coordination with network isolation. Each group occupies its own cloned DHT provisioned via `clone_cell`. Entry types: `GroupProfile`, `GroupMembership`, `WorkLog`, `SoftLink`, `NdoAnchor`. See PR #107 and issue #112.
+
+**NDO DNA** (cloned cell, `deferred: true`, `clone_limit: 512`)
+
+- **`ndo` role** (`dnas/ndo/workdir/dna.yaml`): one clone per NDO, completing the fractal Lobby → Group → NDO holarchy. Bundles the **existing** `zome_resource` and `zome_gouvernance` WASMs (ADR-012, no code fork). The NDO's immutable Layer 0 fields (name, initiator, property regime, resource nature, created_at) live in the clone's DNA properties, so the resulting `DnaHash` is the NDO's permanent, organization-agnostic identity (ADR-010); the `NondominiumIdentity` genesis entry inside the cell keeps the mutable lifecycle chain. Groups reference NDO cells through `NdoAnchor` entries carrying the full clone coordinates (ADR-011). See issue #112.
 
 ### Technology Foundation
 

--- a/documentation/zomes/group_zome.md
+++ b/documentation/zomes/group_zome.md
@@ -57,6 +57,27 @@ Link from a group to an NDO. This is the Group → NDO relationship in the `Lobb
 
 **Derived from action header**: created_by = `record.action().author()`, created_at = `record.action().timestamp()`.
 
+### `NdoAnchor`
+Authoritative pointer from the group to an NDO cell (one NDO = one cloned DHT cell, ADR-010/ADR-011). Fixes the bare-ActionHash weakness of `SoftLink`: the anchor carries the full clone coordinates — `(ndo_dna_hash, network_seed)` plus the DNA property inputs — so any reader can re-derive the clone, verify `ndo_dna_hash` as a pinning check, and join the NDO network. Browsing NDOs never requires joining their cells: anchors carry enough cached descriptor data to render cards. `SoftLink` survives as a planning-level reference to anything, including NDOs the group does not participate in.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `group_hash` | `ActionHash` | Parent group hash |
+| `name` | `String` | Cached from DNA properties (1–100 characters) |
+| `description` | `Option<String>` | Optional description |
+| `ndo_dna_hash` | `DnaHash` | THE permanent NDO identity (ADR-010) |
+| `network_seed` | `String` | Needed to clone/join the NDO cell (non-empty) |
+| `identity_action_hash` | `ActionHash` | Layer 0 genesis entry inside the NDO cell |
+| `initiator` | `AgentPubKey` | DNA property input — the NDO's initiator (not the anchor author) |
+| `ndo_created_at` | `Timestamp` | DNA property input — the NDO's creation time |
+| `lifecycle_stage` | `LifecycleStage` | Cached, best-effort synced via `update_ndo_anchor` |
+| `property_regime` | `PropertyRegime` | Immutable classification (DNA property) |
+| `resource_nature` | `ResourceNature` | Immutable classification (DNA property) |
+
+**Derived from action header**: anchored_by = `record.action().author()`, anchored_at = `record.action().timestamp()`.
+
+**Immutability split**: the identity coordinates (`ndo_dna_hash`, `network_seed`, `identity_action_hash`, `initiator`, `ndo_created_at`, regime, nature) are copied from the original entry on every update — only the cached descriptor fields (`name`, `description`, `lifecycle_stage`) are mutable.
+
 ## Link Types
 
 | Link type | Source | Target | Purpose |
@@ -68,6 +89,8 @@ Link from a group to an NDO. This is the Group → NDO relationship in the `Lobb
 | `GroupToWorkLogs` | `GroupProfile` | `WorkLog` | Work log enumeration |
 | `AgentToWorkLogs` | `AgentPubKey` | `WorkLog` | Per-agent work log lookup |
 | `GroupToSoftLinks` | `GroupProfile` | `SoftLink` | Soft link enumeration |
+| `GroupToNdoAnchors` | `GroupProfile` | `NdoAnchor` | NDO anchor enumeration |
+| `NdoAnchorUpdates` | `NdoAnchor` | `NdoAnchor` | Cached descriptor version chain |
 
 ## Coordinator Functions
 
@@ -106,11 +129,21 @@ Link from a group to an NDO. This is the Group → NDO relationship in the `Lobb
 | `get_soft_links` | `ActionHash` (group hash) | `Vec<Record>` | Returns Records for all soft links; creator = `record.action().author()` |
 | `delete_soft_link` | `ActionHash` (soft link hash) | `ActionHash` | Removes the `GroupToSoftLinks` discovery link and deletes the entry; only the original creator may call this |
 
+### NDO Anchors
+
+| Function | Input | Output | Description |
+|----------|-------|--------|-------------|
+| `create_ndo_anchor` | `NdoAnchorInput { group_hash, name, description, ndo_dna_hash, network_seed, identity_action_hash, initiator, ndo_created_at, lifecycle_stage, property_regime, resource_nature }` | `Record` | Anchors an NDO cell in this group's DHT with full clone coordinates |
+| `get_ndo_anchors` | `ActionHash` (group hash) | `Vec<Record>` | Returns the latest Record per anchor, resolving the `NdoAnchorUpdates` chain |
+| `update_ndo_anchor` | `UpdateNdoAnchorInput { original_action_hash, previous_action_hash, updated_name, updated_description, updated_lifecycle_stage }` | `Record` | Refreshes cached descriptor fields; identity coordinates are copied from the original entry |
+
 ## Validation Rules
 
 - `GroupProfile.name` must be non-empty and ≤ 100 characters
 - `WorkLog.description` must be non-empty
 - `WorkLog.hours` must be > 0
+- `NdoAnchor.name` must be non-empty and ≤ 100 characters
+- `NdoAnchor.network_seed` must be non-empty
 
 > Hash fields (`group_hash`, `target_ndo_hash`) are always 39 bytes and cannot be "empty". Existence of the referenced entry is validated at the coordinator level, not in the integrity zome (which has no DHT access).
 
@@ -135,20 +168,27 @@ Domain errors are defined in `nondominium_shared::GroupError`:
 
 **ADR-GROUP-04**: `WorkLog` and `SoftLink` entries are planning-only and do not generate `EconomicEvent` entries or PPRs. Generating PPRs for planning-level actions would misrepresent intent and inflate reputation counts.
 
+**ADR-010 / ADR-011 (NDO-per-cell)**: one NDO = one cloned cell of the `ndo` DNA (`dnas/ndo/workdir/dna.yaml`, bundling the existing `zome_resource` and `zome_gouvernance` WASMs). The NDO's immutable Layer 0 fields live in the clone's DNA properties, so the `DnaHash` is the permanent, organization-agnostic NDO identity. Groups hold `NdoAnchor` entries instead of a global NDO registry; the Lobby stays a group registry.
+
 ## Testing
 
-Tests live in `dnas/group/tests/src/group/mod.rs`. All tests use `setup_two_agents()` from `common::conductors` and `await_consistency_20_s` for cross-agent DHT sync.
+Tests live in `dnas/group/tests/src/group/mod.rs` (group lifecycle) and `dnas/group/tests/src/ndo_anchor/mod.rs` (NDO-per-cell + anchors). All tests use `setup_two_agents()` / `ndo_dna_with_coordinates()` from `common::conductors` and `await_consistency_20_s` for cross-agent DHT sync.
 
-Test coverage: group creation, `get_group` (fetch by hash), `get_my_group`, membership (join/leave/is_member/duplicate-join error), work logs (`log_work`, `get_work_logs`, `get_my_work_logs`, `delete_work_log`), soft links (`create_soft_link`, `get_soft_links`, `delete_soft_link`), `update_group`, and validation rejection cases (empty name, zero hours). 13 tests total — `--test-threads 6` required to avoid port exhaustion.
+Group target coverage: group creation, `get_group` (fetch by hash), `get_my_group`, membership (join/leave/is_member/duplicate-join error), work logs (`log_work`, `get_work_logs`, `get_my_work_logs`, `delete_work_log`), soft links (`create_soft_link`, `get_soft_links`, `delete_soft_link`), `update_group`, and validation rejection cases (empty name, zero hours). 13 tests — `--test-threads 6` required to avoid port exhaustion.
+
+NDO anchor target coverage: DNA-hash-as-identity derivation (same coordinates → same hash, different properties → different network), genesis identity round trip inside an NDO cell, anchor round trip with clone coordinates, cached descriptor update chain, empty-name validation rejection, and the full second-agent join-via-anchor-coordinates flow with the DnaHash pinning check. 6 tests.
 
 ```bash
 # Prerequisites
 bun run build:happ
 
-# Run all group tests (thread-limited — 12 tests × 2 conductors each)
+# Run all group tests (thread-limited — 13 tests × 2 conductors each)
 CARGO_TARGET_DIR=target/native-tests cargo test --package group_sweettest --test group -- --test-threads 6
+
+# Run the NDO anchor / NDO-per-cell tests
+CARGO_TARGET_DIR=target/native-tests cargo test --package group_sweettest --test ndo_anchor -- --test-threads 6
 
 # Run a specific test
 CARGO_TARGET_DIR=target/native-tests cargo test --package group_sweettest --test group create_group_returns_profile
-CARGO_TARGET_DIR=target/native-tests cargo test --package group_sweettest --test group get_group_by_hash
+CARGO_TARGET_DIR=target/native-tests cargo test --package group_sweettest --test ndo_anchor second_agent_joins_ndo_via_anchor_coordinates
 ```

--- a/workdir/happ.yaml
+++ b/workdir/happ.yaml
@@ -47,3 +47,14 @@ roles:
         properties: ~
         origin_time: 1716323893645
       clone_limit: 64  # Hard ceiling per conductor: max 64 groups per agent install
+  - name: ndo
+    provisioning:
+      strategy: create
+      deferred: true  # One clone per NDO, created on demand; immutable Layer 0 fields go in clone DNA properties (ADR-010)
+    dna:
+      path: "../dnas/ndo/workdir/ndo.dna"
+      modifiers:
+        network_seed: ~
+        properties: ~
+        origin_time: 1716323893645
+      clone_limit: 512  # Hard ceiling per conductor: max 512 engaged NDO cells per agent install


### PR DESCRIPTION
## Summary

Implements Phase A (backend pilot) of the approved NDO-per-cell architecture: **one NDO = one cloned DHT cell**, completing the fractal Lobby → Group → NDO holarchy. Implements #112 (child of epic #78); unblocks the amended #110 UI cutover.

**Key mechanism (ADR-010):** the NDO's immutable Layer 0 fields live in the clone's DNA properties, so the resulting `DnaHash` is unique per NDO and cryptographically bound to its identity. Immutability is enforced by hash physics; the `DnaHash` becomes the NDO's permanent, organization-agnostic identifier. The `NondominiumIdentity` genesis entry lives inside the cell and keeps the mutable lifecycle chain.

## Changes

- **`dnas/ndo/workdir/dna.yaml`** (new): `ndo` DNA bundling the **existing** `zome_resource` and `zome_gouvernance` WASMs, integrity and coordinator. No Rust changes to those zomes (ADR-012). `zome_person`, hREA bridge, and `misc` stay out of NDO cells.
- **`workdir/happ.yaml`**: `ndo` role, `deferred: true`, `clone_limit: 512` (packed automatically by the existing recursive `hc app pack`).
- **`zome_group`**: new `NdoAnchor` entry type (appended last in `EntryTypes` — existing entry indices preserved) with the full clone coordinates (`ndo_dna_hash`, `network_seed`, `identity_action_hash`, `initiator`, `ndo_created_at`, regime, nature) plus cached descriptor fields (`name`, `description`, `lifecycle_stage`). Link types `GroupToNdoAnchors` and `NdoAnchorUpdates`. Externs `create_ndo_anchor`, `get_ndo_anchors` (resolves the update chain), `update_ndo_anchor` (cache-only mutation; identity coordinates copied from the original entry). This fixes the bare-ActionHash weakness of `SoftLink` (ADR-011): any reader can re-derive the clone from the anchor and verify the `DnaHash` as a pinning check. `SoftLink` survives as a planning-level reference.
- **Sweettest** (`dnas/group/tests/src/ndo_anchor/mod.rs`, 6 tests): identity-by-physics derivation (same coordinates → same hash; changed property → different network), genesis identity round trip inside an NDO cell, anchor round trip, cached descriptor sync, empty-name validation rejection, and the full flow — a second agent joins the NDO network from anchor coordinates alone, passing the DnaHash pinning check, and reads the genesis identity.
- **Docs**: `group_zome.md` (NdoAnchor entry, links, externs, tests) and `architecture_overview.md` (ndo role in the DNA topology).

## Design refinements vs the architecture doc

- `NdoAnchor` additionally carries `initiator` and `ndo_created_at`: joiners must reconstruct the full DNA properties from the anchor, and those two identity fields are property inputs. They describe the NDO, not the anchor author (the zome_group header convention still applies: anchor author/timestamp come from the action header, so the doc's `anchored_by`/`anchored_at` fields are covered there).
- Identity coordinates are immutable across `update_ndo_anchor` by construction (copied from the original entry), mirroring the immutability the DNA properties enforce inside the cell.

## Known pilot limitations (documented in #112)

- `zome_gouvernance` role-check paths that cross-zome call `zome_person` (contribution/agreement) will error inside NDO cells; not exercised by the Phase A surface, resolved with the governance-as-operator track (#41 to #45).
- DNA-properties validation in the integrity zome (genesis entry must match properties) is a Phase D fast follow.
- Open decision (design doc section 10, question 3): retirement of the legacy shared-DHT NDO view is Phase C and intentionally untouched here — all shared-DHT NDO code paths remain functional.

## Verification

- `bun run build:happ` exits 0 and packs `dnas/ndo/workdir/ndo.dna`
- New suite: `cargo test -p group_sweettest --test ndo_anchor` — 6/6 passed
- Regression: `cargo test -p group_sweettest --test group -- --test-threads 6` — 13/13 passed

Closes #112. Refs #78, #110 (amended — see the amendment comment there), design doc ADR-010/011/012.
