### PR TITLE
fix(group): robust member listing, group persistence, and join reliability

### DIFF
--- a/dnas/group/tests/src/group/mod.rs
+++ b/dnas/group/tests/src/group/mod.rs
@@ -163,8 +163,11 @@ async fn join_group_creates_membership() {
         .await
         .unwrap();
 
-    // get_group_members now returns Vec<Record>; member identity is action.author()
-    let member_records: Vec<Record> = conductors[0]
+    // get_group_members returns Vec<AgentPubKey> read from each GroupToMembers
+    // link's author (the joining agent). Membership identity no longer depends on
+    // a per-member `get` of the GroupMembership record, which could be absent from
+    // the local DHT shard before full sync.
+    let members: Vec<AgentPubKey> = conductors[0]
         .call(
             &cell_alice.zome("zome_group"),
             "get_group_members",
@@ -175,7 +178,7 @@ async fn join_group_creates_membership() {
     let bob_key = cell_bob.agent_pubkey().clone();
 
     assert!(
-        member_records.iter().any(|r| r.action().author() == &bob_key),
+        members.iter().any(|m| *m == bob_key),
         "Bob should appear in get_group_members after joining"
     );
 }
@@ -217,7 +220,7 @@ async fn leave_group_removes_membership() {
         .await
         .unwrap();
 
-    let member_records: Vec<Record> = conductors[0]
+    let members: Vec<AgentPubKey> = conductors[0]
         .call(
             &cell_alice.zome("zome_group"),
             "get_group_members",
@@ -228,7 +231,7 @@ async fn leave_group_removes_membership() {
     let bob_key = cell_bob.agent_pubkey().clone();
 
     assert!(
-        !member_records.iter().any(|r| r.action().author() == &bob_key),
+        !members.iter().any(|m| *m == bob_key),
         "Bob should not appear in get_group_members after leaving"
     );
 }

--- a/dnas/group/zomes/coordinator/zome_group/src/membership.rs
+++ b/dnas/group/zomes/coordinator/zome_group/src/membership.rs
@@ -1,5 +1,6 @@
 use crate::GroupError;
 use hdk::prelude::*;
+use std::collections::HashSet;
 use zome_group_integrity::*;
 
 #[hdk_extern]
@@ -57,14 +58,11 @@ pub fn leave_group(group_hash: ActionHash) -> ExternResult<()> {
   // Only the discovery links are removed; the GroupMembership entry itself is intentionally
   // left on the source chain. Holochain entries are append-only, so the membership record
   // serves as an audit trail of prior participation even after the agent leaves.
-  // Member identity comes from the action author, not from the entry.
+  // The link's author is the joining agent (the member), so comparing link.author avoids a
+  // per-link `get` of the membership record, which may not be held locally for other agents.
   for link in links {
-    if let Some(membership_hash) = link.target.clone().into_action_hash() {
-      if let Some(record) = get(membership_hash, GetOptions::default())? {
-        if record.action().author() == &agent {
-          delete_link(link.create_link_hash, GetOptions::default())?;
-        }
-      }
+    if link.author == agent {
+      delete_link(link.create_link_hash, GetOptions::default())?;
     }
   }
 
@@ -82,21 +80,27 @@ pub fn leave_group(group_hash: ActionHash) -> ExternResult<()> {
   Ok(())
 }
 
-/// Returns Records for all current group members.
-/// The member's AgentPubKey is the action author: `record.action().author()`.
-/// The join timestamp is `record.action().timestamp()`.
+/// Returns the AgentPubKey of every current member of this group.
+///
+/// Membership identity is read directly from each `GroupToMembers` link's `author`
+/// (the agent who called `join_group`), rather than from a `get` of the linked
+/// `GroupMembership` record. A `get_links` call returns every link and its author
+/// in a single round-trip; the previous per-member `get` could fail when another
+/// member's record had not yet propagated to this cell's DHT shard, silently
+/// dropping that member from the list (only the local agent appeared).
+/// Duplicate authors are collapsed defensively.
 #[hdk_extern]
-pub fn get_group_members(group_hash: ActionHash) -> ExternResult<Vec<Record>> {
+pub fn get_group_members(group_hash: ActionHash) -> ExternResult<Vec<AgentPubKey>> {
   let link_query = LinkQuery::try_new(group_hash, LinkTypes::GroupToMembers)?;
   let links = get_links(link_query, GetStrategy::default())?;
 
-  let members = links
-    .iter()
-    .filter_map(|link| {
-      let hash = link.target.clone().into_action_hash()?;
-      get(hash, GetOptions::default()).ok()?
-    })
-    .collect();
+  let mut seen: HashSet<AgentPubKey> = HashSet::new();
+  let mut members: Vec<AgentPubKey> = Vec::new();
+  for link in links {
+    if seen.insert(link.author.clone()) {
+      members.push(link.author);
+    }
+  }
 
   Ok(members)
 }
@@ -105,5 +109,5 @@ pub fn get_group_members(group_hash: ActionHash) -> ExternResult<Vec<Record>> {
 pub fn is_member(input: (AgentPubKey, ActionHash)) -> ExternResult<bool> {
   let (agent, group_hash) = input;
   let members = get_group_members(group_hash)?;
-  Ok(members.iter().any(|r| r.action().author() == &agent))
+  Ok(members.contains(&agent))
 }

--- a/documentation/API_REFERENCE.md
+++ b/documentation/API_REFERENCE.md
@@ -1376,8 +1376,8 @@ Creates a `GroupMembership` entry and `GroupToMembers` + `MemberToGroups` links.
 Deletes the `GroupToMembers` and `MemberToGroups` links for the calling agent.
 The `GroupMembership` entry is intentionally retained on-chain as an audit trail.
 
-#### `get_group_members(group_hash: ActionHash) -> ExternResult<Vec<Record>>`
-Returns Records for all current members reachable via `GroupToMembers` links. Member identity = `record.action().author()`.
+#### `get_group_members(group_hash: ActionHash) -> ExternResult<Vec<AgentPubKey>>`
+Returns the `AgentPubKey` of every current member, read from each `GroupToMembers` link's author in a single `get_links` round-trip (does not `get` each `GroupMembership` record, which may be absent from the local shard before sync).
 
 #### `is_member(input: (AgentPubKey, ActionHash)) -> ExternResult<bool>`
 Predicate: does the given agent appear in `get_group_members`?

--- a/documentation/zomes/group_zome.md
+++ b/documentation/zomes/group_zome.md
@@ -109,7 +109,7 @@ Authoritative pointer from the group to an NDO cell (one NDO = one cloned DHT ce
 |----------|-------|--------|-------------|
 | `join_group` | `ActionHash` (group hash) | `Record` | Creates a `GroupMembership` entry; guards against duplicate joins |
 | `leave_group` | `ActionHash` (group hash) | `()` | Deletes discovery links for the calling agent; entry remains on-chain as audit trail |
-| `get_group_members` | `ActionHash` (group hash) | `Vec<Record>` | Returns Records for all current members; member = `record.action().author()` |
+| `get_group_members` | `ActionHash` (group hash) | `Vec<AgentPubKey>` | Returns the `AgentPubKey` of every current member, read from each `GroupToMembers` link's author in one `get_links` round-trip |
 | `is_member` | `(AgentPubKey, ActionHash)` | `bool` | Predicate: does the given agent appear in `get_group_members`? |
 
 ### Work Logs

--- a/packages/shared-types/src/lobby.types.ts
+++ b/packages/shared-types/src/lobby.types.ts
@@ -45,6 +45,13 @@ export interface GroupInvitePayload {
   group_dna_hash: string;
   group_name: string;
   description?: string;
+  /**
+   * Base64 ActionHash of the group's GroupProfile entry. Lets a joining agent
+   * call `join_group` immediately (without waiting for the profile to gossip
+   * into the freshly-cloned cell), so membership is committed at join time.
+   * Optional for backward compatibility with invites predating this field.
+   */
+  group_hash?: string;
 }
 
 export interface NdoHardLink {

--- a/ui/src/lib/services/zomes/group.service.ts
+++ b/ui/src/lib/services/zomes/group.service.ts
@@ -1,10 +1,7 @@
 import { Context, Layer, Effect as E } from 'effect';
 import type { ActionHash, CellId } from '@holochain/client';
 import { decodeHashFromBase64, encodeHashToBase64 } from '@holochain/client';
-import {
-  HolochainClientServiceTag,
-  HolochainClientServiceLive
-} from '../holochain.service.svelte';
+import { HolochainClientServiceTag, HolochainClientServiceLive } from '../holochain.service.svelte';
 import { GroupError } from '$lib/errors/group.errors';
 import { GROUP_CONTEXTS } from '$lib/errors/error-contexts';
 import type { SoftLink } from '@nondominium/shared-types';
@@ -40,7 +37,7 @@ export interface GroupService {
   ) => E.Effect<void, GroupError>;
 }
 
-export class GroupServiceTag extends Context.Tag('GroupService')<GroupServiceTag, GroupService>() { }
+export class GroupServiceTag extends Context.Tag('GroupService')<GroupServiceTag, GroupService>() {}
 
 export const GroupServiceLive: Layer.Layer<GroupServiceTag, never, HolochainClientServiceTag> =
   Layer.effect(
@@ -79,9 +76,7 @@ export const GroupServiceLive: Layer.Layer<GroupServiceTag, never, HolochainClie
           ),
           (record) => {
             const profile = record ? groupProfileFromRecord(record) : null;
-            return profile
-              ? (decodeHashFromBase64(profile.groupHashB64) as ActionHash)
-              : null;
+            return profile ? (decodeHashFromBase64(profile.groupHashB64) as ActionHash) : null;
           }
         );
 
@@ -90,16 +85,15 @@ export const GroupServiceLive: Layer.Layer<GroupServiceTag, never, HolochainClie
           E.flatMap(resolveGroupHash(groupCellId), (groupHash) => {
             if (!groupHash) return E.succeed([]);
             return E.map(
-              callGroupZome<GroupHolochainRecord[]>(
+              callGroupZome<Uint8Array[]>(
                 groupCellId,
                 'get_group_members',
                 groupHash,
                 GROUP_CONTEXTS.GET_GROUP_MEMBERS
               ),
-              (records) =>
-                records.map((r) => {
-                  const authorBytes = r.signed_action?.hashed?.content?.author;
-                  const authorB64 = authorBytes ? encodeHashToBase64(authorBytes) : 'unknown';
+              (memberPubKeys) =>
+                memberPubKeys.map((pk) => {
+                  const authorB64 = encodeHashToBase64(pk);
                   return {
                     id: authorB64,
                     name: `${authorB64.slice(0, 8)}…${authorB64.slice(-4)}`,
@@ -165,9 +159,7 @@ export const GroupServiceLive: Layer.Layer<GroupServiceTag, never, HolochainClie
               );
             }),
             (records) =>
-              records
-                .map((r) => softLinkTargetHashB64(r))
-                .filter((h): h is string => h !== null)
+              records.map((r) => softLinkTargetHashB64(r)).filter((h): h is string => h !== null)
           ),
 
         createSoftLink: (groupCellId, groupHashB64, targetNdoHashB64, description) =>

--- a/ui/src/lib/services/zomes/lobby.service.ts
+++ b/ui/src/lib/services/zomes/lobby.service.ts
@@ -9,18 +9,11 @@ import type {
   LobbyAgentProfileInput,
   GroupInvitePayload
 } from '@nondominium/shared-types';
-import {
-  HolochainClientServiceTag,
-  HolochainClientServiceLive
-} from '../holochain.service.svelte';
+import { HolochainClientServiceTag, HolochainClientServiceLive } from '../holochain.service.svelte';
 import { wrapZomeCallWithErrorFactory } from '$lib/utils/zome-helpers';
 import { devStorageKey } from '$lib/utils/hc-connect';
 import { LobbyError } from '$lib/errors/lobby.errors';
-import {
-  enumerateGroupCells,
-  getGroupCellHandleBySeed,
-  type GroupCellInfo
-} from '../cell.manager';
+import { enumerateGroupCells, getGroupCellHandleBySeed, type GroupCellInfo } from '../cell.manager';
 import {
   generateNetworkSeed,
   groupProfileFromRecord,
@@ -30,6 +23,35 @@ import {
 // Per-group presentation profiles (Level 2 identity) — still localStorage-only.
 // Namespaced per dev agent so two same-origin windows don't share disclosure prefs.
 const GROUP_PROFILES_KEY = devStorageKey('ndo_group_profiles_v1');
+
+// Name cache so a joined group stays visible (with its real name) through a page
+// refresh and in the group-detail header, even when the GroupProfile entry has not
+// yet gossiped into the freshly-cloned cell. Without it, buildDescriptorsFromCells
+// would skip such cells entirely (Bug 2) and the detail page would fall back to
+// "Group" (Bug 3). Populated whenever a name is learned (create/join/profile resolve).
+const GROUP_NAMES_KEY = devStorageKey('ndo_group_names_v1');
+
+function loadGroupNames(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(GROUP_NAMES_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function cacheGroupName(networkSeed: string, name: string): void {
+  if (!networkSeed || !name) return;
+  try {
+    const names = loadGroupNames();
+    if (names[networkSeed] !== name) {
+      names[networkSeed] = name;
+      localStorage.setItem(GROUP_NAMES_KEY, JSON.stringify(names));
+    }
+  } catch {
+    // localStorage unavailable
+  }
+}
 
 function loadGroupProfiles(): Record<string, GroupDescriptor['memberProfile']> {
   try {
@@ -50,7 +72,9 @@ function saveGroupMemberProfile(groupId: string, profile: GroupDescriptor['membe
   }
 }
 
-export function getStoredGroupMemberProfile(groupId: string): GroupDescriptor['memberProfile'] | undefined {
+export function getStoredGroupMemberProfile(
+  groupId: string
+): GroupDescriptor['memberProfile'] | undefined {
   return loadGroupProfiles()[groupId];
 }
 
@@ -79,7 +103,10 @@ export interface LobbyService {
    * gossiped in yet.
    */
   getGroupHash: (groupId: string) => E.Effect<string | null, LobbyError>;
-  saveGroupMemberProfile: (groupId: string, profile: NonNullable<GroupDescriptor['memberProfile']>) => E.Effect<void, LobbyError>;
+  saveGroupMemberProfile: (
+    groupId: string,
+    profile: NonNullable<GroupDescriptor['memberProfile']>
+  ) => E.Effect<void, LobbyError>;
   // Lobby DHT (zome-backed)
   announceGroup: (input: AnnounceGroupInput) => E.Effect<unknown, LobbyError>;
   getAllGroupAnnouncements: () => E.Effect<GroupAnnouncement[], LobbyError>;
@@ -88,7 +115,7 @@ export interface LobbyService {
   getLobbyAgentProfile: (agentPubKey: Uint8Array) => E.Effect<LobbyAgentProfile | null, LobbyError>;
 }
 
-export class LobbyServiceTag extends Context.Tag('LobbyService')<LobbyServiceTag, LobbyService>() { }
+export class LobbyServiceTag extends Context.Tag('LobbyService')<LobbyServiceTag, LobbyService>() {}
 
 function encodeInvitePayload(payload: GroupInvitePayload): string {
   return btoa(JSON.stringify(payload));
@@ -96,7 +123,7 @@ function encodeInvitePayload(payload: GroupInvitePayload): string {
 
 function decodeInvitePayload(inviteCode: string): GroupInvitePayload {
   const encoded = inviteCode.includes('?group=')
-    ? inviteCode.split('?group=')[1]?.split('&')[0] ?? inviteCode
+    ? (inviteCode.split('?group=')[1]?.split('&')[0] ?? inviteCode)
     : inviteCode.trim();
   const decoded = atob(encoded);
   const data = JSON.parse(decoded) as Record<string, unknown>;
@@ -106,7 +133,8 @@ function decodeInvitePayload(inviteCode: string): GroupInvitePayload {
       network_seed: data.network_seed as string,
       group_dna_hash: data.group_dna_hash as string,
       group_name: data.group_name as string,
-      description: data.description as string | undefined
+      description: data.description as string | undefined,
+      group_hash: data.group_hash as string | undefined
     };
   }
 
@@ -119,7 +147,8 @@ function decodeInvitePayload(inviteCode: string): GroupInvitePayload {
       network_seed: legacyId,
       group_dna_hash: legacyDna,
       group_name: legacyName,
-      description: (data.description as string | undefined) ?? undefined
+      description: (data.description as string | undefined) ?? undefined,
+      group_hash: (data.groupHash as string | undefined) ?? undefined
     };
   }
 
@@ -132,10 +161,14 @@ function descriptorFromCell(
   createdBy?: string
 ): GroupDescriptor {
   const profiles = loadGroupProfiles();
+  const name = profile?.name ?? cell.networkSeed;
+  // Persist the authoritative name so the group survives a refresh even if the
+  // GroupProfile has not yet re-gossiped into this agent's cell.
+  cacheGroupName(cell.networkSeed, name);
   return {
     id: cell.networkSeed,
     networkSeed: cell.networkSeed,
-    name: profile?.name ?? cell.networkSeed,
+    name,
     description: profile?.description,
     createdBy,
     createdAt: Date.now(),
@@ -153,7 +186,11 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
     E.gen(function* () {
       const holochainClient = yield* HolochainClientServiceTag;
 
-      const wzLobby = <T>(fnName: string, payload: unknown, context: string): E.Effect<T, LobbyError> =>
+      const wzLobby = <T>(
+        fnName: string,
+        payload: unknown,
+        context: string
+      ): E.Effect<T, LobbyError> =>
         wrapZomeCallWithErrorFactory<T, LobbyError>(
           holochainClient,
           'zome_lobby',
@@ -189,12 +226,7 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
         cellId: CellId
       ): E.Effect<ReturnType<typeof groupProfileFromRecord>, LobbyError> =>
         E.map(
-          callGroupZome<GroupHolochainRecord | null>(
-            cellId,
-            'get_my_group',
-            null,
-            'GET_MY_GROUP'
-          ),
+          callGroupZome<GroupHolochainRecord | null>(cellId, 'get_my_group', null, 'GET_MY_GROUP'),
           (record) => (record ? groupProfileFromRecord(record) : null)
         );
 
@@ -213,7 +245,9 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
       ): E.Effect<ReturnType<typeof groupProfileFromRecord>, LobbyError> =>
         E.gen(function* () {
           for (let attempt = 1; attempt <= attempts; attempt += 1) {
-            const profile = yield* fetchGroupProfile(cellId).pipe(E.catchAll(() => E.succeed(null)));
+            const profile = yield* fetchGroupProfile(cellId).pipe(
+              E.catchAll(() => E.succeed(null))
+            );
             if (profile) return profile;
             if (attempt < attempts) yield* E.sleep(`${delayMs} millis`);
           }
@@ -246,7 +280,10 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
         cell: GroupCellInfo,
         name: string,
         description?: string
-      ): E.Effect<{ groupHash: ActionHash; profile: NonNullable<ReturnType<typeof groupProfileFromRecord>> }, LobbyError> =>
+      ): E.Effect<
+        { groupHash: ActionHash; profile: NonNullable<ReturnType<typeof groupProfileFromRecord>> },
+        LobbyError
+      > =>
         E.gen(function* () {
           let profile = yield* fetchGroupProfile(cell.cellId);
           if (!profile) {
@@ -258,7 +295,9 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
             );
             profile = groupProfileFromRecord(record);
             if (!profile) {
-              return yield* E.fail(LobbyError.fromError(new Error('create_group returned no profile'), 'CREATE_GROUP'));
+              return yield* E.fail(
+                LobbyError.fromError(new Error('create_group returned no profile'), 'CREATE_GROUP')
+              );
             }
             const groupHash = decodeHashFromBase64(profile.groupHashB64) as ActionHash;
             // Best-effort: the group entry already exists. If self-join fails
@@ -293,13 +332,31 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
             catch: (e) => LobbyError.fromError(e, 'GET_MY_GROUPS')
           });
           const cells = enumerateGroupCells(appInfo);
+          const cachedNames = loadGroupNames();
+          const profiles = loadGroupProfiles();
           const descriptors: GroupDescriptor[] = [];
           for (const cell of cells) {
-            const profile = yield* fetchGroupProfile(cell.cellId).pipe(
+            // Brief retry: a GroupProfile may still be gossiping into a freshly
+            // joined cell. A couple of quick attempts absorb transient delays.
+            const profile = yield* fetchGroupProfileWithRetry(cell.cellId, 3, 200).pipe(
               E.catchAll(() => E.succeed(null))
             );
             if (profile) {
               descriptors.push(descriptorFromCell(cell, profile));
+            } else {
+              // Do NOT drop the cell: it exists and the agent has joined it. Fall
+              // back to the cached name (or the network seed) so the group stays
+              // visible after a refresh and the detail page shows a real name.
+              // The descriptor reconciles to the full profile on a later load.
+              const fallbackName = cachedNames[cell.networkSeed] ?? cell.networkSeed;
+              descriptors.push({
+                id: cell.networkSeed,
+                networkSeed: cell.networkSeed,
+                name: fallbackName,
+                createdAt: Date.now(),
+                dnaHash: cell.dnaHash,
+                memberProfile: profiles[cell.networkSeed]
+              });
             }
           }
           return descriptors;
@@ -412,6 +469,40 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
             console.warn(
               '[lobby] group profile not synced yet; using invite payload for descriptor'
             );
+
+            // Best-effort: commit membership now if the invite carries the group
+            // ActionHash, so the creator sees this agent in the member list without
+            // waiting for the profile to gossip in (which is also what join_group
+            // needs). Without this, a join that races the profile would leave the
+            // agent uncommitted until the next group-open self-heal.
+            if (payload.group_hash) {
+              const groupHashFromPayload = decodeHashFromBase64(payload.group_hash) as ActionHash;
+              const agentPubKeyForJoin = yield* E.tryPromise({
+                try: () => holochainClient.getMyAgentPubKey(),
+                catch: (e) => LobbyError.fromError(e, 'JOIN_GROUP')
+              });
+              const alreadyMember = yield* callGroupZome<boolean>(
+                cell.cellId,
+                'is_member',
+                [agentPubKeyForJoin, groupHashFromPayload],
+                'IS_MEMBER'
+              ).pipe(E.catchAll(() => E.succeed(false)));
+              if (!alreadyMember) {
+                yield* callGroupZome<GroupHolochainRecord>(
+                  cell.cellId,
+                  'join_group',
+                  groupHashFromPayload,
+                  'JOIN_GROUP'
+                ).pipe(
+                  E.catchAll((e) => {
+                    console.warn('[lobby] payload-path join_group failed (non-fatal):', e);
+                    return E.succeed(null as unknown as GroupHolochainRecord);
+                  })
+                );
+              }
+            }
+
+            cacheGroupName(cell.networkSeed, payload.group_name);
             return {
               id: cell.networkSeed,
               networkSeed: cell.networkSeed,
@@ -488,7 +579,8 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
               network_seed: cell.networkSeed,
               group_dna_hash: encodeHashToBase64(cell.dnaHash),
               group_name: profile?.name ?? groupId,
-              description: profile?.description
+              description: profile?.description,
+              group_hash: profile?.groupHashB64
             };
             const encoded = encodeInvitePayload(payload);
             const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -498,10 +590,18 @@ export const LobbyServiceLive: Layer.Layer<LobbyServiceTag, never, HolochainClie
         announceGroup: (input) => wzLobby<unknown>('announce_group', input, 'ANNOUNCE_GROUP'),
 
         getAllGroupAnnouncements: () =>
-          wzLobby<GroupAnnouncement[]>('get_all_group_announcements', null, 'GET_ALL_GROUP_ANNOUNCEMENTS'),
+          wzLobby<GroupAnnouncement[]>(
+            'get_all_group_announcements',
+            null,
+            'GET_ALL_GROUP_ANNOUNCEMENTS'
+          ),
 
         getMyGroupAnnouncements: () =>
-          wzLobby<GroupAnnouncement[]>('get_my_group_announcements', null, 'GET_MY_GROUP_ANNOUNCEMENTS'),
+          wzLobby<GroupAnnouncement[]>(
+            'get_my_group_announcements',
+            null,
+            'GET_MY_GROUP_ANNOUNCEMENTS'
+          ),
 
         upsertLobbyAgentProfile: (input) =>
           wzLobby<Uint8Array>('upsert_lobby_agent_profile', input, 'UPSERT_LOBBY_AGENT_PROFILE'),


### PR DESCRIPTION
Fixes the first batch of bugs from `.local/bugs-list.md`. All three share a common theme: group data not reliably visible across freshly-cloned/joined cells.

## Bugs fixed

### 1. Only one member listed in groups even if there are more
**Root cause:** `get_group_members` did a per-member `get()` of each `GroupMembership` record to read the member identity. When another member's record had not propagated to the local DHT shard, the `get` failed and `filter_map` silently dropped that member, leaving only the local agent.

**Fix:** Holochain 0.6 `Link` already carries `.author` (the joining agent), so `get_group_members` now returns `Vec<AgentPubKey>` derived from `GroupToMembers` link authors in a single `get_links` round-trip — no per-member `get`. `leave_group` uses `link.author` the same way (avoids the same fragile fetch).

**Robustness:** the invite payload now carries the group `ActionHash` so a joining agent can call `join_group` immediately, without waiting for the `GroupProfile` to gossip into the cloned cell. Membership commits at join time instead of being deferred to a later self-heal.

### 2. Joined groups not persisted after refresh
**Root cause:** `buildDescriptorsFromCells` skipped any cell whose `GroupProfile` had not gossiped in, so joined groups vanished after a page reload.

**Fix:** it now retries the profile fetch briefly and, when still unavailable, keeps the cell visible using a cached name instead of dropping it.

### 3. Joined group name shows in sidebar but as "Group" in detail page
**Root cause:** same as #2 — `getMyGroups()` omitted the joined group (profile not gossiped), so `groupStore.group` was null and the header fell back to `"Group"`. The sidebar was correct only because `lobbyStore.groups` retained the join-time descriptor.

**Fix:** a localStorage name cache (populated at create / join / profile-resolve) supplies the real name until the profile reconciles.

## Verification

- `cargo check -p zome_group_coordinator --target wasm32-unknown-unknown` — clean
- `bun run build:happ` — green (group DNA rebuilt with new zome)
- `svelte-check` — 0 errors, 0 warnings
- Sweettest (`group_sweettest --test group`): **all 13 tests pass.** Two timed out under default parallel load due to keystore contention (`holochain_keystore test_keystore.rs:90 "timeout elapsed"` — `work_log_zero_hours_rejected` failed identically and was untouched); both pass when run single-threaded (`--test-threads=1`).

## Files

- `dnas/group/zomes/coordinator/zome_group/src/membership.rs` — `get_group_members` → `Vec<AgentPubKey>` from link authors; `leave_group` via `link.author`
- `ui/src/lib/services/zomes/group.service.ts` — `getMembers` maps `AgentPubKey[]`
- `ui/src/lib/services/zomes/lobby.service.ts` — name cache; `buildDescriptorsFromCells` retry + no-skip; join-fallback commits membership via invite `group_hash`
- `packages/shared-types/src/lobby.types.ts` — optional `group_hash` on `GroupInvitePayload`
- `dnas/group/tests/src/group/mod.rs` — sweettests updated to `Vec<AgentPubKey>`