### PR TITLE
feat(ndo): NDO membership — join, list, and is-member on the per-NDO cell

### DIFF
--- a/.rules
+++ b/.rules
@@ -166,7 +166,7 @@ dnas/nondominium/tests/src/
 - `setup_three_agents()` — three conductors with nondominium DNA
 - `setup_dual_dna_two_agents()` — two conductors with nondominium + hREA DNAs (explicit role names)
 
-**DHT sync** between agents: `await_consistency_20_s(&[&cell_a, &cell_b]).await.unwrap()` (holochain 0.6.0 requires a timeout arg; use the `_20_s` wrapper)
+**DHT sync** between agents: `await_consistency_20_s([&cell_a, &cell_b]).await.unwrap()` (holochain 0.6.0 requires a timeout arg; use the `_20_s` wrapper). Pass the array **by value**, not `&[...]`: the bound is `IntoIterator<Item = &SweetCell>`, so a slice reference yields `&&SweetCell` and fails to compile.
 
 ### Deprecated: Tryorama (TypeScript)
 

--- a/crates/shared/src/errors.rs
+++ b/crates/shared/src/errors.rs
@@ -92,6 +92,12 @@ pub enum ResourceError {
   #[error("Not the custodian of this resource")]
   NotCustodian,
 
+  #[error("NDO identity not found: {0}")]
+  NdoNotFound(String),
+
+  #[error("Already a member of this NDO")]
+  AlreadyMember,
+
   #[error("Serialization error: {0}")]
   SerializationError(String),
 

--- a/dnas/nondominium/tests/src/nondominium/mod.rs
+++ b/dnas/nondominium/tests/src/nondominium/mod.rs
@@ -1,1 +1,2 @@
 pub mod ndo_layer0;
+pub mod ndo_membership;

--- a/dnas/nondominium/tests/src/nondominium/ndo_membership/mod.rs
+++ b/dnas/nondominium/tests/src/nondominium/ndo_membership/mod.rs
@@ -1,0 +1,294 @@
+//! NDO membership Sweettest integration tests.
+//!
+//! Covers `join_ndo` / `get_ndo_members` / `is_ndo_member`: the round trip, the
+//! idempotency guard, cross-agent convergence, and rejection of a membership that
+//! points at an identity this cell does not hold.
+//!
+//! Membership records *participation*, not access. Under the per-NDO-cell model an
+//! agent already holds the cell to read the NDO at all, so nothing here asserts that
+//! a non-member is denied a read — that would encode a guarantee the design does not
+//! make (see ndo_membership.rs module docs).
+//!
+//! Prerequisites (runtime — not compile-time):
+//!   bun run build:happ
+//!
+//! Run:
+//!   CARGO_TARGET_DIR=target/native-tests cargo test --test nondominium ndo_membership -- --test-threads 6
+
+use holochain::prelude::*;
+use holochain::sweettest::*;
+use serde::{Deserialize, Serialize};
+
+use nondominium_sweettest::common::*;
+
+// ---------------------------------------------------------------------------
+// Local mirror types — the test binary cannot import WASM-compiled zome crates.
+// Field and variant names must match the zome types; order does not matter.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum LifecycleStage {
+    Ideation,
+    Specification,
+    Development,
+    Prototype,
+    Stable,
+    Distributed,
+    Active,
+    Hibernating,
+    Deprecated,
+    EndOfLife,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum PropertyRegime {
+    Private,
+    Commons,
+    Collective,
+    Pool,
+    CommonPool,
+    Nondominium,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum ResourceNature {
+    Physical,
+    Digital,
+    Service,
+    Hybrid,
+    Information,
+}
+
+/// Mirrors `zome_resource_coordinator::NdoInput`.
+#[derive(Debug, Serialize, Deserialize)]
+struct NdoInput {
+    pub name: String,
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+    pub lifecycle_stage: LifecycleStage,
+    pub description: Option<String>,
+}
+
+/// Mirrors `zome_resource_coordinator::NdoOutput` (only the field we need).
+#[derive(Debug, Deserialize)]
+struct NdoOutput {
+    pub action_hash: ActionHash,
+}
+
+/// Mirrors `zome_resource_coordinator::JoinNdoInput`.
+#[derive(Debug, Serialize)]
+struct JoinNdoInput {
+    pub ndo_identity_hash: ActionHash,
+    pub role: Option<String>,
+}
+
+fn ndo_input(name: &str) -> NdoInput {
+    NdoInput {
+        name: name.to_string(),
+        property_regime: PropertyRegime::Commons,
+        resource_nature: ResourceNature::Digital,
+        lifecycle_stage: LifecycleStage::Ideation,
+        description: None,
+    }
+}
+
+fn join_input(hash: ActionHash) -> JoinNdoInput {
+    JoinNdoInput {
+        ndo_identity_hash: hash,
+        role: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ndo_membership_join_round_trip() {
+    let (conductors, alice, _bob) = setup_two_agents().await;
+
+    let ndo: NdoOutput = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "create_ndo",
+            ndo_input("Round Trip NDO"),
+        )
+        .await;
+
+    // Creating an NDO does not join it — participation is an explicit act.
+    let members_before: Vec<AgentPubKey> = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "get_ndo_members",
+            ndo.action_hash.clone(),
+        )
+        .await;
+    assert!(
+        members_before.is_empty(),
+        "creating an NDO must not implicitly create membership"
+    );
+
+    let alice_key = alice.agent_pubkey().clone();
+    let is_member_before: bool = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "is_ndo_member",
+            (alice_key.clone(), ndo.action_hash.clone()),
+        )
+        .await;
+    assert!(!is_member_before, "initiator is not a member until joining");
+
+    let _: Record = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "join_ndo",
+            join_input(ndo.action_hash.clone()),
+        )
+        .await;
+
+    let members: Vec<AgentPubKey> = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "get_ndo_members",
+            ndo.action_hash.clone(),
+        )
+        .await;
+    assert_eq!(members, vec![alice_key.clone()], "joiner must be listed");
+
+    let is_member: bool = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "is_ndo_member",
+            (alice_key, ndo.action_hash),
+        )
+        .await;
+    assert!(is_member, "is_ndo_member must be true after join");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ndo_membership_double_join_is_rejected() {
+    let (conductors, alice, _bob) = setup_two_agents().await;
+
+    let ndo: NdoOutput = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "create_ndo",
+            ndo_input("Double Join NDO"),
+        )
+        .await;
+
+    let _: Record = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "join_ndo",
+            join_input(ndo.action_hash.clone()),
+        )
+        .await;
+
+    let second: Result<Record, _> = conductors[0]
+        .call_fallible(
+            &alice.zome("zome_resource"),
+            "join_ndo",
+            join_input(ndo.action_hash.clone()),
+        )
+        .await;
+    assert!(
+        second.is_err(),
+        "a second join from the same agent must be rejected (AlreadyMember)"
+    );
+
+    // The rejection must leave exactly one membership, not a duplicate.
+    let members: Vec<AgentPubKey> = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "get_ndo_members",
+            ndo.action_hash,
+        )
+        .await;
+    assert_eq!(members.len(), 1, "double join must not duplicate membership");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ndo_membership_join_unknown_identity_rejected() {
+    let (conductors, alice, _bob) = setup_two_agents().await;
+
+    // A syntactically valid ActionHash that is not a NondominiumIdentity in this cell.
+    // Using a real-but-wrong hash (an NDO's own membership record would also do) proves
+    // the check is about identity existence, not hash shape.
+    let bogus = ActionHash::from_raw_36(vec![0xdb; 36]);
+
+    let result: Result<Record, _> = conductors[0]
+        .call_fallible(
+            &alice.zome("zome_resource"),
+            "join_ndo",
+            join_input(bogus),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "joining an identity this cell does not hold must be rejected"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ndo_membership_two_agents_converge() {
+    let (conductors, alice, bob) = setup_two_agents().await;
+
+    let ndo: NdoOutput = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "create_ndo",
+            ndo_input("Shared NDO"),
+        )
+        .await;
+
+    let _: Record = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "join_ndo",
+            join_input(ndo.action_hash.clone()),
+        )
+        .await;
+
+    await_consistency_20_s([&alice, &bob]).await.unwrap();
+
+    let _: Record = conductors[1]
+        .call(
+            &bob.zome("zome_resource"),
+            "join_ndo",
+            join_input(ndo.action_hash.clone()),
+        )
+        .await;
+
+    await_consistency_20_s([&alice, &bob]).await.unwrap();
+
+    // Both agents must see both members. This is the claim that would fail if
+    // get_ndo_members did a per-link `get` instead of reading the link author:
+    // the peer's membership record may not be held by this shard yet.
+    for (conductor_idx, cell, who) in [(0usize, &alice, "alice"), (1usize, &bob, "bob")] {
+        let members: Vec<AgentPubKey> = conductors[conductor_idx]
+            .call(
+                &cell.zome("zome_resource"),
+                "get_ndo_members",
+                ndo.action_hash.clone(),
+            )
+            .await;
+        assert_eq!(
+            members.len(),
+            2,
+            "{who} must see both members, saw {members:?}"
+        );
+        assert!(
+            members.contains(alice.agent_pubkey()) && members.contains(bob.agent_pubkey()),
+            "{who} must see alice and bob, saw {members:?}"
+        );
+    }
+
+    // Cross-agent is_ndo_member: alice can confirm bob is taking part.
+    let bob_is_member: bool = conductors[0]
+        .call(
+            &alice.zome("zome_resource"),
+            "is_ndo_member",
+            (bob.agent_pubkey().clone(), ndo.action_hash),
+        )
+        .await;
+    assert!(bob_is_member, "alice must see bob as a member");
+}

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/lib.rs
@@ -4,11 +4,13 @@ pub use nondominium_shared::errors::ResourceError;
 pub mod economic_resource;
 pub mod governance_rule;
 pub mod ndo_identity;
+pub mod ndo_membership;
 pub mod resource_specification;
 
 pub use economic_resource::*;
 pub use governance_rule::*;
 pub use ndo_identity::*;
+pub use ndo_membership::*;
 pub use resource_specification::*;
 
 #[allow(clippy::large_enum_variant)]

--- a/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_membership.rs
+++ b/dnas/nondominium/zomes/coordinator/zome_resource/src/ndo_membership.rs
@@ -1,0 +1,118 @@
+//! NDO membership — explicit, listable participation in a Nondominium Object.
+//!
+//! Under the per-NDO-cell model (ADR-010 model A) each NDO is its own cloned cell, and an
+//! agent must already hold that cell to read the NDO at all. Membership therefore grants
+//! **nothing**: it records that the agent has declared participation so other members can
+//! enumerate who is taking part. No caller may treat the absence of an `NdoMembership` as a
+//! read denial — cell possession is what confers access.
+//!
+//! Mirrors the proven `zome_group::membership` pattern, including the hard-won rule that
+//! member identity is read from each link's `author` rather than from a `get` of the linked
+//! record (see `get_ndo_members`).
+
+use crate::ResourceError;
+use hdk::prelude::*;
+use std::collections::HashSet;
+use zome_resource_integrity::*;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JoinNdoInput {
+  pub ndo_identity_hash: ActionHash,
+  pub role: Option<String>,
+}
+
+/// Declare participation in this NDO.
+///
+/// Idempotent by contract: a second call from the same agent for the same NDO returns
+/// `AlreadyMember` rather than committing a duplicate entry. The guard reads the
+/// `MemberToNdos` reverse link, whose only author is the calling agent, so it is resolved
+/// from local state and cannot be defeated by gossip lag.
+#[hdk_extern]
+pub fn join_ndo(input: JoinNdoInput) -> ExternResult<Record> {
+  let agent = agent_info()?.agent_initial_pubkey;
+  let ndo_identity_hash = input.ndo_identity_hash;
+
+  // Semantic validation the integrity zome cannot do: the referenced identity must exist in
+  // this cell. Prevents membership entries that point at a hash from another DNA or at
+  // nothing at all. (The integrity zome deliberately skips this — see validate_ndo_membership.)
+  if get(ndo_identity_hash.clone(), GetOptions::default())?.is_none() {
+    return Err(ResourceError::NdoNotFound(format!("{:?}", ndo_identity_hash)).into());
+  }
+
+  let already_member = get_links(
+    LinkQuery::try_new(agent.clone(), LinkTypes::MemberToNdos)?,
+    GetStrategy::default(),
+  )?
+  .iter()
+  .any(|link| {
+    link
+      .target
+      .clone()
+      .into_action_hash()
+      .is_some_and(|h| h == ndo_identity_hash)
+  });
+  if already_member {
+    return Err(ResourceError::AlreadyMember.into());
+  }
+
+  let membership = NdoMembership {
+    ndo_identity_hash: ndo_identity_hash.clone(),
+    role: input.role,
+  };
+
+  let membership_hash = create_entry(&EntryTypes::NdoMembership(membership))?;
+  let record = get(membership_hash.clone(), GetOptions::default())?.ok_or(
+    ResourceError::EntryOperationFailed("Failed to retrieve created NdoMembership".to_string()),
+  )?;
+
+  create_link(
+    ndo_identity_hash.clone(),
+    membership_hash,
+    LinkTypes::NdoToMembers,
+    (),
+  )?;
+  create_link(agent, ndo_identity_hash, LinkTypes::MemberToNdos, ())?;
+
+  // TODO(signals): remote_signal other members with { kind: NdoMember, ndo_identity_hash }
+  // so their member list refreshes push-style instead of via poll/reload. Same pending
+  // upgrade as zome_group; the UI currently pulls on focus and a gentle poll.
+
+  Ok(record)
+}
+
+/// Returns the AgentPubKey of every declared member of this NDO.
+///
+/// Membership identity is read directly from each `NdoToMembers` link's `author` (the agent
+/// who called `join_ndo`), NOT from a `get` of the linked `NdoMembership` record. `get_links`
+/// returns every link and its author in one round-trip; a per-link `get` can fail when
+/// another member's record has not yet propagated to this cell's shard, silently dropping
+/// that member so only the local agent appears. That exact bug was fixed in `zome_group`;
+/// do not reintroduce it here. Duplicate authors are collapsed defensively.
+#[hdk_extern]
+pub fn get_ndo_members(ndo_identity_hash: ActionHash) -> ExternResult<Vec<AgentPubKey>> {
+  let links = get_links(
+    LinkQuery::try_new(ndo_identity_hash, LinkTypes::NdoToMembers)?,
+    GetStrategy::default(),
+  )?;
+
+  let mut seen: HashSet<AgentPubKey> = HashSet::new();
+  let mut members: Vec<AgentPubKey> = Vec::new();
+  for link in links {
+    if seen.insert(link.author.clone()) {
+      members.push(link.author);
+    }
+  }
+
+  Ok(members)
+}
+
+/// Whether `agent` has declared membership in this NDO.
+///
+/// This answers "is this agent taking part", never "may this agent read the NDO" — see the
+/// module docs. Used by the client to decide whether to show a Join affordance.
+#[hdk_extern]
+pub fn is_ndo_member(input: (AgentPubKey, ActionHash)) -> ExternResult<bool> {
+  let (agent, ndo_identity_hash) = input;
+  let members = get_ndo_members(ndo_identity_hash)?;
+  Ok(members.contains(&agent))
+}

--- a/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
+++ b/dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs
@@ -111,6 +111,23 @@ pub struct NondominiumIdentity {
   pub hibernation_origin: Option<LifecycleStage>,
 }
 
+// NDO membership — makes participation in an NDO explicit and listable.
+//
+// IMPORTANT: this is NOT an access grant. Under the per-NDO-cell model (ADR-010 model A) an
+// agent must already hold the cloned NDO cell to read the NDO at all, so cell possession is
+// what confers access. NdoMembership records that the agent has *declared* participation, so
+// other members can enumerate who is taking part. Nothing may treat its absence as a read
+// denial. See ndo_membership.rs in the coordinator.
+//
+// The joining agent is the action author; join timestamp comes from the action header —
+// neither is stored in the entry (same convention as GroupMembership in the group DNA).
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct NdoMembership {
+  pub ndo_identity_hash: ActionHash,
+  pub role: Option<String>,
+}
+
 #[hdk_entry_types]
 #[unit_enum(UnitEntryTypes)]
 #[derive(Serialize, Deserialize, SerializedBytes)]
@@ -119,6 +136,7 @@ pub enum EntryTypes {
   EconomicResource(EconomicResource),
   GovernanceRule(GovernanceRule),
   NondominiumIdentity(NondominiumIdentity),
+  NdoMembership(NdoMembership),
 }
 
 #[hdk_link_types]
@@ -140,6 +158,10 @@ pub enum LinkTypes {
   NdoByPropertyRegime, // Path("ndo.regime.{regime}")   → NondominiumIdentity action hashes
 
   // NDO Layer 0 lifecycle links
+  // NDO membership links (one NDO = one cloned cell)
+  NdoToMembers, // NondominiumIdentity action hash → NdoMembership
+  MemberToNdos, // member AgentPubKey → NondominiumIdentity action hash (duplicate-join guard)
+
   NdoToSuccessor, // deprecated NDO action hash → successor NondominiumIdentity (REQ-NDO-LC-06)
   NdoToTransitionEvent, // NDO action hash → EconomicEvent that triggered the transition (REQ-NDO-L0-05)
   // Link only; full event validation deferred (integrity cannot
@@ -202,6 +224,7 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
         EntryTypes::NondominiumIdentity(ndi) => {
           validate_create_nondominium_identity(&ndi, &action.author)
         }
+        EntryTypes::NdoMembership(membership) => validate_ndo_membership(&membership),
       },
       OpEntry::UpdateEntry {
         app_entry, action, ..
@@ -213,6 +236,7 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
           validate_update_economic_resource(&resource, &action.author)
         }
         EntryTypes::GovernanceRule(rule) => validate_update_governance_rule(&rule, &action.author),
+        EntryTypes::NdoMembership(membership) => validate_ndo_membership(&membership),
         EntryTypes::NondominiumIdentity(new_ndi) => {
           // Fetch original entry to enforce immutability of all fields except lifecycle_stage
           // (REQ-NDO-L0-03, REQ-NDO-L0-04)
@@ -346,6 +370,29 @@ fn validate_create_governance_rule(
     ));
   }
 
+  Ok(ValidateCallbackResult::Valid)
+}
+
+// NDO membership validation.
+//
+// The referenced NondominiumIdentity's existence is deliberately NOT checked here: an
+// ActionHash is always 39 bytes and `must_get_valid_record` on a hash from another agent's
+// chain would make membership creation depend on gossip timing. Semantic validation (the
+// identity exists in this cell) lives in the coordinator, matching the convention used by
+// GroupMembership and SoftLink in the group DNA.
+fn validate_ndo_membership(membership: &NdoMembership) -> ExternResult<ValidateCallbackResult> {
+  if let Some(role) = &membership.role {
+    if role.trim().is_empty() {
+      return Ok(ValidateCallbackResult::Invalid(
+        "NdoMembership role, when present, cannot be empty".to_string(),
+      ));
+    }
+    if role.len() > 100 {
+      return Ok(ValidateCallbackResult::Invalid(
+        "NdoMembership role too long (max 100 characters)".to_string(),
+      ));
+    }
+  }
   Ok(ValidateCallbackResult::Valid)
 }
 

--- a/documentation/DOCUMENTATION_INDEX.md
+++ b/documentation/DOCUMENTATION_INDEX.md
@@ -318,7 +318,7 @@ CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest 
 
 - Use `warn!` macro in Rust zome functions to log debugging information visible in test output
 - Use `#[ignore]` on tests not yet ready for execution
-- DHT sync between agents: `await_consistency_20_s(&[&cell_a, &cell_b]).await.unwrap()`
+- DHT sync between agents: `await_consistency_20_s([&cell_a, &cell_b]).await.unwrap()` (pass the array by value, not `&[...]`)
 
 ---
 

--- a/documentation/specifications/specifications.md
+++ b/documentation/specifications/specifications.md
@@ -1501,7 +1501,7 @@ Every "where is this NDO anchored" question is answered from a single `scanGroup
 | `getAssociatedGroupIds(ndoHashB64)` | Groups whose anchors carry this NDO identity, from the one scan |
 | `associateNdoWithGroup(ndoHashB64, groupId)` | Copies an existing anchor's clone coordinates into a second group as a new `NdoAnchor` (no-op if already anchored there) |
 | `getNdoTransitionHistory(hash)` | `get_ndo_transition_history` on the resolved ndo cell; legacy shared-cell fallback |
-| `joinNdo` / `getNdoMembers` | Stub (`NdoNotImplementedError`) until `zome_resource` implements NDO membership |
+| `joinNdo` / `getNdoMembers` | Resolves the ndo cell from anchor coordinates, then `join_ndo` / `get_ndo_members` on `zome_resource`. `joinNdo` is idempotent (`is_ndo_member` guard); member names resolve via `zome_person` with a truncated-pubkey fallback |
 
 ### 7.3 Error Context Registry
 

--- a/documentation/specifications/ui_architecture.md
+++ b/documentation/specifications/ui_architecture.md
@@ -261,7 +261,7 @@ const wz = <T>(fnName: string, payload: unknown, context: string) =>
 | `getNdoTransitionHistory(hash)` | `resource.getNdoTransitionHistory(hash)` (zome fn not yet implemented; returns `[]`) |
 | `getGroupNdoDescriptors(groupId)` | `get_soft_links` → resolve each target via `resource.getNdo` |
 | `getAssociatedGroupIds(ndoHashB64)` | SoftLink scan across agent's groups |
-| `joinNdo` / `getNdoMembers` | Stub — `NdoNotImplementedError` until `zome_resource` implements membership |
+| `joinNdo` / `getNdoMembers` | DHT-backed via `zome_resource` `join_ndo` / `get_ndo_members` on the per-NDO clone cell; `joinNdo` is idempotent |
 
 ### `lobby.service.ts` — LobbyServiceTag (Group + Lobby DNA)
 

--- a/documentation/zomes/resource_zome.md
+++ b/documentation/zomes/resource_zome.md
@@ -64,36 +64,41 @@ All other fields are permanently immutable after creation. Delete is always `Inv
 
 **Lifecycle links**: `NdoToSuccessor` (deprecated NDO → successor NDO, REQ-NDO-LC-06), `NdoToTransitionEvent` (NDO → triggering `EconomicEvent`, REQ-NDO-L0-05)
 
-### NDO membership (planned — MVP UI stub)
+### NDO membership
 
-> **Status**: UI flow exists in `NdoView.svelte`; coordinator functions are **not yet implemented** in `zome_resource`. Distinct from **Group `SoftLink`** association (curated NDO list per group).
+> **Status**: **Implemented.** Coordinator functions live in `zome_resource/src/ndo_membership.rs`; UI flow in `NdoView.svelte`. Distinct from **Group `SoftLink`** association (curated NDO list per group).
 
-When implemented, NDO membership lets an agent join an NDO as a participant/contributor independent of group membership.
+NDO membership lets an agent declare participation in an NDO independently of group membership.
 
-**Planned coordinator API** (`zome_resource`):
+**It is not an access grant.** Under the per-NDO-cell model (ADR-010 model A) an agent must already hold the cloned NDO cell to read the NDO at all, so cell possession is what confers access. `NdoMembership` makes participation *listable*; no code may treat its absence as a read denial.
+
+**Coordinator API** (`zome_resource`):
 
 | Function | Input | Output | Notes |
 |---|---|---|---|
-| `join_ndo` | `ndo_identity_hash: ActionHash` | `Record` (`NdoMembership`) | Agent signs membership; creates discovery links |
-| `get_ndo_members` | `ndo_identity_hash: ActionHash` | `Vec<Record>` | Public member list for UI |
+| `join_ndo` | `JoinNdoInput { ndo_identity_hash, role }` | `Record` (`NdoMembership`) | Idempotent: a second join returns `AlreadyMember`. Verifies the identity exists in this cell. |
+| `get_ndo_members` | `ndo_identity_hash: ActionHash` | `Vec<AgentPubKey>` | Members read from link **authors**, never a per-link `get` (see below) |
+| `is_ndo_member` | `(AgentPubKey, ActionHash)` | `bool` | "Is this agent taking part", never "may this agent read" |
 
-**Planned integrity entries**:
+**Integrity entry**:
 
 ```rust
 pub struct NdoMembership {
-    pub ndo_hash: ActionHash,
-    pub agent: AgentPubKey,
-    pub joined_at: Timestamp,
+    pub ndo_identity_hash: ActionHash,
     pub role: Option<String>, // e.g. "contributor", "observer" — community-defined
 }
 ```
 
-**Planned links**:
+The joining agent and join time are **not** stored in the entry: they come from the action header (`record.action().author()` / `.timestamp()`), matching the `GroupMembership` convention in the group DNA.
 
-- `NdoToMembers` — NDO identity hash → membership entry hashes (discovery)
-- `AgentToNdoMemberships` — agent pubkey → membership entry hashes (agent-centric query)
+**Links**:
 
-**UI contract** (`ndo.service.ts`): `joinNdo(hashB64)` and `getNdoMembers(hashB64)` return `NdoNotImplementedError` until the zome functions above land.
+- `NdoToMembers` — NDO identity hash → `NdoMembership` (discovery)
+- `MemberToNdos` — member pubkey → NDO identity hash (duplicate-join guard, resolved from local state)
+
+**Why members come from link authors**: `get_ndo_members` reads each `NdoToMembers` link's `author` rather than fetching the linked record. A per-link `get` can fail when another member's record has not yet gossiped to this shard, silently dropping that member so only the local agent appears. That exact bug was found and fixed in `zome_group`; do not reintroduce it.
+
+**Not in scope**: `leave_ndo` (no UI affordance yet), and `Person` entry creation on join (REQ-UI-ID-03 names joining an NDO as a Level 3 trigger, but that is a separate change to the identity model).
 
 **TODO (post-MVP)**: `get_ndo_transition_history(ndo_hash) -> Vec<NdoTransitionHistoryEvent>` for lifecycle audit panel (`TransitionHistoryPanel.svelte`).
 

--- a/ui/src/lib/components/group/MemberList.svelte
+++ b/ui/src/lib/components/group/MemberList.svelte
@@ -21,7 +21,10 @@
   {:else}
     <ul class="space-y-2">
       {#each members as m (m.id)}
-        <li class="flex items-center justify-between rounded border border-gray-200 bg-white px-3 py-2 text-sm">
+        <li
+          data-testid="member-row"
+          class="flex items-center justify-between rounded border border-gray-200 bg-white px-3 py-2 text-sm"
+        >
           <span class="font-medium text-gray-800">{m.name}</span>
           {#if m.role}
             <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">{m.role}</span>

--- a/ui/src/lib/components/ndo/NdoView.svelte
+++ b/ui/src/lib/components/ndo/NdoView.svelte
@@ -31,10 +31,11 @@
   let showAssociateModal = $state(false);
   let showJoinPanel = $state(false);
   let joinMessage = $state<string | null>(null);
+  let joinError = $state<string | null>(null);
   let joinLoading = $state(false);
   let ndoMembers = $state<{ id: string; name: string; role?: string }[]>([]);
   let membersLoading = $state(false);
-  let membersStubMessage = $state<string | null>(null);
+  let membersError = $state<string | null>(null);
 
   $effect(() => {
     try {
@@ -92,7 +93,7 @@
 
   async function loadNdoMembers() {
     membersLoading = true;
-    membersStubMessage = null;
+    membersError = null;
     const exit = await E.runPromiseExit(
       pipe(
         E.gen(function* () {
@@ -104,8 +105,7 @@
     );
     membersLoading = false;
     if (Exit.isFailure(exit)) {
-      membersStubMessage =
-        'NDO member listing is not yet implemented on the DHT. See documentation/zomes/resource_zome.md § NDO membership (planned).';
+      membersError = 'Could not load members. They may not have reached this node yet.';
       ndoMembers = [];
     } else {
       ndoMembers = exit.value.map((m) => ({ ...m, role: 'Member' }));
@@ -115,6 +115,7 @@
   async function handleJoinNdo() {
     joinLoading = true;
     joinMessage = null;
+    joinError = null;
     const exit = await E.runPromiseExit(
       pipe(
         E.gen(function* () {
@@ -126,8 +127,7 @@
     );
     joinLoading = false;
     if (Exit.isFailure(exit)) {
-      joinMessage =
-        'NDO membership is not yet implemented on the DHT. See documentation/zomes/resource_zome.md § NDO membership (planned).';
+      joinError = 'Could not join this NDO. Please try again.';
     } else {
       joinMessage = 'You have joined this NDO.';
       void loadNdoMembers();
@@ -136,7 +136,7 @@
   }
 
   $effect(() => {
-    if (showJoinPanel && ndoMembers.length === 0 && !membersLoading && !membersStubMessage) {
+    if (showJoinPanel && ndoMembers.length === 0 && !membersLoading && !membersError) {
       void loadNdoMembers();
     }
   });
@@ -306,24 +306,21 @@
           onclick={handleJoinNdo}
           class="rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50"
         >
-          {joinLoading ? 'Requesting…' : 'Request to join'}
+          {joinLoading ? 'Joining…' : 'Join this NDO'}
         </button>
       </div>
       {#if joinMessage}
-        <p
-          class="mt-2 text-xs {joinMessage.includes('not yet implemented')
-            ? 'text-amber-700'
-            : 'text-gray-600'}"
-        >
-          {joinMessage}
-        </p>
+        <p class="mt-2 text-xs text-gray-600">{joinMessage}</p>
+      {/if}
+      {#if joinError}
+        <p class="mt-2 text-xs text-amber-700">{joinError}</p>
       {/if}
       <div class="mt-4">
         <MemberList members={ndoMembers} />
         {#if membersLoading}
           <p class="mt-2 text-xs text-gray-400 italic">Loading members…</p>
-        {:else if membersStubMessage}
-          <p class="mt-2 text-xs text-amber-700">{membersStubMessage}</p>
+        {:else if membersError}
+          <p class="mt-2 text-xs text-amber-700">{membersError}</p>
         {/if}
       </div>
     </div>

--- a/ui/src/lib/errors/ndo.errors.ts
+++ b/ui/src/lib/errors/ndo.errors.ts
@@ -4,11 +4,6 @@ export class NdoNotFoundError extends Data.TaggedError('NdoNotFoundError')<{
   hash: string;
 }> { }
 
-export class NdoNotImplementedError extends Data.TaggedError('NdoNotImplementedError')<{
-  feature: string;
-  message: string;
-}> { }
-
 export class LobbyConnectionError extends Data.TaggedError('LobbyConnectionError')<{
   reason: string;
 }> { }

--- a/ui/src/lib/services/zomes/ndo.service.ts
+++ b/ui/src/lib/services/zomes/ndo.service.ts
@@ -1,5 +1,5 @@
 import { Context, Effect as E, Layer } from 'effect';
-import type { ActionHash, CellId } from '@holochain/client';
+import type { ActionHash, AgentPubKey, CellId } from '@holochain/client';
 import { decodeHashFromBase64, encodeHashToBase64 } from '@holochain/client';
 import type {
   NdoDescriptor,
@@ -11,7 +11,7 @@ import type {
   UpdateLifecycleStageInput,
   NdoTransitionHistoryEvent
 } from '@nondominium/shared-types';
-import { NdoNotFoundError, NdoNotImplementedError } from '$lib/errors/ndo.errors';
+import { NdoNotFoundError } from '$lib/errors/ndo.errors';
 import { ResourceError } from '$lib/errors/resource.errors';
 import {
   ResourceServiceTag,
@@ -19,6 +19,7 @@ import {
 } from './resource.service';
 import { LobbyServiceTag, LobbyServiceResolved } from './lobby.service';
 import { GroupServiceTag, GroupServiceResolved } from './group.service';
+import { PersonServiceTag, PersonServiceResolved } from './person.service';
 import {
   HolochainClientServiceTag,
   HolochainClientServiceLive
@@ -46,8 +47,15 @@ export interface NdoService {
     ndoHashB64: string,
     targetGroupId: string
   ) => E.Effect<void, ResourceError | NdoNotFoundError>;
-  joinNdo: (ndoHashB64: string) => E.Effect<void, NdoNotImplementedError>;
-  getNdoMembers: (ndoHashB64: string) => E.Effect<{ id: string; name: string }[], NdoNotImplementedError>;
+  /**
+   * Declare participation in an NDO. Idempotent: joining twice is a no-op, not an error.
+   * Membership makes participation listable; it is not an access grant (the agent already
+   * holds the cloned cell to read the NDO at all).
+   */
+  joinNdo: (ndoHashB64: string) => E.Effect<void, ResourceError | NdoNotFoundError>;
+  getNdoMembers: (
+    ndoHashB64: string
+  ) => E.Effect<{ id: string; name: string }[], ResourceError | NdoNotFoundError>;
 }
 
 export class NdoServiceTag extends Context.Tag('NdoService')<NdoServiceTag, NdoService>() {}
@@ -125,19 +133,25 @@ const NdoServiceDepsResolved = Layer.mergeAll(
   ResourceServiceResolved,
   LobbyServiceResolved,
   GroupServiceResolved,
+  PersonServiceResolved,
   HolochainClientServiceLive
 );
 
 export const NdoServiceLive: Layer.Layer<
   NdoServiceTag,
   never,
-  ResourceServiceTag | LobbyServiceTag | GroupServiceTag | HolochainClientServiceTag
+  | ResourceServiceTag
+  | LobbyServiceTag
+  | GroupServiceTag
+  | PersonServiceTag
+  | HolochainClientServiceTag
 > = Layer.effect(
   NdoServiceTag,
   E.gen(function* () {
     const resource = yield* ResourceServiceTag;
     const lobby = yield* LobbyServiceTag;
     const groupService = yield* GroupServiceTag;
+    const person = yield* PersonServiceTag;
     const holochainClient = yield* HolochainClientServiceTag;
 
     /** Call a zome_resource function on a specific ndo clone cell. */
@@ -258,6 +272,25 @@ export const NdoServiceLive: Layer.Layer<
         if (!first) return null;
         const cellId = yield* ensureCellForAnchor(first.anchor);
         return { cellId, anchor: first.anchor, matches };
+      });
+
+    /**
+     * Membership variant of the resolver. Unlike reads, membership has no legacy
+     * shared-cell fallback: an NDO with no anchor cannot be joined, so an unresolved
+     * identity is a hard NdoNotFoundError rather than a silent degrade.
+     */
+    const resolveNdoCellOrFail = (
+      identityHashB64: string
+    ): E.Effect<{ cellId: CellId; identityHash: ActionHash }, ResourceError | NdoNotFoundError> =>
+      E.gen(function* () {
+        const resolved = yield* resolveNdoCellForIdentity(identityHashB64);
+        if (!resolved) {
+          return yield* E.fail(new NdoNotFoundError({ hash: identityHashB64 }));
+        }
+        return {
+          cellId: resolved.cellId,
+          identityHash: resolved.anchor.identity_action_hash
+        };
       });
 
     return {
@@ -486,23 +519,51 @@ export const NdoServiceLive: Layer.Layer<
             .pipe(E.mapError((e) => ResourceError.fromError(e, 'CREATE_NDO_ANCHOR')));
         }),
 
-      joinNdo: () =>
-        E.fail(
-          new NdoNotImplementedError({
-            feature: 'join_ndo',
-            message:
-              'NDO membership is not yet implemented on the DHT. See documentation/zomes/resource_zome.md § NDO membership (planned).'
-          })
-        ),
+      joinNdo: (ndoHashB64) =>
+        E.gen(function* () {
+          const { cellId, identityHash } = yield* resolveNdoCellOrFail(ndoHashB64);
+          const myPubKey = yield* E.tryPromise({
+            try: () => holochainClient.getMyAgentPubKey(),
+            catch: (e) => ResourceError.fromError(e, 'NDO_CELL_JOIN_NDO')
+          });
 
-      getNdoMembers: () =>
-        E.fail(
-          new NdoNotImplementedError({
-            feature: 'get_ndo_members',
-            message:
-              'NDO member listing is not yet implemented on the DHT. See documentation/zomes/resource_zome.md § NDO membership (planned).'
-          })
-        )
+          // Idempotent by design: re-joining is a benign no-op, not an error the user
+          // should see. Mirrors the group's self-healing membership (REQ-UI-GRP-04).
+          const alreadyMember = yield* callNdoZome<boolean>(cellId, 'is_ndo_member', [
+            myPubKey,
+            identityHash
+          ]).pipe(E.catchAll(() => E.succeed(false)));
+          if (alreadyMember) return;
+
+          yield* callNdoZome<unknown>(cellId, 'join_ndo', {
+            ndo_identity_hash: identityHash,
+            role: null
+          });
+        }),
+
+      getNdoMembers: (ndoHashB64) =>
+        E.gen(function* () {
+          const { cellId, identityHash } = yield* resolveNdoCellOrFail(ndoHashB64);
+          const members = yield* callNdoZome<AgentPubKey[]>(
+            cellId,
+            'get_ndo_members',
+            identityHash
+          );
+
+          // Person entries live in the provisioned nondominium cell, not the ndo clone,
+          // so names are resolved separately. An agent with no Person entry yet is normal
+          // (REQ-UI-ID-03 defers Person creation); fall back to a truncated pubkey, the
+          // same convention the initiator display uses (REQ-UI-NDO-02).
+          const persons = yield* person.getAllPersons().pipe(E.catchAll(() => E.succeed([])));
+          const nameByKey = new Map(
+            persons.map((p) => [encodeHashToBase64(p.agent_pub_key), p.name])
+          );
+
+          return members.map((key) => {
+            const id = encodeHashToBase64(key);
+            return { id, name: nameByKey.get(id) ?? `${id.slice(0, 8)}…${id.slice(-4)}` };
+          });
+        })
     } satisfies NdoService;
   })
 );

--- a/ui/tests/e2e/specs/multi-agent.spec.ts
+++ b/ui/tests/e2e/specs/multi-agent.spec.ts
@@ -171,4 +171,37 @@ test.describe.serial('nondominium multi-agent flows', () => {
       { timeoutMs: 240_000, pollMs: 6_000, onPoll: async () => { await bob.reload(); } }
     );
   });
+
+  test('both agents join the NDO and see each other in the member list', async () => {
+    test.setTimeout(360_000);
+
+    // Membership is an explicit act: creating the NDO did not make alice a member.
+    // Both agents are already on the NDO detail page from the previous tests.
+    for (const page of [alice, bob]) {
+      await page.getByRole('button', { name: 'Join NDO' }).click();
+      await page.getByRole('button', { name: 'Join this NDO' }).click();
+      await expect(page.getByText('You have joined this NDO.')).toBeVisible({ timeout: 90_000 });
+    }
+
+    // Each agent's own membership commits locally, so it appears immediately; the
+    // peer's membership arrives by gossip, which is what the poll waits for. This is
+    // the assertion that fails if get_ndo_members ever fetches the linked record
+    // instead of reading the link author — the peer's record may not be held here.
+    for (const page of [alice, bob]) {
+      await expectEventually(
+        page,
+        async () => {
+          await expect(page.getByTestId('member-row')).toHaveCount(2, { timeout: 5_000 });
+        },
+        {
+          timeoutMs: 240_000,
+          pollMs: 6_000,
+          onPoll: async () => {
+            await page.reload();
+            await page.getByRole('button', { name: 'Join NDO' }).click();
+          }
+        }
+      );
+    }
+  });
 });


### PR DESCRIPTION
## What this does

Replaces the NDO membership **stub** (`NdoNotImplementedError`) with a real DHT-backed surface in `zome_resource`, so an agent can declare participation in an NDO and enumerate who else is taking part.

**Stacked on #128** (`fix/120-clone-cell-dna-properties`). Review/merge that first; this PR targets it as base.

## The design decision worth reading

**Membership is not an access grant.** Under the per-NDO-cell model (ADR-010 model A) an agent must already hold the cloned NDO cell to read the NDO at all, so *cell possession* is what confers access. `NdoMembership` only makes participation **listable**. Nothing may treat its absence as a read denial, and the module docs, integrity comments, and tests all say so explicitly so a future reader does not turn it into a permission check.

## Backend — `zome_resource`

New integrity entry:

```rust
pub struct NdoMembership {
    pub ndo_identity_hash: ActionHash,
    pub role: Option<String>,
}
```

The joining agent and join time are **not** in the entry — they come from the action header, matching the `GroupMembership` convention in the group DNA.

| Function | Behaviour |
|---|---|
| `join_ndo(JoinNdoInput)` | Idempotent: a second join returns `AlreadyMember`. Verifies the identity exists in this cell. Creates `NdoToMembers` + `MemberToNdos`. |
| `get_ndo_members(ActionHash)` | `Vec<AgentPubKey>`, read from each link's **author** |
| `is_ndo_member((AgentPubKey, ActionHash))` | "is this agent taking part", never "may this agent read" |

**Why members come from link authors, not a per-link `get`:** a per-link `get` can fail when a peer's membership record has not yet gossiped to this shard, silently dropping that member so only the local agent appears. That exact bug was found and fixed in `zome_group` (#126); the comment in `get_ndo_members` says not to reintroduce it, and the two-agent Sweettest is the assertion that would catch a regression.

Validation split follows the group DNA convention: integrity checks only what is local (role non-empty, <= 100 chars); identity existence is checked in the coordinator so membership creation never depends on gossip timing.

## UI

- `joinNdo` / `getNdoMembers` resolve the NDO clone cell from its anchor, then call the zome. Unlike reads, membership has **no legacy shared-cell fallback**: an unresolved identity is a hard `NdoNotFoundError` rather than a silent degrade.
- `joinNdo` guards on `is_ndo_member` so re-joining is a benign no-op (mirrors the group's self-healing membership, REQ-UI-GRP-04).
- Member names resolve via `zome_person` on the provisioned cell, with a truncated-pubkey fallback for agents who have no `Person` entry yet (normal — REQ-UI-ID-03 defers Person creation).
- `NdoNotImplementedError` deleted; the amber "not yet implemented" banners become real error states.

## Tests

- **Sweettest** `dnas/nondominium/tests/src/nondominium/ndo_membership/` — round trip (creating an NDO does *not* implicitly join it), double-join rejection with no duplicate, unknown-identity rejection, and two-agent convergence where each agent must see both members.
- **Playwright** `multi-agent.spec.ts` — both agents join and see each other in the member list, polling through gossip.

## Docs

`resource_zome.md`, `specifications.md`, `ui_architecture.md` move from "planned / stub" to implemented, with the not-an-access-grant rule and the link-author rule written down. `.rules` + `DOCUMENTATION_INDEX.md` record that `await_consistency_20_s` takes the array **by value** (`[&a, &b]`, not `&[&a, &b]`) — the bound is `IntoIterator<Item = &SweetCell>`, so a slice reference yields `&&SweetCell` and fails to compile.


Closes #133
