### PR TITLE
docs: retrofit architecture documentation to multi-DNA reality (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,25 @@ Built on the Holochain framework and using the ValueFlows standard, nondominium 
 
 ## Overview
 
-Nondominium is a 3-zome Holochain hApp that enables decentralized resource sharing through:
+Nondominium is a multi-DNA Holochain hApp that enables decentralized resource sharing through:
 
 - **Agent identity management** with role-based access control
 - **Resource lifecycle tracking** following ValueFlows standards
 - **Embedded governance** for access and transfer rules
 - **Capability-based security** using Holochain's native features
+- **A fractal Lobby → Group → NDO holarchy** of DHT networks
 
 ### Architecture
 
-**Governance-as-Operator Design:**
+**Multi-DNA topology:**
+
+- **Nondominium DNA** (provisioned, shared): the 3-zome core described below
+- **Lobby DNA** (provisioned, fixed network seed): permissionless entry point — agent presence (`LobbyAgentProfile`) and the global group registry (`GroupAnnouncement`)
+- **Group DNA** (cloned cell per group, `deferred: true`): per-group coordination with network isolation — `GroupProfile`, `GroupMembership`, `WorkLog`, `SoftLink`
+- **NDO DNA** (cloned cell per NDO, `deferred: true`): one DHT network per Nondominium Object, bundling the existing resource and governance zomes; the clone's DNA hash is the NDO's permanent identity (issue #112)
+- **hREA DNA** (vendored): canonical ValueFlows event recording via the hREA bridge
+
+**Governance-as-Operator Design (Nondominium DNA core):**
 
 nondominium implements a modular governance-as-operator architecture that separates data management from business logic enforcement:
 
@@ -166,10 +175,15 @@ All zomes follow consistent patterns for:
 
 **Primary: Sweettest (Rust)**
 
-All new tests are written in Sweettest (`dnas/nondominium/tests/src/`). Shared setup utilities:
+All new tests are written in Sweettest. Each DNA has its own suite:
 
-- `setup_two_agents()` — two conductors, nondominium DNA
-- `setup_three_agents()` — three conductors, nondominium DNA
+- `dnas/nondominium/tests/` (`nondominium_sweettest`) — person, resource, governance, NDO Layer 0, hREA bridge
+- `dnas/lobby/tests/` (`lobby_sweettest`) — lobby agent profiles and group announcements
+- `dnas/group/tests/` (`group_sweettest`) — group lifecycle, membership, work logs, soft links, NDO anchors
+
+Shared setup utilities (per suite `common::conductors`):
+
+- `setup_two_agents()` / `setup_three_agents()` — multi-conductor setups for the suite's DNA
 - `setup_dual_dna_two_agents()` — two conductors, nondominium + hREA DNAs
 
 **Deprecated: Tryorama (TypeScript)**
@@ -193,8 +207,10 @@ This generates:
 
 - ✅ **Phase 1 (Backend)**: Person management, resource specifications, economic resources, governance foundation, PPR data structures, hREA Person/ReaAgent bridge, NDO Layer 0 identity anchor
 - ✅ **MVP UI**: Lobby → Group → NDO three-level hierarchy with three-level identity model, NDO creation, lifecycle transitions, filter browser, fork friction modal
-- 🔄 **Phase 2 (In Progress)**: Economic processes (Use/Transport/Storage/Repair), PPR receipt generation, governance-as-operator architecture, agent promotion workflows
-- 📋 **Post-MVP**: Group DNA backend, NDO cell cloning, PPR reputation UI, Unyt/Flowsta integrations
+- ✅ **Lobby DNA** (#103): agent presence + global group registry, with Sweettest suite
+- ✅ **Group DNA** (#107): per-group cloned-cell coordination DHT, with Sweettest suite; DHT-backed group UI (#111)
+- 🔄 **Phase 2 (In Progress)**: NDO-per-cell architecture (#112: NDO DNA role, NdoAnchor), economic processes (Use/Transport/Storage/Repair), PPR receipt generation, governance-as-operator architecture, agent promotion workflows
+- 📋 **Post-MVP**: PPR reputation UI, Unyt/Flowsta integrations, cross-cell reputation aggregation
 
 ## Documentation
 

--- a/documentation/ARCHITECTURE_COMPONENTS.md
+++ b/documentation/ARCHITECTURE_COMPONENTS.md
@@ -9,7 +9,15 @@
 
 ## 🎯 Executive Summary
 
-Nondominium implements a sophisticated **3-zome Holochain architecture** that enables distributed resource sharing with embedded governance, capability-based security, and cryptographically-secured reputation tracking. The system supports **four structured Economic Processes** (Use, Transport, Storage, Repair) with role-based access control and **14-category PPR reputation system** for trustworthy agent interactions.
+Nondominium implements a **multi-DNA Holochain architecture** that enables distributed resource sharing with embedded governance, capability-based security, and cryptographically-secured reputation tracking. The hApp composes five DNA roles into a fractal **Lobby → Group → NDO** holarchy:
+
+- **Nondominium DNA** (provisioned, shared): the 3-zome core (`zome_person`, `zome_resource`, `zome_gouvernance`) detailed throughout this document
+- **Lobby DNA** (provisioned, fixed network seed): permissionless entry point — agent presence and the global group registry (PR #103; see `zomes/lobby_zome.md`)
+- **Group DNA** (one cloned cell per group, `deferred: true`): per-group coordination DHT with network isolation (PR #107; see `zomes/group_zome.md`)
+- **NDO DNA** (one cloned cell per NDO, `deferred: true`): per-NDO resource network bundling the existing resource and governance zome WASMs; the clone's DNA hash is the NDO's permanent identity (issue #112, ADR-010/011/012)
+- **hREA DNA** (vendored): canonical ValueFlows event recording via the hREA bridge
+
+The core supports **four structured Economic Processes** (Use, Transport, Storage, Repair) with role-based access control and a **16-category PPR reputation system** for trustworthy agent interactions.
 
 ---
 
@@ -26,11 +34,23 @@ graph TB
 
     subgraph "Holochain Runtime"
         WASM[WASM Compilation]
-        DHT[DHT-based P2P Network]
+        DHT[DHT-based P2P Networks]
         CapSec[Capability-Based Security]
     end
 
-    subgraph "Zome Layer"
+    subgraph "Lobby DNA (provisioned)"
+        Lobby["zome_lobby<br/>Agent presence + group registry"]
+    end
+
+    subgraph "Group DNA (cloned per group)"
+        Group["zome_group<br/>Membership, work logs, soft links, NDO anchors"]
+    end
+
+    subgraph "NDO DNA (cloned per NDO)"
+        NdoCell["zome_resource + zome_gouvernance<br/>One network per NDO"]
+    end
+
+    subgraph "Nondominium DNA (3-zome core)"
         Person["zome_person<br/>Identity and Access"]
         Resource["zome_resource<br/>Resource Management"]
         Gov["zome_gouvernance<br/>Governance and Reputation"]
@@ -41,6 +61,9 @@ graph TB
     WASM --> DHT
     WASM --> CapSec
 
+    Lobby --> DHT
+    Group --> DHT
+    NdoCell --> DHT
     Person --> DHT
     Resource --> DHT
     Gov --> DHT
@@ -1120,6 +1143,14 @@ Encryption Performance:
 **Rationale**: Clear separation of concerns, focused responsibility domains
 **Alternatives Considered**: Single monolithic zome, 5+ specialized zomes
 **Impact**: Simplified development, clear API boundaries, cross-zome coordination complexity
+**Status note**: The 3-zome design still describes the Nondominium DNA core, but the hApp is no longer a single DNA — see ADR-013.
+
+### ADR-013: Multi-DNA Split — Lobby, Group, and NDO Networks
+
+**Decision**: Split the hApp into multiple DNA roles: a provisioned Lobby DNA (global group registry + agent presence), a cloned Group DNA per group (isolated coordination DHT), and a cloned NDO DNA per Nondominium Object (isolated resource network reusing the existing resource and governance zome WASMs), alongside the provisioned Nondominium core and vendored hREA DNA.
+**Rationale**: Complexity matching — coordination overhead activates when coordination begins, not at install. Group data does not belong in a global DHT; an NDO must not be captive to any single group's DHT (REQ-RES-02). Placing immutable Layer 0 fields in the NDO clone's DNA properties makes the DNA hash the NDO's permanent, organization-agnostic identity, enforced by hash physics rather than validation code (ADR-010 in the NDO-per-cell design).
+**Alternatives Considered**: Single shared DHT for everything (rejected: no network isolation, group-scoped visibility impossible); a Lobby-level global NDO registry (rejected in PR #107; group-level `NdoAnchor` entries carry clone coordinates instead, ADR-011); a dedicated slim NDO zome (rejected for MVP: code fork, ADR-012).
+**Impact**: Delivered incrementally by PR #103 (Lobby), PR #107 (Group), and issue #112 (NDO DNA + NdoAnchor). Browsing NDOs reads group-cell anchors and never requires joining NDO cells; PPRs and governance run inside each NDO network; `Person` identity and the hREA bridge stay in the provisioned cells.
 
 ### ADR-002: PPR-Based Reputation System
 

--- a/documentation/DOCUMENTATION_INDEX.md
+++ b/documentation/DOCUMENTATION_INDEX.md
@@ -76,7 +76,7 @@ nondominium implements a **Governance-as-Operator** architecture that separates 
 | **[`zome_resource`](zomes/resource_zome.md)** | Pure data model | EconomicResource & EconomicEvent data structures, resource state management only, cross-zome interface for governance requests, no business logic |
 | **[`zome_gouvernance`](zomes/governance_zome.md)** | State transition operator | Governance rule evaluation, state transition validation, economic event generation, PPR issuance (16 categories), agent promotion & capability progression |
 | **[`zome_group`](zomes/group_zome.md)** | Per-group coordination (cloned cell) | Group profiles, membership, work logs, soft links; one cloned cell per group; `all_groups` anchor; 13 `#[hdk_extern]` functions |
-| **[`zome_lobby`](zomes/lobby_zome.md)** | Lobby coordination | NDO announcement/discovery across groups |
+| **[`zome_lobby`](zomes/lobby_zome.md)** | Global group registry (provisioned Lobby DHT) | `LobbyAgentProfile` presence, `GroupAnnouncement` group registry; NDO announcements were removed in PR #107 (NDOs are group-scoped) |
 
 ### Governance-as-Operator Architecture
 
@@ -121,7 +121,7 @@ nondominium implements a **Governance-as-Operator** architecture that separates 
 | Document | Description | Status |
 | --- | --- | --- |
 | **[NDO v1.0 Architecture Design](specifications/ndo-v1-architecture-design.md)** | Dual-DNA architecture, VF 1.0 class mapping, entry type specs, ADRs, migration notes | ✅ Active |
-| **[Lobby DNA Architecture](specifications/post-mvp/lobby-architecture.md)** | Full design: Lobby + Group DNAs, NDO extensions, entry types, coordinator APIs, Moss contract, 7 ADRs | 🔄 Post-MVP |
+| **[Lobby DNA Architecture](specifications/lobby-architecture.md)** | Original design: Lobby + Group DNAs, NDO extensions, entry types, coordinator APIs, Moss contract, 7 ADRs | ⚠️ Superseded in part — Lobby (#103) and Group (#107) DNAs shipped with the registry model inverted (Lobby registers groups, not NDOs); `zomes/lobby_zome.md` and `zomes/group_zome.md` are authoritative |
 | **[hREA Integration Strategy](hREA/integration-strategy.md)** | Cross-DNA call architecture, zome-level integration pattern, migration plan | ✅ Active |
 | **[hREA VF 1.0 Compliance Analysis](hREA/valueflows-1.0-compliance.md)** | Field-by-field audit of hREA main-0.6 against VF 1.0 ontology (~65% compliance) | ✅ Active |
 | **[hREA Strategic Roadmap](hREA/strategic-roadmap.md)** | Phase 1+2 maintainership proposal: VF 1.0 gap closure and JSON-LD API | ✅ Active |
@@ -149,10 +149,10 @@ nondominium implements a **Governance-as-Operator** architecture that separates 
 
 | Document | Description | Status |
 | --- | --- | --- |
-| **[Lobby DNA Requirements](requirements/post-mvp/lobby-dna.md)** | Multi-network federation: Lobby DNA, Group DNA, NDO extensions (REQ-LOBBY-*, REQ-GROUP-*, REQ-NDO-EXT-*) | 🔄 Post-MVP |
+| **[Lobby DNA Requirements](requirements/lobby-dna.md)** | Multi-network federation: Lobby DNA, Group DNA, NDO extensions (REQ-LOBBY-*, REQ-GROUP-*, REQ-NDO-EXT-*) | ✅ Lobby + Group DNAs shipped (#103, #107); NDO-level extensions in progress (#112) |
 | **[Unyt Integration](requirements/post-mvp/unyt-integration.md)** | Economic settlement, Smart Agreements, RAVE proofs, PPR↔RAVE provenance | 🔄 Post-MVP |
 | **[Flowsta Integration](requirements/post-mvp/flowsta-integration.md)** | Cross-app identity (IsSamePersonEntry, FlowstaIdentity, DID, key recovery) | 🔄 Post-MVP |
-| **[Versioning](requirements/post-mvp/versioning.md)** | DAG-based version graph, fork/merge/repair relations, contribution propagation | 🔄 Post-MVP |
+| **[NDO Versioning](requirements/post-mvp/ndo-versioning.md)** | DAG-based version graph, fork/merge/repair relations, contribution propagation | 🔄 Post-MVP |
 | **[Digital Resource Integrity](requirements/post-mvp/digital-resource-integrity.md)** | Cryptographic integrity verification, Merkle tree, composable architecture | 🔄 Post-MVP |
 | **[Many-to-Many Flows](requirements/post-mvp/many-to-many-flows.md)** | Multi-custodian custody, shared ownership, resource pools | 🔄 Post-MVP |
 | **[Resource Transport Flow Protocol](requirements/post-mvp/resource-transport-flow-protocol.md)** | Resource transport specifications | 🔄 Post-MVP |

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -12,7 +12,9 @@ Infrastructure for organization-agnostic, uncapturable, self-governed resources 
 
 - [Architecture Components](ARCHITECTURE_COMPONENTS.md) - System design and zome interactions
 - [NDO v1 Architecture Design](specifications/ndo-v1-architecture-design.md) - NDO three-layer model
-- [Zomes Overview](zomes/architecture_overview.md) - Person, Resource, Governance zome breakdown
+- [Zomes Overview](zomes/architecture_overview.md) - Multi-DNA topology and the Person, Resource, Governance core
+- [Lobby Zome](zomes/lobby_zome.md) - Lobby DNA: agent presence and the global group registry
+- [Group Zome](zomes/group_zome.md) - Group DNA: cloned-cell coordination, membership, soft links, NDO anchors
 - [hREA Integration](hREA/README.md) - ValueFlows / hREA integration strategy
 
 ## Requirements

--- a/documentation/TEST_COMMANDS.md
+++ b/documentation/TEST_COMMANDS.md
@@ -49,7 +49,7 @@ CARGO_TARGET_DIR=target/native-tests cargo test --package lobby_sweettest --test
 CARGO_TARGET_DIR=target/native-tests cargo test --package lobby_sweettest --test lobby -- --nocapture
 
 # Run a single test
-CARGO_TARGET_DIR=target/native-tests cargo test --package lobby_sweettest --test lobby announce_ndo_cross_conductor
+CARGO_TARGET_DIR=target/native-tests cargo test --package lobby_sweettest --test lobby announce_group_cross_conductor
 ```
 
 ### Group DNA Sweettest

--- a/documentation/Testing_Infrastructure.md
+++ b/documentation/Testing_Infrastructure.md
@@ -40,7 +40,7 @@ dnas/
     └── src/
         ├── common/
         │   └── conductors.rs # setup_two_lobby_agents()
-        └── lobby/mod.rs      # announce_ndo, upsert_lobby_agent_profile, get_my_groups tests
+        └── lobby/mod.rs      # announce_group, upsert_lobby_agent_profile, get_my_groups tests
 ```
 
 Per-zome test modules are co-evolved alongside implementation PRs. Each PR that adds new `#[hdk_extern]` functions adds corresponding tests in the relevant module.

--- a/documentation/requirements/lobby-dna.md
+++ b/documentation/requirements/lobby-dna.md
@@ -142,14 +142,16 @@ For the comparative table and worked example, see
 
 ## 4. Lobby DNA Requirements
 
-> **Implementation note (PR #103):** The Lobby is a **separate DNA** (`dnas/lobby/`), not a zome inside
-> the nondominium DNA. The `lobby` role in `workdir/happ.yaml` uses canonical
-> `network_seed: "nondominium-lobby-v1"`. Entry types are `LobbyAgentProfile` and
-> **`NdoAnnouncement`** (not `NdoDescriptor` — see ADR-LOBBY-04 in `lobby-architecture.md`).
-> Coordinator APIs: `upsert_lobby_agent_profile`, `get_lobby_agent_profile`, `get_all_lobby_agents`,
-> `announce_ndo`, `get_all_ndo_announcements`, `get_my_ndo_announcements`,
-> `get_ndo_announcements_by_lifecycle`, `update_ndo_announcement`, `get_ndo_announcement`.
-> `get_my_groups` returns a solo-workspace **stub** until Group DNA (#101) lands.
+> **Implementation note (PR #103, revised by PR #107):** The Lobby is a **separate DNA** (`dnas/lobby/`),
+> not a zome inside the nondominium DNA. The `lobby` role in `workdir/happ.yaml` uses canonical
+> `network_seed: "nondominium-lobby-v1"`. PR #103 initially shipped `LobbyAgentProfile` plus an
+> `NdoAnnouncement` registry; **PR #107 removed the NDO registry** (`NdoAnnouncement`, `announce_ndo`,
+> `get_all_ndo_announcements`, `update_ndo_announcement`) and replaced it with the **group registry**:
+> entry types are now `LobbyAgentProfile` and `GroupAnnouncement`, with coordinator APIs
+> `upsert_lobby_agent_profile`, `get_lobby_agent_profile`, `announce_group`,
+> `get_my_group_announcements`, `get_all_group_announcements`. NDOs are group-scoped; the
+> NDO-per-cell design (issue #112) resurrects the descriptor idea as the group-level `NdoAnchor`.
+> Authoritative reference: `documentation/zomes/lobby_zome.md`.
 
 ### 4.1 Agent profile
 
@@ -165,19 +167,24 @@ For the comparative table and worked example, see
 
 ### 4.2 NDO descriptor registry
 
-Normative name: **`NdoDescriptor`**. Implemented entry type: **`NdoAnnouncement`** (same role,
-same fields; see `documentation/zomes/lobby_zome.md`).
+Normative name: **`NdoDescriptor`**. Initially implemented as **`NdoAnnouncement`** in PR #103,
+then **removed in PR #107**: the Lobby became a group registry and NDO visibility became
+group-scoped. The descriptor concept survives at group level as **`NdoAnchor`** (issue #112),
+which carries the same clone coordinates (name, DnaHash, network_seed, Layer 0 identity hash,
+lifecycle_stage, property_regime, resource_nature) inside each group cell.
 
 - **REQ-LOBBY-04**: Any agent may register an `NdoDescriptor` / `NdoAnnouncement` entry in the
   Lobby DHT for an NDO they initiated. The descriptor contains: NDO name, DnaHash, network_seed,
   Layer 0 identity hash, lifecycle_stage, property_regime, resource_nature, and description.
-  **Status:** ✅ Implemented (`announce_ndo`).
+  **Status:** ⚠️ Superseded — removed from the Lobby in PR #107; fulfilled at group scope by
+  `NdoAnchor` (#112). A future Lobby-level NDO index remains an explicit option.
 - **REQ-LOBBY-05**: Only the registrant may update a descriptor. Descriptors cannot be
   deleted (mirroring the permanent nature of NondominiumIdentity in the NDO DHT).
-  **Status:** ✅ Implemented (integrity zome rejects deletes; author check on update).
+  **Status:** ⚠️ Superseded — see REQ-LOBBY-04; anchor updates are author-gated in `zome_group`.
 - **REQ-LOBBY-06**: The only mutable field on a descriptor after registration is
   `lifecycle_stage`, which mirrors transitions on the NDO's `NondominiumIdentity`.
-  **Status:** ✅ Implemented (`update_ndo_announcement`).
+  **Status:** ⚠️ Superseded — `NdoAnchor` allows cached descriptor sync (name, description,
+  lifecycle_stage) while its identity coordinates stay immutable.
 - **REQ-LOBBY-07**: Descriptors are discoverable via global anchors and categorization paths
   by lifecycle stage, resource nature, and property regime.
   **Status:** 🔄 Partial — global anchor (`lobby.ndos`) and lifecycle paths
@@ -470,57 +477,35 @@ an actual deployed DNA (discoverable by peers who attempt to connect).
 
 ## 10. Current State vs Planned Enforcement
 
-*Last reconciled with `IMPLEMENTATION_STATUS.md` and the codebase, 2026-05-23.*
+*Last reconciled with the codebase, 2026-07-19.*
 
 ### 10.1 What is implemented
 
 | Layer | Status | Notes |
 |-------|--------|-------|
-| **Lobby DNA** | ✅ PR #103 | `dnas/lobby/` — `LobbyAgentProfile`, `NdoAnnouncement`; `lobby` role in `happ.yaml` with `network_seed: "nondominium-lobby-v1"`; Sweettest (`lobby_sweettest`) |
+| **Lobby DNA** | ✅ PR #103, revised #107 | `dnas/lobby/` — `LobbyAgentProfile` + `GroupAnnouncement` (group registry); `lobby` role in `happ.yaml` with `network_seed: "nondominium-lobby-v1"`; Sweettest (`lobby_sweettest`, 5 tests) |
+| **Group DNA** | ✅ PR #107 | `dnas/group/` — `GroupProfile`, `GroupMembership`, `WorkLog`, `SoftLink`; `group` role (`deferred: true`, `clone_limit: 64`); Sweettest (`group_sweettest`, 13 tests) |
+| **DHT-backed group UI** | ✅ PR #111 | `createCloneCell` group provisioning, invite links, DHT member list, SoftLink NDO association; multi-agent web harness (`scripts/launch-happ.mjs`) |
 | **NDO federation extensions** | ✅ PR #103 | `NdoHardLink`, `Contribution`, `Agreement` in `zome_gouvernance`; coordinator APIs + partial Sweettest |
-| **NDO Layer 0** | ✅ PR #80 | `NondominiumIdentity` on single shared NDO DHT (`clone_limit: 0`) — Stage 2 hard-link deployment |
-| **MVP UI shell** | ✅ | Persistent Lobby sidebar, Group panel, NDO detail (`ui_design.md`); groups + lobby profile in **localStorage**; NDO data on **nondominium** DHT |
-| **Lobby service (UI)** | 🔄 Partial | `ui/src/lib/services/zomes/lobby.service.ts` exposes `announce_ndo` and `upsert_lobby_agent_profile` zome calls, but main flows still use localStorage profile + `get_all_ndos` on resource zome for browse — **Lobby DHT not yet wired end-to-end** |
+| **NDO Layer 0** | ✅ PR #80 | `NondominiumIdentity` on the shared nondominium DHT |
+| **NDO DNA + NdoAnchor** | 🔄 Issue #112 | `ndo` role (`deferred: true`, `clone_limit: 512`) bundling existing resource + governance WASMs; `NdoAnchor` in `zome_group` with clone coordinates; one NDO = one cloned cell |
 
 ### 10.2 In progress or not started
 
 | Layer | Status | Notes |
 |-------|--------|-------|
-| **Group DNA** | 🔄 Issue #101 | No `dnas/group/` yet; `get_my_groups` stub in Lobby coordinator; UI `Associate with group` writes localStorage only |
-| **`group` hApp role** | ❌ | `happ.yaml` has `lobby` + `nondominium` + `hrea`; `group` role with `clone_limit: 255` not yet added |
-| **Per-NDO cell cloning** | ❌ | `nondominium` role still `clone_limit: 0` — Stage 3 multi-DHT not active |
+| **NDO-per-cell UI cutover** | 🔄 Issue #110 (amended) | `NdoCreateModal` provisions an NDO cell + `NdoAnchor` instead of a shared-DHT entry + SoftLink; group NDO grid renders from anchors |
+| **Lobby profile UI sync** | 🔄 Issue #106 / PR #114 | Profile bar + fire-and-forget `upsert_lobby_agent_profile` |
 | **Moss WeApplet** | ❌ | `ui/src/we-applet.ts` contract specified in architecture doc; not in repo |
-| **Lobby ↔ NDO lifecycle sync** | ❌ | `update_ndo_announcement` not called automatically on `update_lifecycle_stage` |
-| **Facet discovery (nature / regime)** | ❌ | REQ-LOBBY-07 nature and property-regime path anchors not in Lobby DNA |
+| **Facet discovery (nature / regime)** | ❌ | REQ-LOBBY-07 nature and property-regime path anchors not in Lobby DNA (NDO announcements removed; facets now group-scoped via anchors) |
 | **Governance-as-operator** | ❌ | #41–#44 — blocks full AccountableAgent enforcement on Contribution / Agreement / hard links |
 
-### 10.3 MVP UI alignment (`ui_design.md`)
+### 10.3 Planned next steps
 
-The MVP implements the **Lobby → Group → NDO** hierarchy in the frontend while the backend
-catches up:
-
-- **Lobby profile (Level 1):** `LobbyUserProfile` in `localStorage` — not yet synced to
-  `LobbyAgentProfile` on the Lobby DHT (service method exists).
-- **Groups (Level 2):** `GroupDescriptor` in `localStorage` — replace with Group DNA when #101
-  lands; `LobbyService` interface designed for swap without component changes (REQ-UI-GRP-01).
-- **NDO browse:** Aggregates NDOs linked to the agent's local groups via `get_all_ndos` on the
-  resource zome, not yet via `get_all_ndo_announcements` on the Lobby DHT.
-- **Associate NDO with group:** localStorage only; Group DHT write pending (MVP ToDo #7 in
-  `ui_design.md`).
-- **PropertyRegime:** UI and Rust use **4 variants** (Private, Commons, Nondominium, CommonPool);
-  Collective and Pool removed after design review — Lobby `NdoAnnouncement` uses the same enum
-  via `nondominium_shared::types`.
-
-### 10.4 Planned next steps (see `implementation_plan.md §12.6`)
-
-1. **Group DNA (#101)** — `GroupDescriptor`, `GroupMembership`, `WorkLog`, `SoftLink`,
-   `GroupGovernanceRule`; add `group` role to `happ.yaml`.
-2. **Wire UI to Lobby DHT** — profile upsert, `announce_ndo` on NDO creation, browse via
-   `get_all_ndo_announcements`; mirror lifecycle updates to `update_ndo_announcement`.
-3. **Replace localStorage groups** — `LobbyService.getMyGroups()` → Group DNA; propagate
-   `associateNdoWithGroup` to Group DHT.
-4. **Governance-as-operator (#41–#44)** — enforce AccountableAgent on federation extension writes.
-5. **Stage 3 federation** — per-NDO `clone_limit`, Moss WeApplet, Flowsta identity bridge.
+1. **NDO-per-cell (#112 + amended #110)** — backend anchor plumbing, then UI cutover.
+2. **Per-LinkType validation (#85)** — scope extended to lobby, group, and ndo DNAs.
+3. **Governance-as-operator (#41–#44)** — the operator evaluates inside each NDO cell.
+4. **Post-MVP** — cross-cell reputation aggregation, optional Lobby-level NDO index, Moss WeApplet, Flowsta identity bridge.
 
 The companion architecture specification
 (`documentation/specifications/post-mvp/lobby-architecture.md`) remains the detailed schema,

--- a/documentation/specifications/lobby-architecture.md
+++ b/documentation/specifications/lobby-architecture.md
@@ -8,10 +8,19 @@ scope: post-mvp
 
 # Nondominium Lobby DNA — Architecture Design
 
+> **⚠️ Superseded in part (2026-07-19).** The Lobby DNA (PR #103) and Group DNA (PR #107) shipped
+> with the registry model **inverted** relative to this design: the Lobby is a **group registry**
+> (`GroupAnnouncement`); NDOs are group-scoped, and the Lobby-level `NdoDescriptor` registry
+> described below was removed in PR #107. The NDO-per-cell architecture (issue #112) partially
+> resurrects the `NdoDescriptor` idea as the **group-level `NdoAnchor`** entry, which carries the
+> same clone coordinates (`ndo_dna_hash`, `network_seed`) at group scope. Implementation-accurate
+> references: `documentation/zomes/lobby_zome.md` and `documentation/zomes/group_zome.md`.
+> This document is kept for the decision trail (entry sketches, Moss contract, ADRs).
+
 **Design session:** 2026-04-14
 **Basis:** Requirements discovery session + Moss/Weave ecosystem research
 **Scope:** Lobby DNA + Group DNA (new) + NDO DNA extensions (zome_gouvernance)
-**Requirements:** `documentation/requirements/post-mvp/lobby-dna.md`
+**Requirements:** `documentation/requirements/lobby-dna.md`
 
 ---
 

--- a/documentation/specifications/ui_architecture.md
+++ b/documentation/specifications/ui_architecture.md
@@ -15,7 +15,7 @@ The Nondominium frontend is a SvelteKit application using Svelte 5 runes, Effect
 
 This hierarchy maps to the three concentric organizational scopes in `ui_design.md`:
 
-- **Lobby** — the entry point: all NDOs visible to any connected agent, Groups listed in sidebar.
+- **Lobby** — the entry point: the NDOs aggregated from the agent's own groups, Groups listed in sidebar (no global public NDO registry).
 - **Group** — organizational context: NDOs scoped to a group, where new NDOs are created.
 - **NDO** — the resource identity detail view: Layer 0 metadata, lifecycle transitions, fork friction.
 
@@ -80,8 +80,10 @@ This hierarchy maps to the three concentric organizational scopes in `ui_design.
 └──────────────────────────────────────────────────────────────────┘
                                 ↓
 ┌──────────────────────────────────────────────────────────────────┐
-│ HOLOCHAIN CONDUCTOR (3-Zome DNA)                                  │
-│ zome_person · zome_resource · zome_gouvernance                    │
+│ HOLOCHAIN CONDUCTOR (multi-DNA hApp)                              │
+│ nondominium DNA: zome_person · zome_resource · zome_gouvernance   │
+│ lobby DNA (provisioned) · group DNA (cloned per group)            │
+│ ndo DNA (cloned per NDO, #112) · hrea DNA (vendored)              │
 └──────────────────────────────────────────────────────────────────┘
 ```
 


### PR DESCRIPTION
## Summary

Implements #113: retrofits the architecture documentation to the multi-DNA reality (Lobby DNA #103, Group DNA #107, DHT-backed UI #111, NDO DNA #112 in flight). The 2026-07-19 docs audit found the core docs still describing a single 3-zome DNA with localStorage groups; several audit items had already been fixed by #111, so each item was re-verified against current `dev` before editing.

## Changes

**P1 (actively misleading):**

- `ARCHITECTURE_COMPONENTS.md`: multi-DNA executive summary and high-level diagram (all five DNA roles); 16 PPR categories (was 14); ADR-001 status note plus a new **ADR-013** recording the DNA split and its rationale (complexity matching, REQ-RES-02, DNA-hash-as-identity)
- `README.md`: multi-DNA overview, architecture section, development status (#103/#107/#111 shipped, #112 in progress), per-DNA Sweettest suite list
- `specifications/lobby-architecture.md`: supersession banner — the shipped registry model is inverted relative to this design (Lobby registers groups, not NDOs); the NDO-per-cell design partially resurrects the `NdoDescriptor` idea as the group-level `NdoAnchor`, stated explicitly to keep the decision trail honest
- `requirements/lobby-dna.md`: implementation notes and REQ-LOBBY-04..06 statuses now reflect the #107 removal of `NdoAnnouncement`; section 10 (current state / next steps) rewritten to current reality
- `specifications/ui_architecture.md`: group-scoped Lobby description (no global NDO registry); conductor diagram lists all five DNA roles

**P2 (incomplete):**

- `DOCUMENTATION_INDEX.md`: `zome_lobby` correctly described as the group registry; paths fixed for files moved/renamed by #111 (`lobby-architecture.md`, `lobby-dna.md`, `ndo-versioning.md`); status labels updated
- `documentation/README.md`: links to `zomes/lobby_zome.md` and `zomes/group_zome.md`
- `TEST_COMMANDS.md`, `Testing_Infrastructure.md`: stale `announce_ndo` test references replaced with real lobby suite names

**Not touched (already accurate):** `zomes/lobby_zome.md` and `zomes/group_zome.md` (the latter gains NdoAnchor in #115, not here). `ui_design.md` and `IMPLEMENTATION_STATUS.md` audit items were already fixed by #111.

## Sequencing

Merge **after #115** so the ndo-role references (ADR-013, README status, index) document merged reality. No code changes.

Closes #113
