### PR TITLE
docs(sync): harmonize documentation and READMEs across the repo

### DIFF
--- a/.rules
+++ b/.rules
@@ -42,21 +42,33 @@ bun run package          # Create final .webhapp distribution
 
 ### Testing Commands
 
-**Primary test suite: Sweettest (Rust)** in `dnas/nondominium/tests/`
+**Primary test suite: Sweettest (Rust).** Full reference: `documentation/TEST_COMMANDS.md`.
 
 ```bash
 # Prerequisites — must run before any test execution:
 bun run build:happ
 
-# Run all Sweettest tests
+# Sweettest via package scripts
+bun run sweettest            # build:happ + run all nondominium Sweettest tests
+bun run sweettest:verbose    # same, with --nocapture
+bun run sweettest:only       # skip the build step
+
+# Or cargo directly (inside nix develop)
 CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
 
-# Run a specific test module
+# Run a specific test binary
 CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test person
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test misc
 
 # Run a specific test function
 CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test person person_create_populates_hrea_agent_hash
+```
+
+**E2E (Playwright + real conductors)** — see `ui/tests/README.md`:
+
+```bash
+bun run build:happ           # required once, or after zome changes
+bun run e2e                  # headless
+bun run e2e:ui               # Playwright UI mode
 ```
 
 > **Deprecated:** `bun run tests` runs the legacy Tryorama (TypeScript) test suite. All tests in `tests/` are deprecated. New tests must be written in Sweettest. See `tests/DEPRECATED.md`.
@@ -84,21 +96,33 @@ bun run --filter tests test        # Backend test execution
 
 ## Architecture Overview
 
-nondominium is a **3-zome Holochain hApp** implementing ValueFlows-compliant resource sharing:
+nondominium is a **multi-DNA Holochain hApp** implementing ValueFlows-compliant resource sharing. The `workdir/happ.yaml` manifest declares five roles:
 
-### Zome Architecture
+| Role | Provisioning | Source |
+|---|---|---|
+| `lobby` | provisioned, fixed seed `nondominium-lobby-v1` | `dnas/lobby/` — agent presence, global group registry |
+| `nondominium` | provisioned | `dnas/nondominium/` — the 3-zome core below |
+| `hrea` | provisioned | `vendor/hrea/` (git submodule) — canonical ValueFlows event recording |
+| `group` | cloned on demand, `clone_limit: 64` | `dnas/group/` — per-group coordination DHT |
+| `ndo` | cloned on demand, `clone_limit: 512` | `dnas/ndo/` — one DHT per Nondominium Object (#112) |
+
+### Zome Architecture (Nondominium DNA core)
 
 - **`zome_person`**: Agent identity, profiles, roles, capability-based access
 - **`zome_resource`**: Resource specifications and lifecycle management
 - **`zome_gouvernance`**: Commitments, claims, economic events, governance rules, PPR system
 
+The Lobby and Group DNAs have their own zomes (`zome_lobby_coordinator`, `zome_group`). See `documentation/zomes/architecture_overview.md`.
+
 ### Technology Stack
 
+Canonical list: `README.md` § Technology Stack. Summary:
+
 - **Backend**: Rust (Holochain HDK ^0.6.0 / HDI ^0.7.0), WASM compilation target
-- **Frontend**: Svelte 5.0 + TypeScript + Vite 6.2.5
-- **UI Stack**: UnoCSS (atomic CSS) + Melt UI next-gen (`melt`) for headless components
+- **Frontend**: SvelteKit 2 + Svelte 5 + TypeScript + Vite 7
+- **UI Stack**: UnoCSS (atomic CSS) + Melt UI next-gen (`melt`) + Effect-TS
 - **Testing**: Sweettest (Rust, `holochain = "=0.6.0" features = ["test_utils"]`) — primary; Tryorama (TypeScript) deprecated
-- **Client**: @holochain/client 0.19.0 for DHT interaction
+- **Client**: @holochain/client ^0.20.0 (UI); ^0.19.1 (root dev tooling)
 
 ### Data Model Foundations
 
@@ -112,7 +136,7 @@ nondominium is a **3-zome Holochain hApp** implementing ValueFlows-compliant res
 - **Normative NDO / capability requirements:** `documentation/requirements/ndo_prima_materia.md` (REQ-NDO-*, §6.6 Unyt, §6.7 Flowsta)
 - **Master index:** `documentation/DOCUMENTATION_INDEX.md`
 - **Integration stubs:** `documentation/requirements/post-mvp/unyt-integration.md`, `documentation/requirements/post-mvp/flowsta-integration.md`
-- **Ontology archives:** `documentation/archives/resources.md`, `agent.md`, `governance.md`
+- **Ontology references:** `documentation/requirements/resources.md`, `agent.md`, `governance.md`
 
 ## Key Development Patterns
 
@@ -135,7 +159,7 @@ create_link(path.path_entry_hash()?, hash.clone(), LinkTypes::AnchorType, LinkTa
 ### Privacy Model
 
 - **Public Data**: `Person` entries with name/avatar (discoverable)
-- **Private Data**: `EncryptedProfile` entries with PII (access-controlled)
+- **Private Data**: `PrivatePersonData` entries with PII, stored as Holochain private entries (capability-gated)
 - **Role Assignments**: Linked to profiles with validation metadata in link tags
 
 ### Function Naming Convention
@@ -150,21 +174,33 @@ create_link(path.path_entry_hash()?, hash.clone(), LinkTypes::AnchorType, LinkTa
 
 ### Primary: Sweettest (Rust)
 
-All new tests are written in Sweettest (Rust) in `dnas/nondominium/tests/src/`.
+All new tests are written in Sweettest (Rust). Each DNA has its own suite and its own `[[test]]` binaries:
+
+| Package | Location | `--test` binaries |
+|---|---|---|
+| `nondominium_sweettest` | `dnas/nondominium/tests/src/` | `misc`, `person`, `resource`, `governance`, `nondominium` |
+| `group_sweettest` | `dnas/group/tests/src/` | `group`, `ndo_anchor` |
+| `lobby_sweettest` | `dnas/lobby/tests/src/` | `lobby` |
 
 ```
 dnas/nondominium/tests/src/
 ├── lib.rs                  # Module declarations
-├── common/
-│   └── conductors.rs       # Shared setup: setup_two_agents(), setup_dual_dna_two_agents()
+├── common/conductors.rs    # Shared setup: setup_two_agents(), setup_dual_dna_two_agents()
 ├── misc/mod.rs             # Misc zome tests (ping)
-└── person/mod.rs           # Person zome + hREA bridge tests
+├── person/mod.rs           # Person zome + hREA bridge tests
+├── resource/mod.rs         # Resource zome tests
+├── governance/mod.rs       # Governance zome tests
+└── nondominium/            # NDO Layer 0 lifecycle tests (ndo_layer0/)
 ```
 
-**Shared setup functions** (from `common::conductors`):
-- `setup_two_agents()` — two conductors with nondominium DNA
-- `setup_three_agents()` — three conductors with nondominium DNA
+**Shared setup functions** (per suite, from `common::conductors`):
+- `setup_two_agents()` — two conductors with the suite's DNA
+- `setup_three_agents()` — three conductors with the suite's DNA
 - `setup_dual_dna_two_agents()` — two conductors with nondominium + hREA DNAs (explicit role names)
+
+> Group suite tests spin up 2 conductors each; run the full suite with `-- --test-threads 6`.
+
+Full command reference: `documentation/TEST_COMMANDS.md`.
 
 **DHT sync** between agents: `await_consistency_20_s([&cell_a, &cell_b]).await.unwrap()` (holochain 0.6.0 requires a timeout arg; use the `_20_s` wrapper). Pass the array **by value**, not `&[...]`: the bound is `IntoIterator<Item = &SweetCell>`, so a slice reference yields `&&SweetCell` and fails to compile.
 
@@ -174,8 +210,9 @@ Tests in `tests/` use Tryorama and are deprecated. See `tests/DEPRECATED.md` for
 
 ## Development Status
 
-**Phase 1 (Complete)**: Person management with role-based access control
-**Phase 2 (In Progress)**: Resource lifecycle and governance implementation, PPR system
-- NDO Layer 0 (`NondominiumIdentity` identity anchor): complete (#80)
+Canonical status: `README.md` § Development Status and `documentation/IMPLEMENTATION_STATUS.md`. Summary:
+
+- **Complete**: person management with role-based access, NDO Layer 0 (`NondominiumIdentity`, #80), MVP UI (Lobby → Group → NDO), Lobby DNA (#103), Group DNA (#107), DHT-backed group UI (#111)
+- **In progress**: NDO-per-cell architecture (#112), economic processes, PPR receipt generation, governance-as-operator, agent promotion workflows
 
 The codebase follows Holochain best practices with comprehensive testing, clear zome separation, and ValueFlows standard compliance.

--- a/README.md
+++ b/README.md
@@ -56,14 +56,9 @@ nondominium implements a modular governance-as-operator architecture that separa
 - **Testability**: Governance logic can be unit tested independently of data management
 - **Separation of Concerns**: Clear boundaries between data persistence and business rule enforcement
 
-**Technology Stack:**
+**Technology Stack:** see [Technology Stack](#technology-stack) below.
 
-- Backend: Rust (Holochain HDK ^0.6.0 / HDI ^0.7.0) compiled to WASM
-- Frontend: SvelteKit 2 + Svelte 5 + TypeScript + Vite 6.2.5 + UnoCSS + Melt UI next-gen + Effect-TS
-- Testing: Sweettest (Rust, primary) — Tryorama (TypeScript) is deprecated
-- Client: @holochain/client 0.19.0
-
-**Documentation map:** See [documentation/DOCUMENTATION_INDEX.md](documentation/DOCUMENTATION_INDEX.md). Post-MVP **NDO** model and optional **Unyt** / **Flowsta** integrations are specified in [documentation/requirements/ndo_prima_materia.md](documentation/requirements/ndo_prima_materia.md) and the stubs under [documentation/requirements/post-mvp/](documentation/requirements/post-mvp/).
+**Documentation map:** See [documentation/README.md](documentation/README.md). Post-MVP **NDO** model and optional **Unyt** / **Flowsta** integrations are specified in [documentation/requirements/ndo_prima_materia.md](documentation/requirements/ndo_prima_materia.md) and the stubs under [documentation/requirements/post-mvp/](documentation/requirements/post-mvp/).
 
 ## AI Tooling
 
@@ -98,12 +93,16 @@ primary discovery path) on every `nix develop`. `.agents/` is gitignored.
 
 > **PREREQUISITE**: Set up the [Holochain development environment](https://developer.holochain.org/docs/install/).
 
-Enter the nix shell by running this in the root folder of the repository:
+Run this in the root folder of the repository:
 
 ```bash
-nix develop              # Enter reproducible environment (REQUIRED)
-bun install              # Install all dependencies
+git submodule update --init --recursive  # Initialize the hREA submodule (REQUIRED)
+nix develop                              # Enter reproducible environment (REQUIRED)
+bun install                              # Install all dependencies
 ```
+
+The `hrea` role is vendored as a git submodule at `vendor/hrea`; `bun run build:happ` builds
+and packs it, so the build fails without this step.
 
 **⚠️ Run all commands from within the nix shell, otherwise they won't work.**
 
@@ -126,13 +125,16 @@ AGENTS=3 bun run network    # Bootstrap custom agent network (replace 3 with des
 ### Testing
 
 ```bash
-# Sweettest (Rust) — primary test runner
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
+bun run sweettest         # build:happ + all nondominium Sweettest tests
+bun run sweettest:verbose # same, with --nocapture
+bun run sweettest:only    # skip the build step
 
-# Test suites
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest person
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest -- --nocapture  # verbose
+bun run e2e               # Playwright E2E against real conductors
+bun run e2e:ui            # Playwright UI mode
 ```
+
+Full reference for every suite (nondominium / group / lobby Sweettest, E2E, legacy Tryorama):
+[documentation/TEST_COMMANDS.md](documentation/TEST_COMMANDS.md).
 
 > **Note**: Tryorama (TypeScript) tests in `tests/` are **deprecated**. See `tests/DEPRECATED.md`. Do not write new tests there.
 
@@ -186,6 +188,12 @@ Shared setup utilities (per suite `common::conductors`):
 - `setup_two_agents()` / `setup_three_agents()` — multi-conductor setups for the suite's DNA
 - `setup_dual_dna_two_agents()` — two conductors, nondominium + hREA DNAs
 
+**E2E: Playwright + real conductors**
+
+`ui/tests/` drives the Lobby → Group → NDO flows in a browser against real conductors,
+covering the UI-to-conductor seam and multi-agent UX that Sweettest cannot reach.
+See [ui/tests/README.md](ui/tests/README.md).
+
 **Deprecated: Tryorama (TypeScript)**
 
 Tests in `tests/` are deprecated. See `tests/DEPRECATED.md`. Do not write new tests there.
@@ -214,58 +222,40 @@ This generates:
 
 ## Documentation
 
-### Project Documentation
+**Start here: [documentation/README.md](documentation/README.md)** — the documentation hub,
+organized by topic. Two other entry points cover the same corpus differently:
 
-- [Requirements](documentation/requirements/requirements.md) - Project goals and functional requirements
-- [Specifications](documentation/specifications/specifications.md) - Detailed technical specifications
-- [Governance Operator Architecture](documentation/specifications/governance/governance-operator-architecture.md) - Modular governance design patterns
-- [Governance Implementation Guide](documentation/specifications/governance/governance-operator-implementation-guide.md) - Implementation details with code examples
-- [Cross-Zome API](documentation/specifications/governance/cross-zome-api.md) - API specifications for zome communication
-- [UI Architecture](documentation/specifications/ui_architecture.md) - Frontend architecture and design patterns
-- [Testing Infrastructure](documentation/Testing_Infrastructure.md) - Testing strategy and framework details
-- [ValueFlows Action Usage](documentation/specifications/VfAction_Usage.md) - ValueFlows implementation patterns with governance examples
-- [API Reference](documentation/API_REFERENCE.md) - Complete API documentation
-- [Documentation Index](documentation/DOCUMENTATION_INDEX.md) - Comprehensive documentation guide
+| Entry point | Use it for |
+|---|---|
+| [documentation/README.md](documentation/README.md) | Curated hub, grouped by topic. The default door. |
+| [documentation/DOCUMENTATION_INDEX.md](documentation/DOCUMENTATION_INDEX.md) | Annotated guide with commands and status per area |
+| [documentation/SUMMARY.md](documentation/SUMMARY.md) | Flat linear table of contents (mdBook order) |
 
-### Zome Documentation
+Most-used pages:
 
-- [Architecture Overview](documentation/zomes/architecture_overview.md) - Overall zome architecture and interactions
-- [Person Zome](documentation/zomes/person_zome.md) - Agent identity and profile management
-- [Resource Zome](documentation/zomes/resource_zome.md) - Resource lifecycle and management
-- [Governance Zome](documentation/zomes/governance_zome.md) - Governance rules and implementation
-
-### Governance & Security
-
-**Governance Architecture:**
-
-- [Governance Operator Architecture](documentation/specifications/governance/governance-operator-architecture.md) - Modular governance design patterns
-- [Governance Implementation Guide](documentation/specifications/governance/governance-operator-implementation-guide.md) - Implementation details with code examples
-- [Cross-Zome API](documentation/specifications/governance/cross-zome-api.md) - API specifications for zome communication
-- [Governance Model](documentation/specifications/governance/governance.md) - Legacy governance model and decision-making processes
-
-**Reputation & Security:**
-
-- [Private Participation Receipts](documentation/specifications/governance/private-participation-receipt.md) - PPR system documentation
-- [PPR Security Implementation](documentation/specifications/governance/PPR_Security_Implementation.md) - Security implementation for PPR system
-
-### Applications & Use Cases
-
-- [Artcoin Integration](documentation/Applications/nondominium_artcoin.md) - Artcoin application integration
-- [User Stories](documentation/Applications/user-story/) - Complete user journey scenarios
-
-### Additional Resources
-
-- [hREA Integration Strategy](documentation/hREA/integration-strategy.md) - hREA integration planning
-- [Resource Transport Flow Protocol](documentation/requirements/post-mvp/resource-transport-flow-protocol.md) - Resource transport specifications
-- [Protocol Bridge Specifications](documentation/specifications/protocol-bridge-specifications.md) - Bun Protocol Bridge architecture for platform integration (Tiki, Odoo, etc.)
+- [Requirements](documentation/requirements/requirements.md) — goals, REQ-* IDs, user stories
+- [Specifications](documentation/specifications/specifications.md) — zome entries, functions, cross-zome API
+- [API Reference](documentation/API_REFERENCE.md) — complete zome function reference
+- [Architecture Components](documentation/ARCHITECTURE_COMPONENTS.md) — system design and ADRs
+- [Zomes Overview](documentation/zomes/architecture_overview.md) — multi-DNA topology and the 3-zome core
+- [Test Commands](documentation/TEST_COMMANDS.md) — every test suite, one page
 
 ## Technology Stack
 
+This section is the canonical version list; other docs link here rather than restate it.
+
+| Layer | Choice |
+|---|---|
+| Backend | Rust, Holochain HDK ^0.6.0 / HDI ^0.7.0, WASM target |
+| Frontend | SvelteKit 2 + Svelte 5 (runes) + TypeScript + Vite 7 |
+| UI | UnoCSS + Melt UI next-gen (`melt`) + Effect-TS |
+| Client | [@holochain/client](https://www.npmjs.com/package/@holochain/client) ^0.20.0 (UI), ^0.19.1 (root tooling) |
+| Testing | Sweettest (Rust, `holochain = "=0.6.0"`) primary; Playwright for E2E; Tryorama deprecated |
+| Tooling | [bun](https://bun.sh/) workspaces, [Nix](https://nixos.org/) dev shell, [hc](https://github.com/holochain/holochain/tree/develop/crates/hc) CLI |
+
+Ecosystem:
+
 - [Holochain](https://holochain.org/): Distributed application framework
-- [NPM Workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces/): Monorepo management
-- [hc](https://github.com/holochain/holochain/tree/develop/crates/hc): Holochain CLI development tool
-- [@holochain/tryorama](https://www.npmjs.com/package/@holochain/tryorama): Testing framework
-- [@holochain/client](https://www.npmjs.com/package/@holochain/client): UI-to-Holochain client library
 - [Holochain Playground](https://github.com/darksoil-studio/holochain-playground): Development introspection tools
 - [Valueflows](https://www.valueflo.ws/): Economic coordination ontology
 - [hREA](https://github.com/h-REA/hREA/): Holochain implementation of Valueflows

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -46,7 +46,7 @@ For every PR, check:
 
 ### Flag if
 
-- A new `get_*` extern exposes `EncryptedProfile` or private data without a capability check
+- A new `get_*` extern exposes `PrivatePersonData` or private data without a capability check
 - A new role assignment function lacks link tag validation (role assignments store metadata in link tags)
 - `grant_private_data_access()` is modified to allow grants exceeding 30 days (hard cap per `PrivateDataCapabilityMetadata`)
 - A new entry type containing PII is marked public (not `Private` in entry def)

--- a/documentation/API_REFERENCE.md
+++ b/documentation/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # Nondominium API Reference
 
-**Generated**: 2025-12-17
-**Version**: 3.0 (Updated with Current Implementation)
+**Generated**: 2025-12-17 · **Resource / governance input structs re-synced against source 2026-08-29 (post-#132)**
+**Version**: 3.1 (Updated with Current Implementation)
 **Scope**: Complete function documentation for all zomes based on actual codebase
 
 ---
@@ -600,29 +600,32 @@ pub struct UpdateLifecycleStageInput {
 
 ### Resource Specification Management
 
-#### `create_resource_specification(input: ResourceSpecificationInput) -> ExternResult<Record>`
-**Purpose**: Define new resource type with properties and governance rules
-**Authorization**: Any agent can create resource specifications
+#### `create_resource_specification(input: ResourceSpecificationInput) -> ExternResult<CreateResourceSpecificationOutput>`
+**Purpose**: Activate NDO Layer 1 — define the resource's form and its typed governance rules
+**Authorization**: Any agent; the target NDO must be at lifecycle stage `Specification` through `Active`
 **Input**:
 ```rust
 pub struct ResourceSpecificationInput {
     pub name: String,
     pub description: String,
-    pub resource_class: String,
-    pub default_unit: String,
-    pub custom_properties: HashMap<String, PropertyValue>,
-    pub behavior: Option<String>,
-    pub conforming: bool,
-    pub image: Option<String>,
-    pub category: Option<String>,
+    pub category: String,
+    pub image_url: Option<String>,
     pub tags: Vec<String>,
-    pub governance_rules: Vec<ActionHash>,
+    pub scope: ResourceScope,          // Project | Network | Public
+    pub ndo_identity_hash: ActionHash, // Layer 0 NDO this spec activates
+    pub governance_rules: Vec<NestedGovernanceRuleInput>,
+}
+
+pub struct NestedGovernanceRuleInput {
+    pub rule_data: RuleData,
+    pub enforced_by: Option<String>,
 }
 ```
-**Returns**: Created `ResourceSpecification` entry
+**Returns**: `CreateResourceSpecificationOutput { spec_hash, spec, governance_rule_hashes }`
 **Side Effects**:
-- Creates specification entry with discovery anchors
-- Links to governance rules for compliance
+- Creates the specification entry with discovery anchors (`Project` scope skips the global anchor)
+- Creates the `NdoToSpecification` link — this is Layer 1 activation
+- Creates each nested `GovernanceRule` and links it via `SpecificationToGovernanceRule`, so rules are never orphaned
 - Creates category and tag-based discovery links
 
 #### `get_latest_resource_specification(original_action_hash: ActionHash) -> ExternResult<ResourceSpecification>`
@@ -786,21 +789,20 @@ pub struct UpdateOperationalStateInput {
 ### Governance Rules Management
 
 #### `create_governance_rule(input: GovernanceRuleInput) -> ExternResult<Record>`
-**Purpose**: Create governance rule for resource or process compliance
-**Authorization**: Governance role required
+**Purpose**: Create a typed governance rule bound to an NDO's classification
+**Authorization**: Any agent; `check_rule_data_permitted` rejects rules the NDO's `PropertyRegime` / `ResourceNature` forbid
 **Input**:
 ```rust
 pub struct GovernanceRuleInput {
-    pub name: String,
-    pub description: String,
-    pub rule_type: String,
-    pub resource_specification: Option<ActionHash>,
-    pub economic_process: Option<String>,
-    pub condition_expression: String,
-    pub action_required: String,
-    pub validation_method: String,
-    pub active: bool,
-    pub priority: u32,
+    pub rule_data: RuleData,           // AccessRequirement | UsageLimit | TransferCondition | MaintenanceSchedule
+    pub enforced_by: Option<String>,
+    pub ndo_identity_hash: ActionHash,
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+    pub rivalry_override: Option<Rivalry>,
+    /// Set this to link the rule to a spec. Omitting it creates an orphan rule
+    /// that `get_resource_specification_with_rules` cannot surface.
+    pub specification_hash: Option<ActionHash>,
 }
 ```
 **Returns**: Created `GovernanceRule` entry

--- a/documentation/ARCHITECTURE_COMPONENTS.md
+++ b/documentation/ARCHITECTURE_COMPONENTS.md
@@ -29,7 +29,7 @@ The core supports **four structured Economic Processes** (Use, Transport, Storag
 graph TB
     subgraph "Frontend Layer"
         UI["Svelte 5.0 + TypeScript"]
-        Client["holochain-client 0.19.0"]
+        Client["holochain-client ^0.20.0"]
     end
 
     subgraph "Holochain Runtime"
@@ -98,8 +98,8 @@ sequenceDiagram
 ┌─────────────────────────────────────────────────────────────┐
 │                    FRONTEND LAYER                           │
 ├─────────────────────────────────────────────────────────────┤
-│ Svelte 5.0 + TypeScript + Vite 6.2.5                        │
-│ @holochain/client 0.19.0                                    │
+│ Svelte 5.0 + TypeScript + Vite 7                            │
+│ @holochain/client ^0.20.0                                   │
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -133,7 +133,7 @@ graph TB
     subgraph "zome_person"
         subgraph "Agent Identity"
             Person[Person Entry<br/>Public Profile]
-            EncProfile[EncryptedProfile<br/>Private Data]
+            EncProfile[PrivatePersonData<br/>Private Data]
             Discovery[Discovery Anchors<br/>Agent Directory]
         end
 
@@ -171,7 +171,7 @@ graph TB
 ├─────────────────────────────────────────────────────────────┤
 │ 1.1 AGENT IDENTITY                                          │
 │ ├── Person Entry (public profile)                           │
-│ ├── EncryptedProfile Entry (private data)                   │
+│ ├── PrivatePersonData Entry (private data)                   │
 │ └── Discovery Anchors (findable agent directory)            │
 │                                                             │
 │ 1.2 CAPABILITY SYSTEM                                       │

--- a/documentation/DOCUMENTATION_INDEX.md
+++ b/documentation/DOCUMENTATION_INDEX.md
@@ -1,6 +1,9 @@
 # Nondominium Project Documentation Index
 
-**Updated**: 2026-05-04
+**Updated**: 2026-08-13
+
+> Annotated guide to the documentation set. For the topic-grouped hub see
+> [README.md](README.md); for a flat table of contents see [SUMMARY.md](SUMMARY.md).
 
 ---
 
@@ -23,8 +26,9 @@
 ### Prerequisites & Setup
 
 ```bash
-nix develop              # Enter reproducible environment (REQUIRED)
-bun install              # Install dependencies
+git submodule update --init --recursive  # Initialize the hREA submodule (REQUIRED)
+nix develop                              # Enter reproducible environment (REQUIRED)
+bun install                              # Install dependencies
 ```
 
 **Key Documentation:**
@@ -41,16 +45,20 @@ bun run start            # Start 2-agent development network with UIs
 AGENTS=3 bun run network # Custom agent network
 
 # Testing — Sweettest (Rust, primary)
-bun run build:happ
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test person
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest -- --nocapture
+bun run sweettest        # build:happ + all nondominium Sweettest tests
+bun run sweettest:only   # skip the build step
+
+# Testing — E2E (Playwright + real conductors)
+bun run e2e
+bun run e2e:ui
 
 # Build
 bun run build:zomes     # Compile Rust zomes to WASM
-bun run build:happ      # Package DNA into .happ bundle
+bun run build:happ      # Build zomes + hREA, pack all DNAs into the .happ bundle
 bun run package         # Create final .webhapp distribution
 ```
+
+Canonical command reference for every suite: [TEST_COMMANDS.md](TEST_COMMANDS.md).
 
 > **Note**: Tryorama (TypeScript) tests in `tests/` are **deprecated**. All new tests use Sweettest (Rust). See `tests/DEPRECATED.md`.
 
@@ -63,9 +71,9 @@ bun run package         # Create final .webhapp distribution
 nondominium implements a **Governance-as-Operator** architecture that separates data management from business logic enforcement:
 
 - **Framework**: Holochain HDK ^0.6.0 / HDI ^0.7.0 (Rust + WASM)
-- **Frontend**: Svelte 5.0 + TypeScript + Vite 6.2.5
+- **Frontend**: SvelteKit 2 + Svelte 5 + TypeScript + Vite 7
 - **Testing**: Sweettest (Rust, primary) — Tryorama (TypeScript) deprecated
-- **Client**: @holochain/client 0.19.0
+- **Client**: @holochain/client ^0.20.0
 - **Package Management**: Bun for dependency management and build orchestration
 
 ### Zome Structure

--- a/documentation/IMPLEMENTATION_STATUS.md
+++ b/documentation/IMPLEMENTATION_STATUS.md
@@ -10,14 +10,16 @@ This document tracks what is **actually implemented and verified** in the curren
 
 ### Technology Stack
 
+Canonical list: [README.md § Technology Stack](../README.md#technology-stack). Summary:
+
 - **Backend**: Rust (Holochain HDK ^0.6.0 / HDI ^0.7.0), compiled to WASM
-- **Frontend**: Svelte 5.0 + TypeScript + Vite 6.2.5 + UnoCSS + Melt UI next-gen
+- **Frontend**: SvelteKit 2 + Svelte 5 + TypeScript + Vite 7 + UnoCSS + Melt UI next-gen + Effect-TS
 - **Testing**: Sweettest (Rust, primary) — Tryorama (TypeScript) is deprecated
-- **Client**: @holochain/client 0.19.0 for DHT interaction
+- **Client**: @holochain/client ^0.20.0 (UI); ^0.19.1 (root dev tooling)
 
 ### Multi-DNA hApp Architecture
 
-The packaged hApp currently contains four roles:
+The packaged hApp declares five roles in `workdir/happ.yaml`:
 
 1. **`lobby`** — fixed, permissionless federation DHT for Lobby profiles and Group discovery
 2. **`nondominium`** — the core NDO DNA, containing:
@@ -26,8 +28,9 @@ The packaged hApp currently contains four roles:
    - `zome_gouvernance` — events, commitments, claims, validation, PPR prototypes, and federation extensions
 3. **`hrea`** — bundled hREA DNA used by the Person/ReaAgent bridge
 4. **`group`** — deferred template role; each Group is provisioned as an isolated cloned cell (`clone_limit: 64`)
+5. **`ndo`** — deferred template role; each NDO is provisioned as an isolated cloned cell (`clone_limit: 512`, ADR-010/ADR-013)
 
-Each local DNA domain follows the integrity/coordinator pattern. The core Nondominium domain remains a three-zome architecture, but the installed hApp is a multi-DNA system.
+Each local DNA domain follows the integrity/coordinator pattern; the Lobby and Group DNAs carry their own zomes (`zome_lobby_coordinator`, `zome_group`). The core Nondominium domain remains a three-zome architecture, but the installed hApp is a multi-DNA system. See [ARCHITECTURE_COMPONENTS.md](ARCHITECTURE_COMPONENTS.md) and [zomes/architecture_overview.md](zomes/architecture_overview.md).
 
 ### Status Terminology
 

--- a/documentation/IMPLEMENTATION_STATUS.md
+++ b/documentation/IMPLEMENTATION_STATUS.md
@@ -191,11 +191,13 @@ These are operational prototypes. Claim discovery uses DHT links (`AgentToPrivat
 - Multi-reviewer status tracking and validation history queries
 - Person↔governance private-data validation helpers
 
-Several checks are still simplified or stubbed: specialized-role validation auto-approves, authorization is incomplete in places, GovernanceRule semantics are not evaluated, and event/PPR generation is not uniformly automatic.
+Several checks are still simplified or stubbed: specialized-role validation auto-approves, authorization is incomplete in places, and event/PPR generation is not uniformly automatic. GovernanceRule *classification* semantics are now enforced (see below); per-rule runtime conditions are not.
 
-### Governance-as-Operator Architecture ❌ Specified, not implemented
+### Governance-as-Operator Architecture 🔄 Evaluate side implemented; Request side not wired
 
-The Request→Evaluate→Apply architecture is documented in `documentation/specifications/governance/`, but the Rust DNA does **not** currently define `GovernanceTransitionRequest`, `TransitionContext`, `GovernanceTransitionResult`, `evaluate_state_transition`, `evaluate_governance_transition`, or `request_resource_transition`. Existing validation and private-data helpers are related infrastructure, not that operator path. Tracked in #41–#44.
+`GovernanceTransitionRequest`, `TransitionContext`, and `GovernanceTransitionResult` are defined in `crates/shared/src/io/governance.rs`, and `evaluate_state_transition` is a live `#[hdk_extern]` in `zome_gouvernance/src/transition.rs` (#132). It evaluates the Hard and Soft classification constraints from `crates/shared/src/constraints.rs` and returns advisory warnings plus structured `soft_violations` for UI dry-run parity.
+
+Two pieces of the documented architecture are still absent: `request_resource_transition` (the resource-zome-side entry point) and `evaluate_governance_transition`. The evaluation path is therefore **parallel and advisory** rather than the mandatory funnel — `propose_commitment` and `log_economic_event` still write directly, with their own inline constraint checks, instead of routing through the operator. `GovernanceTransitionResult.economic_event_hash` is always `None` on this path because event generation is not yet wired. Tracked in #41–#44.
 
 ---
 
@@ -454,7 +456,8 @@ CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
 | Role promotion and specialized validation              | 🔄 Partial; placeholder/auto-approval paths remain |
 | Resource specifications and economic resources         | ✅ CRUD/query model implemented |
 | GovernanceRule persistence                             | ✅ Implemented |
-| GovernanceRule semantic enforcement                    | ❌ Not implemented |
+| GovernanceRule classification constraints              | ✅ Hard/Soft predicates enforced at integrity and in `evaluate_state_transition` (#132) |
+| GovernanceRule per-rule runtime conditions             | ❌ Not implemented (`requires_validation`, `min_affiliation`, quotas) |
 | ValueFlows action vocabulary + EconomicEvents          | ✅ Implemented |
 | Commitments and Claims                                 | ✅ Implemented |
 | PPR types, validation, local queries, and summaries     | 🔄 Prototype |
@@ -503,12 +506,12 @@ The following are documented and traceable to REQ-NDO-\* in `documentation/requi
 | Track                                             | Design sources                                                                    | Implementation status                                                                                                                                  |
 | ------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **NDO Layer 0 (identity anchor)**                 | `ndo_prima_materia.md` §§4, 8; REQ-NDO-L0-01–07                                   | **Implemented** (#80/#84) — identity, lifecycle validation, and facet anchors exist; required EconomicEvent generation and complete link-integrity hardening remain pending |
-| **NDO Layers 1 & 2**                              | `ndo_prima_materia.md` §§4, 8, 10; `resources.md` §3                              | Not started — Layer 1 (Specification links), Layer 2 (Process links), cross-layer link types pending                                                   |
+| **NDO Layers 1 & 2**                              | `ndo_prima_materia.md` §§4, 8, 10; `resources.md` §3                              | 🔄 Layer 1 implemented (#132) — `NdoToSpecification` created on every `create_resource_specification`, with the Layer 0 pointer pair (`ndo_identity_hash` / `ndo_state_hash`) and a lifecycle gate. Layer 2 (`NDOToProcess`) not started |
 | **Lifecycle vs operational state split**          | `ndo_prima_materia.md` §5, §9.4 (`REQ-NDO-OS-01`, `REQ-NDO-OS-06`)                | ✅ Data layer — `OperationalState` on `EconomicResource`; governance-operator transitions (`REQ-NDO-OS-02`–`05`) deferred |
 | **Unyt (EconomicAgreement, RAVE)**                | `ndo_prima_materia.md` §6.6, §11.5; `unyt-integration.md`; REQ-NDO-CS-07–CS-11    | Not started — no Unyt cell / RAVE validation in governance zome                                                                                        |
 | **Flowsta (agent linking, IdentityVerification)** | `ndo_prima_materia.md` §6.7, §11.6; `flowsta-integration.md`; REQ-NDO-CS-12–CS-15 | Not started — `flowsta-agent-linking` zomes not bundled                                                                                                |
 | **Person capability slot (G15)**                  | `agent.md` §3.2; `person_zome.md`; REQ-AGENT-11, REQ-NDO-AGENT-07                 | Not started — no `FlowstaIdentity` links on `Person` hash                                                                                              |
-| **Lobby DNA (multi-network federation entry point)** | `post-mvp/lobby-dna.md` REQ-LOBBY-*; `specifications/post-mvp/lobby-architecture.md` | **Implemented** (#103) — Lobby DNA with `LobbyAgentProfile` + `GroupAnnouncement`, 9 coordinator externs, 5 Sweettest scenarios, `lobby` role in `happ.yaml`, and Moss manifest. Group DNA complete for its current scope (#107). |
-| **NDO DNA extensions (NdoHardLink, Contribution, Agreement)** | `post-mvp/lobby-dna.md` REQ-NDO-EXT-01–16; `specifications/post-mvp/lobby-architecture.md §6` | **Implemented** (#103) — entry types, link types, and coordinator modules exist; hard-link Sweettest is active, while Agreement/Contribution scenarios are currently ignored. |
+| **Lobby DNA (multi-network federation entry point)** | `requirements/lobby-dna.md` REQ-LOBBY-*; `specifications/lobby-architecture.md` | **Implemented** (#103) — Lobby DNA with `LobbyAgentProfile` + `GroupAnnouncement`, 9 coordinator externs, 5 Sweettest scenarios, `lobby` role in `happ.yaml`, and Moss manifest. Group DNA complete for its current scope (#107). |
+| **NDO DNA extensions (NdoHardLink, Contribution, Agreement)** | `requirements/lobby-dna.md` REQ-NDO-EXT-01–16; `specifications/lobby-architecture.md §6` | **Implemented** (#103) — entry types, link types, and coordinator modules exist; hard-link Sweettest is active, while Agreement/Contribution scenarios are currently ignored. |
 
 See `documentation/implementation_plan.md` Section 12 for a phased checklist aligned with the prima materia.

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,6 +2,10 @@
 
 Infrastructure for organization-agnostic, uncapturable, self-governed resources — built on Holochain and ValueFlows.
 
+This page is the hub. Two alternate views of the same corpus:
+[DOCUMENTATION_INDEX.md](DOCUMENTATION_INDEX.md) (annotated guide, with commands and per-area
+status) and [SUMMARY.md](SUMMARY.md) (flat linear table of contents).
+
 ## Getting Started
 
 - [TELOS](TELOS.md) - Project vision, mission, and philosophy
@@ -29,7 +33,13 @@ Infrastructure for organization-agnostic, uncapturable, self-governed resources 
 
 - [Technical Specifications](specifications/specifications.md) - Zome entries, functions, cross-zome API
 - [Governance Operator Architecture](specifications/governance/governance-operator-architecture.md) - State transition pattern
+- [Governance Implementation Guide](specifications/governance/governance-operator-implementation-guide.md) - Implementation with code examples
+- [Cross-Zome API](specifications/governance/cross-zome-api.md) - Zome-to-zome call contracts
+- [Governance Model](specifications/governance/governance.md) - Legacy governance model and decision processes
 - [Private Participation Receipt](specifications/governance/private-participation-receipt.md) - PPR system design
+- [PPR Security Implementation](specifications/governance/PPR_Security_Implementation.md) - PPR security model
+- [ValueFlows Action Usage](specifications/VfAction_Usage.md) - VF action patterns with governance examples
+- [Protocol Bridge Specifications](specifications/protocol-bridge-specifications.md) - Bun bridge for platform integration (Tiki, Odoo)
 - [UI Architecture](specifications/ui_architecture.md) - Svelte 5 service and store layer
 - [API Reference](API_REFERENCE.md) - Complete zome function reference
 
@@ -38,11 +48,22 @@ Infrastructure for organization-agnostic, uncapturable, self-governed resources 
 - [Implementation Plan](implementation_plan.md) - Phased delivery roadmap
 - [Development Report](development-report.md) - Progress log
 - [Testing Infrastructure](Testing_Infrastructure.md) - Sweettest suite guide
-- [Test Commands](TEST_COMMANDS.md) - Quick command reference
+- [Test Commands](TEST_COMMANDS.md) - Canonical command reference for every suite
+- [E2E Test Suite](../ui/tests/README.md) - Playwright against real conductors
+- [UI README](../ui/README.md) - Frontend dev harness and layout
 
 ## Applications
 
 - [Artcoin](Applications/artcoin_main_doc.md) - Open-source art economy use case
+- [Nondominium × Artcoin](Applications/nondominium_artcoin.md) - Artcoin integration detail
 - [Distributed Journalism](Applications/distributed_journalism.md)
 - [ERP Holochain Bridge](Applications/erp_holochain_bridge.md)
 - [HealthNet](Applications/healthnet.md)
+- [User Stories](Applications/user-story/) - Complete user journey scenarios
+
+## Post-MVP
+
+- [Unyt Integration](requirements/post-mvp/unyt-integration.md) - Economic settlement layer
+- [Flowsta Integration](requirements/post-mvp/flowsta-integration.md) - Cross-app identity and DID
+- [Resource Transport Flow Protocol](requirements/post-mvp/resource-transport-flow-protocol.md)
+- [Full post-MVP set](requirements/post-mvp/) - Versioning, many-to-many flows, digital integrity, DSL

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -12,17 +12,19 @@
 - [Resource Ontology](requirements/resources.md)
 - [Governance Ontology](requirements/governance.md)
 - [NDO Prima Materia](requirements/ndo_prima_materia.md)
+- [Lobby DNA](requirements/lobby-dna.md)
 - [UI Design](requirements/ui_design.md)
 
 ## Post-MVP Requirements
 
-- [Complete Resource Specification](requirements/post-mvp/complete-resource-specification.md)
 - [Digital Resource Integrity](requirements/post-mvp/digital-resource-integrity.md)
+- [Fractal Composable Resource Architecture](requirements/post-mvp/fractal-composable-resource-architecture.md)
 - [Many-to-Many Flows](requirements/post-mvp/many-to-many-flows.md)
+- [NDO Versioning](requirements/post-mvp/ndo-versioning.md)
+- [Open Know-How / IOPA](requirements/post-mvp/open-know-how-iopa.md)
+- [Project-Type NDO Specifications](requirements/post-mvp/project-type-ndo-specifications.md)
 - [Resource Transport Flow Protocol](requirements/post-mvp/resource-transport-flow-protocol.md)
-- [Versioning](requirements/post-mvp/versioning.md)
 - [ValueFlows DSL](requirements/post-mvp/valueflows-dsl.md)
-- [Lobby DNA](requirements/post-mvp/lobby-dna.md)
 - [Unyt Integration](requirements/post-mvp/unyt-integration.md)
 - [Flowsta Integration](requirements/post-mvp/flowsta-integration.md)
 
@@ -47,9 +49,10 @@
 - [Private Participation Receipt](specifications/governance/private-participation-receipt.md)
 - [PPR Security Implementation](specifications/governance/PPR_Security_Implementation.md)
 
+- [Lobby Architecture](specifications/lobby-architecture.md)
+
 ## Post-MVP Specifications
 
-- [Lobby Architecture](specifications/post-mvp/lobby-architecture.md)
 - [ValueFlows DSL Specs](specifications/post-mvp/valueflows-dsl-specs.md)
 
 ---
@@ -60,6 +63,8 @@
 - [Person Zome](zomes/person_zome.md)
 - [Resource Zome](zomes/resource_zome.md)
 - [Governance Zome](zomes/governance_zome.md)
+- [Lobby Zome](zomes/lobby_zome.md)
+- [Group Zome](zomes/group_zome.md)
 
 ---
 
@@ -79,6 +84,7 @@
 - [Development Report](development-report.md)
 - [Testing Infrastructure](Testing_Infrastructure.md)
 - [Test Commands](TEST_COMMANDS.md)
+- [E2E Test Suite](../ui/tests/README.md)
 
 ---
 
@@ -113,7 +119,6 @@
 
 - [P2P Models Comparison](archives/P2PMODELS_COMPARISON_REPORT.md)
 - [Nondominium Mutualization](archives/nondominium_mutualization.md)
-- [Fractal Composable Resource Architecture](archives/fractal-composable-resource-architecture.md)
 - [Digital Fabrics Concept](archives/digital_fabrics_concept_definition_2025-10-28.md)
 - [Holochain Storage Verification Patterns](archives/holochain-storage-verification-patterns.md)
 - [Complexity Oriented Programming](archives/complexity_oriented_programming.md)

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -2,6 +2,7 @@
 
 [Introduction](README.md)
 [TELOS](TELOS.md)
+[Documentation Index](DOCUMENTATION_INDEX.md)
 
 ---
 
@@ -17,6 +18,7 @@
 
 ## Post-MVP Requirements
 
+- [Complete Resource Specification](requirements/post-mvp/complete-resource-specification.md)
 - [Digital Resource Integrity](requirements/post-mvp/digital-resource-integrity.md)
 - [Fractal Composable Resource Architecture](requirements/post-mvp/fractal-composable-resource-architecture.md)
 - [Many-to-Many Flows](requirements/post-mvp/many-to-many-flows.md)
@@ -24,6 +26,10 @@
 - [Open Know-How / IOPA](requirements/post-mvp/open-know-how-iopa.md)
 - [Project-Type NDO Specifications](requirements/post-mvp/project-type-ndo-specifications.md)
 - [Resource Transport Flow Protocol](requirements/post-mvp/resource-transport-flow-protocol.md)
+- [Source-NDO (planning scaffold)](requirements/post-mvp/Source-NDO.md)
+- [Source-NDO Paper](requirements/post-mvp/source-ndo-paper.md)
+- [Source-NDO Requirements](requirements/post-mvp/source-ndo-requirements.md)
+- [Source / ValueFlows Integration](requirements/post-mvp/source-valueflows-integration.md)
 - [ValueFlows DSL](requirements/post-mvp/valueflows-dsl.md)
 - [Unyt Integration](requirements/post-mvp/unyt-integration.md)
 - [Flowsta Integration](requirements/post-mvp/flowsta-integration.md)
@@ -39,6 +45,10 @@
 - [VfAction Usage](specifications/VfAction_Usage.md)
 - [Protocol Bridge Specifications](specifications/protocol-bridge-specifications.md)
 - [API Reference](API_REFERENCE.md)
+
+## Architecture Decision Records
+
+- [ADR-010–013: Per-NDO Cells](specifications/adr/ADR-010-013-per-ndo-cells.md)
 
 ## Governance Specifications
 
@@ -74,6 +84,7 @@
 - [Integration Strategy](hREA/integration-strategy.md)
 - [Strategic Roadmap](hREA/strategic-roadmap.md)
 - [ValueFlows 1.0 Compliance](hREA/valueflows-1.0-compliance.md)
+- [v0.2 Release Plan](hREA/v0.2-release-plan.md)
 
 ---
 
@@ -92,9 +103,11 @@
 
 - [Artcoin](Applications/artcoin_main_doc.md)
 - [Nondominium × Artcoin](Applications/nondominium_artcoin.md)
+- [Digital Dairy Chain](Applications/digitaldairychain.md)
 - [Distributed Journalism](Applications/distributed_journalism.md)
 - [ERP Holochain Bridge](Applications/erp_holochain_bridge.md)
 - [HealthNet](Applications/healthnet.md)
+- [Regenerative Farming](Applications/regen_farming.md)
 - [Strategic Development](Applications/strategic_development.md)
 
 ## User Stories

--- a/documentation/TEST_COMMANDS.md
+++ b/documentation/TEST_COMMANDS.md
@@ -1,16 +1,23 @@
 # Test Commands Reference
 
-Quick reference for running tests from the project root.
+Canonical command reference for running tests from the project root. This is the one place
+that lists every suite; other docs link here rather than restating commands.
+
+**Suite status:** Sweettest (Rust) is the **primary** suite and the only place new tests are
+written. Tryorama (TypeScript, `tests/`) is **deprecated** — see [`tests/DEPRECATED.md`](../tests/DEPRECATED.md).
+E2E (Playwright) covers the UI-to-conductor seam — see [`ui/tests/README.md`](../ui/tests/README.md).
 
 ## 🦀 **Sweettest (Rust) — Primary**
 
 Runs Holochain in-process. Faster, no WebSocket round-trip, direct Rust types.
 
-Four `[[test]]` binaries (targets for `cargo test --test <name>`):
-- `misc` — ping test, validates full build chain end-to-end
-- `person` — Person zome + hREA bridge tests
-- `resource` — Resource zome tests
-- `nondominium` — NDO Layer 0 (`NondominiumIdentity`) lifecycle tests (8 scenarios)
+Each DNA has its own Sweettest package. `[[test]]` binaries (targets for `cargo test --test <name>`):
+
+| Package | Binaries |
+|---|---|
+| `nondominium_sweettest` | `misc` — ping test, validates full build chain end-to-end<br>`person` — Person zome + hREA bridge tests<br>`resource` — Resource zome tests<br>`governance` — Governance zome tests (hard links, contributions, agreements)<br>`nondominium` — NDO Layer 0 (`NondominiumIdentity`) lifecycle tests |
+| `group_sweettest` | `group` — group lifecycle, membership, work logs, soft links<br>`ndo_anchor` — NDO anchor tests |
+| `lobby_sweettest` | `lobby` — agent profiles and group announcements |
 
 ```bash
 # Build .dna bundle then run all Rust tests
@@ -70,6 +77,9 @@ CARGO_TARGET_DIR=target/native-tests cargo test --package group_sweettest --test
 
 # Run a single test (no thread limit needed)
 CARGO_TARGET_DIR=target/native-tests cargo test --package group_sweettest --test group join_group_creates_membership
+
+# NDO anchor tests (second binary in the same package)
+CARGO_TARGET_DIR=target/native-tests cargo test --package group_sweettest --test ndo_anchor
 ```
 
 ### NDO Layer 0 tests (`--test nondominium`)
@@ -82,12 +92,28 @@ CARGO_TARGET_DIR=target/native-tests cargo test --test nondominium
 CARGO_TARGET_DIR=target/native-tests cargo test --test nondominium ndo_cross_agent_discovery
 ```
 
-## 📋 **Tryorama (TypeScript) — Deprecated**
+## 🎭 **E2E (Playwright + real conductors)**
 
-Still the primary test suite until NDO refactor lands and Sweettest tests are co-evolved.
+Browser-level coverage of the Lobby → Group → NDO holarchy against real conductors. Full
+detail, architecture, and debugging notes: [`ui/tests/README.md`](../ui/tests/README.md).
 
+```bash
+bun run build:happ          # once, or after zome changes — e2e does NOT rebuild
+bun run e2e                 # headless
+bun run e2e:ui              # Playwright UI mode (debugging)
 
-## 🚀 **Basic Test Commands**
+E2E_PLAYGROUND=1 bun run e2e   # also start `hc playground` for DHT inspection
+```
+
+---
+
+## 📋 **Tryorama (TypeScript) — DEPRECATED**
+
+> **Do not write new tests here.** Everything below documents the legacy Tryorama suite in
+> `tests/`, kept as historical reference only and no longer maintained. New tests go in
+> Sweettest (above). Migration status: [`tests/DEPRECATED.md`](../tests/DEPRECATED.md).
+
+### Basic Test Commands (legacy)
 
 All commands automatically build zomes and package the hApp before running tests.
 
@@ -105,7 +131,7 @@ bun tests --watch
 bun tests --coverage
 ```
 
-## 🎯 **Pattern-Based Test Selection**
+### 🎯 **Pattern-Based Test Selection**
 
 The test system uses file name pattern matching to run specific test subsets:
 
@@ -123,7 +149,7 @@ bun tests governance
 bun tests ppr
 ```
 
-## 📂 **Layer-Specific Test Patterns**
+### 📂 **Layer-Specific Test Patterns**
 
 ```bash
 # Run all foundation tests (basic connectivity)
@@ -136,7 +162,7 @@ bun tests integration
 bun tests scenario
 ```
 
-## 🔧 **Specific Test Files**
+### 🔧 **Specific Test Files**
 
 ```bash
 # Run specific test files using partial name matching
@@ -155,7 +181,7 @@ bun tests person-capability
 bun tests governance-foundation
 ```
 
-## 🎯 **Development Workflow Commands**
+### 🎯 **Development Workflow Commands**
 
 ```bash
 # Development with hot reload
@@ -170,7 +196,7 @@ bun tests governance
 bun tests person
 ```
 
-## 🧹 **Test Quality & Type Checking**
+### 🧹 **Test Quality & Type Checking**
 
 ```bash
 # Run tests with type checking
@@ -183,10 +209,15 @@ cd tests && npm run check
 bun tests --coverage
 ```
 
+---
+
 ## 💡 **Test Development Tips**
 
 ### Test Isolation During Development
-Use `.only()` on specific test blocks to run single tests:
+
+Sweettest (Rust): mark unfinished tests `#[ignore]`, or filter by name with `cargo test <name>`.
+
+Tryorama (legacy): use `.only()` on specific test blocks to run single tests:
 
 ```typescript
 describe.only('specific test suite', () => { ... })  // Run only this suite
@@ -203,7 +234,13 @@ warn!("Checkpoint reached in function_name");
 warn!("Processing entry: {}", entry_hash);
 ```
 
-## 📊 **Test File Structure**
+---
+
+## 📦 **Tryorama legacy reference (deprecated)**
+
+> Everything in this section describes the deprecated `tests/` suite. Kept for archaeology.
+
+### 📊 **Test File Structure**
 
 ```
 tests/src/nondominium/
@@ -229,14 +266,14 @@ tests/src/nondominium/
     └── misc.test.ts
 ```
 
-## 🎯 **Recommended Testing Workflow**
+### 🎯 **Recommended Testing Workflow**
 
 1. **Feature Development**: `bun tests --watch <feature-area>`
 2. **Specific Test Debugging**: `bun tests --reporter=verbose <specific-test>`
 3. **Pre-commit Validation**: `bun tests foundation && bun tests --typecheck`
 4. **Full Validation**: `bun tests && bun tests --coverage`
 
-## 🔍 **Pattern Matching Rules**
+### 🔍 **Pattern Matching Rules**
 
 The `bun tests` command uses Vitest's file filtering:
 - **Prefix Matching**: `bun tests person` matches all files starting with "person-"
@@ -244,7 +281,7 @@ The `bun tests` command uses Vitest's file filtering:
 - **Specific Files**: Use unique parts of filenames for precise selection
 - **Multiple Patterns**: Chain multiple patterns for broader coverage
 
-## ⚡ **Performance Tips**
+### ⚡ **Performance Tips**
 
 - **Use Specific Patterns**: `bun tests person-foundation` is faster than `bun tests person`
 - **Foundation First**: Run foundation tests before integration/scenario tests

--- a/documentation/hREA/integration-strategy.md
+++ b/documentation/hREA/integration-strategy.md
@@ -27,8 +27,8 @@ This document outlines the comprehensive integration strategy for incorporating 
 │                (Specialized Engine - 3 Zomes)               │
 │  ┌─────────────────┬─────────────────┬─────────────────┐    │
 │  │   Person        │    Resource     │   Governance    │    │
-│  │  (Encrypted     │  (Delegates to  │  (PPR, Rules,   │    │
-│  │   Profile +     │   hREA for core │  Validation —   │    │
+│  │  (Private       │  (Delegates to  │  (PPR, Rules,   │    │
+│  │   PersonData +  │   hREA for core │  Validation —   │    │
 │  │   ReaAgent)     │   VF types)     │   all custom)   │    │
 │  └─────────────────┴─────────────────┴─────────────────┘    │
 │          Cross-DNA calls via CallTargetCell::OtherRole      │
@@ -195,7 +195,7 @@ These are Nondominium's unique innovations and must remain fully custom:
 | `GovernanceRule`                  | Governance-as-operator pattern; Nondominium-specific |
 | `ResourceValidation`              | Community validation flow; Nondominium-specific      |
 | `ValidationReceipt`               | Validator attestation; Nondominium-specific          |
-| `EncryptedProfile`                | Private PII layer; hREA has no privacy model         |
+| `PrivatePersonData`                | Private PII layer; hREA has no privacy model         |
 | Role-based access control         | Capability grants tied to governance roles           |
 
 ---
@@ -212,7 +212,7 @@ These are Nondominium's unique innovations and must remain fully custom:
 | `PrivateParticipationClaim`                | **Keep custom**               | No hREA equivalent; core innovation                                                                                                                                                        |
 | `GovernanceRule`                           | **Keep custom**               | No hREA equivalent; governance-as-operator pattern                                                                                                                                         |
 | `ValidationReceipt` / `ResourceValidation` | **Keep custom**               | No hREA equivalent                                                                                                                                                                         |
-| `Person` / Agent                           | **Hybrid**                    | `ReaAgent` in hREA DNA (public identity); `EncryptedProfile` stays in Nondominium DNA                                                                                                      |
+| `Person` / Agent                           | **Hybrid**                    | `ReaAgent` in hREA DNA (public identity); `PrivatePersonData` stays in Nondominium DNA                                                                                                      |
 
 ---
 
@@ -489,7 +489,7 @@ When creating a Person in Nondominium, also create a `ReaAgent` in hREA and stor
 pub fn create_person_with_hrea_agent(
     name: String,
     avatar_url: Option<String>,
-    private_data: Option<EncryptedProfileData>,
+    private_data: Option<PrivatePersonDataInput>,
 ) -> ExternResult<PersonWithHreaRecord> {
     #[derive(Serialize, Deserialize, Debug)]
     struct ReaAgent {
@@ -522,9 +522,9 @@ pub fn create_person_with_hrea_agent(
     };
     let person_hash = create_entry(&EntryTypes::Person(person.clone()))?;
 
-    // 3. Create EncryptedProfile if private data provided
-    let encrypted_profile_hash = if let Some(private) = private_data {
-        Some(create_entry(&EntryTypes::EncryptedProfile(private))?)
+    // 3. Create PrivatePersonData if private data provided
+    let private_data_hash = if let Some(private) = private_data {
+        Some(create_entry(&EntryTypes::PrivatePersonData(private))?)
     } else {
         None
     };
@@ -532,7 +532,7 @@ pub fn create_person_with_hrea_agent(
     Ok(PersonWithHreaRecord {
         person_hash,
         hrea_agent_hash,
-        encrypted_profile_hash,
+        private_data_hash,
     })
 }
 ```
@@ -665,12 +665,12 @@ hREA has **no custom privacy implementation**. All entries are public by design:
 
 ### Nondominium's Complementary Privacy Layer
 
-Nondominium's `EncryptedProfile` system fills exactly the gap hREA leaves:
+Nondominium's `PrivatePersonData` system fills exactly the gap hREA leaves:
 
 | Layer                  | What                                       | Where                              |
 | ---------------------- | ------------------------------------------ | ---------------------------------- |
 | Public identity        | `ReaAgent` (name, avatar, type)            | hREA DNA — discoverable by all     |
-| Private PII            | `EncryptedProfile` (email, phone, address) | Nondominium DNA — capability-gated |
+| Private PII            | `PrivatePersonData` (email, phone, address) | Nondominium DNA — capability-gated |
 | Economic coordination  | `ReaEconomicResource`, `ReaCommitment`     | hREA DNA — public ValueFlows       |
 | Participation tracking | `PrivateParticipationClaim` (PPR)          | Nondominium DNA — private to agent |
 
@@ -860,14 +860,14 @@ Nondominium's PPR system has no current hREA equivalent. It could eventually be 
 
 ## Conclusion
 
-Nondominium's integration strategy uses hREA as the **economic data layer** (EconomicResource, EconomicEvent, Commitment, Agent) while keeping Nondominium's **governance and privacy layer** entirely custom (PPR, GovernanceRule, ValidationReceipt, EncryptedProfile).
+Nondominium's integration strategy uses hREA as the **economic data layer** (EconomicResource, EconomicEvent, Commitment, Agent) while keeping Nondominium's **governance and privacy layer** entirely custom (PPR, GovernanceRule, ValidationReceipt, PrivatePersonData).
 
 The bridge pattern (`call(CallTargetCell::OtherRole("hrea"), "hrea", fn_name, ...)`) is the mechanism that makes this work at the Rust/zome level without touching hREA's GraphQL API.
 
 Key outcomes:
 
 - **ValueFlows compliance**: hREA's battle-tested VF model handles all economic data correctly
-- **Privacy preserved**: EncryptedProfile + PPR system layers over hREA's public economic data
+- **Privacy preserved**: PrivatePersonData + PPR system layers over hREA's public economic data
 - **Governance innovation intact**: PPR system remains Nondominium's unique contribution
 - **Migration safe**: DHT immutability respected; legacy entries remain valid indefinitely
 - **Ecosystem interoperability**: Other hREA-based apps can interoperate with Nondominium's economic data directly through the shared hREA DNA

--- a/documentation/implementation_plan.md
+++ b/documentation/implementation_plan.md
@@ -30,7 +30,7 @@ This index is the entry point for phased delivery. **Current implementation base
 | [post-mvp/source-ndo-requirements.md](requirements/post-mvp/source-ndo-requirements.md) | **Source-NDO (optional profile)** — `Source` as third flow endpoint when an application governs generative systems; `SourceProfile`, adaptive loop, `vf:Source` (REQ-SOURCE-*); applicability REQ-SOURCE-APP-* in [requirements.md §4.6](requirements/requirements.md) |
 | [post-mvp/Source-NDO.md](requirements/post-mvp/Source-NDO.md) | Paper planning scaffold — thesis, Ostrom/VF argument structure (informative) |
 | [post-mvp/source-ndo-paper.md](requirements/post-mvp/source-ndo-paper.md) | Academic grounding: Occam's razor proof, river case study, Ostrom SES mapping (informative) |
-| [post-mvp/versioning.md](requirements/post-mvp/versioning.md) | Version DAG — **REQ-NDO-L1-03** (multiple `ResourceSpecification` links per NDO identity) |
+| [post-mvp/ndo-versioning.md](requirements/post-mvp/ndo-versioning.md) | Version DAG — **REQ-NDO-L1-03** (multiple `ResourceSpecification` links per NDO identity) |
 | [post-mvp/digital-resource-integrity.md](requirements/post-mvp/digital-resource-integrity.md) | Content-addressed manifests, composable verification — **REQ-NDO-L1-06** `DigitalAsset` capability slots (prima materia §9.2) |
 | [post-mvp/fractal-composable-resource-architecture.md](requirements/post-mvp/fractal-composable-resource-architecture.md) | Archival design — atomic / component / composite nesting; informs integrity (R5–R6) and Composition tab (post-MVP) |
 
@@ -60,7 +60,7 @@ This index is the entry point for phased delivery. **Current implementation base
 
 | Source | Role |
 |--------|------|
-| [post-mvp/lobby-dna.md](requirements/post-mvp/lobby-dna.md) | Multi-network federation — Lobby / Group / NDO DNA extensions (REQ-LOBBY-*, REQ-GROUP-*, REQ-NDO-EXT-*) |
+| [lobby-dna.md](requirements/lobby-dna.md) | Multi-network federation — Lobby / Group / NDO DNA extensions (REQ-LOBBY-*, REQ-GROUP-*, REQ-NDO-EXT-*) |
 | [requirements/agent.md](requirements/agent.md) | Agent ontology — roles, affiliation, `AgentContext` (post-MVP); background for governance participation and process access |
 
 ### 1.2 Status synchronization convention
@@ -141,7 +141,7 @@ Work below is grouped into **parallel tracks** so MVP delivery, NDO migration, a
 |--------|--------|-------------------|
 | **MVP core** | Phases 2–4 in Section 5: private data sharing, economic processes, PPR, promotion, security, cross-zome coordination | [requirements.md](requirements/requirements.md) REQ-USER / REQ-PROC / REQ-GOV |
 | **NDO model and migration** | `NondominiumIdentity`, `NDOToSpecification` / `NDOToProcess`, holonic links, `CapabilitySlot`, lifecycle plus operational split, faceted discovery links, one-time migration (REQ-NDO-MIG-*) | [ndo_prima_materia.md](requirements/ndo_prima_materia.md) §§8–10, §9 |
-| **Agent ontology** | REQ-AGENT-* / REQ-NDO-AGENT-* items under Phases 2–4 | [requirements.md §4.4](requirements/requirements.md); [archives/agent.md](archives/agent.md) for OVN background |
+| **Agent ontology** | REQ-AGENT-* / REQ-NDO-AGENT-* items under Phases 2–4 | [requirements.md §4.4](requirements/requirements.md); [requirements/agent.md](requirements/agent.md) for OVN background |
 | **Unyt / Flowsta** | Phased integration; governance enforcement in later phases | Section 12.2–12.3; REQ-NDO-CS-07–CS-15 |
 | **Source-NDO application profile** | Optional third VF primitive (`vf:Source`) for applications governing generative ecological/knowledge systems — **not** activated for ordinary Project NDOs or mature-resource mutualisation (e.g. shared 3D printer). Opt-in modules only; default UI stays Agent + Resource. | [requirements.md §4.6](requirements/requirements.md) REQ-SOURCE-APP-*; [source-ndo-requirements.md](requirements/post-mvp/source-ndo-requirements.md); §12.7 |
 | **Extended post-MVP** | Many-to-many flows, full version DAG, digital integrity, RTP-FP, VF DSL, Moss contract, and remaining federation work. Lobby/Group DNAs and the first NDO federation primitives are already implemented. | `documentation/requirements/post-mvp/*.md` |
@@ -288,7 +288,7 @@ _Role entries, assignment APIs, promotion externs, and governance validation ent
   - [ ] Enforce agent identity validation with private data verification
   - [ ] Specialized role validation with existing role holder approval
 
-**Agent Ontology Items (Post-MVP, Phase 2 — see [requirements.md §4.4](requirements/requirements.md) and [archives/agent.md](archives/agent.md) §5.3; `REQ-AGENT-*`):**
+**Agent Ontology Items (Post-MVP, Phase 2 — see [requirements.md §4.4](requirements/requirements.md) and [requirements/agent.md](requirements/agent.md) §5.3; `REQ-AGENT-*`):**
 
 - [ ] **[G13] Fix `request_role_promotion` stub** (HIGH PRIORITY — broken workflow):
   - [ ] Create a real `RolePromotionRequest` entry type in `zome_person` integrity, replacing the current placeholder hash return
@@ -336,7 +336,7 @@ _Building on existing capability infrastructure with Economic Process integratio
   - [ ] Enhanced private data access control with granular field permissions
   - [ ] Cross-zome capability validation for complex workflows
 
-**Agent Ontology Items (Post-MVP, Phase 3 — see [requirements.md §4.4](requirements/requirements.md) and [archives/agent.md](archives/agent.md) §5.3; `REQ-AGENT-*`):**
+**Agent Ontology Items (Post-MVP, Phase 3 — see [requirements.md §4.4](requirements/requirements.md) and [requirements/agent.md](requirements/agent.md) §5.3; `REQ-AGENT-*`):**
 
 - [ ] **[G1] `AgentEntityType` configuration** (NEW):
   - [ ] Define `AgentEntityType` enum in `zome_person` integrity: `Individual`, `Collective(String)`, `Project(ActionHash)`, `Network(ActionHash)`, `Bot { capabilities: Vec<String>, operator: AgentPubKey }`, `ExternalOrganisation(String)`
@@ -469,7 +469,7 @@ _Building sophisticated process chaining and automation on established foundatio
   - [ ] Resource utilization analytics and efficiency metrics
   - [ ] Agent performance trends and specialization insights
 
-**Agent Ontology Items (Post-MVP, Phase 4 — see [requirements.md §4.4](requirements/requirements.md) and [archives/agent.md](archives/agent.md) §5.3; `REQ-AGENT-*`):**
+**Agent Ontology Items (Post-MVP, Phase 4 — see [requirements.md §4.4](requirements/requirements.md) and [requirements/agent.md](requirements/agent.md) §5.3; `REQ-AGENT-*`):**
 
 - [ ] **[G8] `PortableCredential` structure and export** (NEW):
   - [ ] Define `PortableCredential` struct: `issuing_network` (DNA hash), `agent`, `credential_type: PortableCredentialType`, `claims`, `issued_at`, `valid_until`, `issuer_signature`, `agent_signature`
@@ -775,7 +775,7 @@ This plan ensures the nondominium hApp will fulfill its vision of decentralized,
 
 ## 12. Post-MVP design tracks (NDO, integrations, extensions)
 
-**Status:** This section mixes implemented post-MVP foundations with unscheduled design tracks. Checked items are present in the current WASM/UI; unchecked items remain specifications until scheduled. Normative NDO requirements: [ndo_prima_materia.md](requirements/ndo_prima_materia.md) (§9 REQ-NDO-*, §10 migration). Integration stubs: [unyt-integration.md](requirements/post-mvp/unyt-integration.md), [flowsta-integration.md](requirements/post-mvp/flowsta-integration.md). Supplementary ontology context: [archives/resources.md](archives/resources.md), [archives/agent.md](archives/agent.md), [archives/governance.md](archives/governance.md).
+**Status:** This section mixes implemented post-MVP foundations with unscheduled design tracks. Checked items are present in the current WASM/UI; unchecked items remain specifications until scheduled. Normative NDO requirements: [ndo_prima_materia.md](requirements/ndo_prima_materia.md) (§9 REQ-NDO-*, §10 migration). Integration stubs: [unyt-integration.md](requirements/post-mvp/unyt-integration.md), [flowsta-integration.md](requirements/post-mvp/flowsta-integration.md). Supplementary ontology context: [requirements/resources.md](requirements/resources.md), [requirements/agent.md](requirements/agent.md), [requirements/governance.md](requirements/governance.md).
 
 ### 12.1 Generic NDO (three-layer model, lifecycle split)
 
@@ -811,24 +811,24 @@ Phase B (tracked — not yet implemented; `zome_gouvernance` currently has zero 
 
 ### 12.4 Agent capability surface (G15)
 
-- [ ] `Person` entry hash as stigmergic attachment point for `FlowstaIdentity` and future slots (`REQ-NDO-AGENT-07`, `REQ-AGENT-11`) — see [archives/agent.md](archives/agent.md) §3.2, [person_zome.md](zomes/person_zome.md) Person TODO.
+- [ ] `Person` entry hash as stigmergic attachment point for `FlowstaIdentity` and future slots (`REQ-NDO-AGENT-07`, `REQ-AGENT-11`) — see [requirements/agent.md](requirements/agent.md) §3.2, [person_zome.md](zomes/person_zome.md) Person TODO.
 
 ### 12.5 Extended post-MVP specifications
 
 High-level ordering and dependencies (detailed requirements live in each file):
 
 - **[many-to-many-flows.md](requirements/post-mvp/many-to-many-flows.md):** Shared custody and n-ary `EconomicEvent` / `Commitment` participants — plan after **AgentContext** / collective custodianship (Phase 3 agent ontology) stabilizes; PPR rules must be extended for multi-party flows.
-- **[versioning.md](requirements/post-mvp/versioning.md):** DAG of versions across material, digital, and app-as-resource — complements **REQ-NDO-L1-03** (multiple `ResourceSpecification` links per NDO); non-breaking addition over existing spec/resource entries.
+- **[ndo-versioning.md](requirements/post-mvp/ndo-versioning.md):** DAG of versions across material, digital, and app-as-resource — complements **REQ-NDO-L1-03** (multiple `ResourceSpecification` links per NDO); non-breaking addition over existing spec/resource entries.
 - **[digital-resource-integrity.md](requirements/post-mvp/digital-resource-integrity.md):** Content-addressed manifests and hierarchical verification — attach via Layer 1 **DigitalAsset** capability slots (prima materia §9.2); aligns with distributed storage expectations for specs.
 - **[resource-transport-flow-protocol.md](requirements/post-mvp/resource-transport-flow-protocol.md):** Multi-dimensional transport and flow semantics — builds on mature **EconomicEvent** metadata and process modeling; cross-link to operational state and RTP-style location/custody dimensions.
 - **[valueflows-dsl.md](requirements/post-mvp/valueflows-dsl.md):** Scriptable network bootstrap and recipe definition — operational tooling; depends on stable VF entry types and governance evaluation surfaces in the DNA.
 - **[source-ndo-requirements.md](requirements/post-mvp/source-ndo-requirements.md):** Optional `Source` application profile; progressive activation per REQ-SOURCE-APP-* — see §12.7; PRD anchor [requirements.md §4.6](requirements/requirements.md)
-- **[lobby-dna.md](requirements/post-mvp/lobby-dna.md):** Federation foundation is implemented; remaining Moss, push-signal, per-NDO-cell, and integration work is tracked in §12.6.
+- **[lobby-dna.md](requirements/lobby-dna.md):** Federation foundation is implemented; remaining Moss, push-signal, per-NDO-cell, and integration work is tracked in §12.6.
 
 ### 12.6 Lobby DNA — multi-network federation
 
-Requirements: [lobby-dna.md](requirements/post-mvp/lobby-dna.md) (REQ-LOBBY-*, REQ-GROUP-*, REQ-NDO-EXT-*)
-Architecture: [specifications/post-mvp/lobby-architecture.md](specifications/post-mvp/lobby-architecture.md)
+Requirements: [lobby-dna.md](requirements/lobby-dna.md) (REQ-LOBBY-*, REQ-GROUP-*, REQ-NDO-EXT-*)
+Architecture: [specifications/lobby-architecture.md](specifications/lobby-architecture.md)
 
 Two implementation sub-scopes with different delivery ordering:
 

--- a/documentation/requirements/ndo_prima_materia.md
+++ b/documentation/requirements/ndo_prima_materia.md
@@ -44,7 +44,7 @@ That model is well-grounded in the ValueFlows standard and works well for resour
 
 **Still outstanding** (this document remains the normative target for these gaps):
 
-- **Layers 1 & 2 not activated:** `ResourceSpecification`, `EconomicResource`, and process entries are not yet linked to Layer 0 via `NDOToSpecification` or `NDOToProcess`. Legacy resource specs can still exist without an NDO parent; specification assets are not yet attached via `DigitalAsset` capability slots (REQ-NDO-L1-06).
+- **Layer 2 not activated:** process entries are not yet linked to Layer 0 via `NDOToProcess`. Layer 1 is activated (#132): `create_resource_specification` writes an `NdoToSpecification` link and the spec carries its Layer 0 pointers, so a spec can no longer be created without an NDO parent. Specification assets are still not attached via `DigitalAsset` capability slots (REQ-NDO-L1-06).
 - **Specification richness:** Structured project-type know-how bundles ([`post-mvp/project-type-ndo-specifications.md`](post-mvp/project-type-ndo-specifications.md)) are post-MVP requirements only — the MVP `ResourceSpecification` entry remains a thin summary (name, description, category, tags).
 - **`ResourceState` conflation:** ~~On `EconomicResource`~~ **Resolved (data layer):** `EconomicResource.operational_state` uses `OperationalState`; lifecycle maturity lives on `NondominiumIdentity.lifecycle_stage`. Governance-zome transition ownership (REQ-NDO-OS-02/03) remains deferred.
 - **Governance-as-operator for lifecycle:** MVP allows only the NDO `initiator` to call `update_lifecycle_stage`. Governance-validated transitions, role authorization per Section 5.3, and automatic `EconomicEvent` generation on each transition (REQ-NDO-LC-02, REQ-NDO-LC-03) remain deferred.
@@ -943,11 +943,11 @@ let ndo_hash = create_entry(&EntryTypes::NondominiumIdentity(identity))?;
 
 ### Pattern 2: Complexity-Matched Layer Activation
 
-> **Status:** 🔄 **Post-MVP** — `NDOToSpecification` and `NDOToProcess` link types not yet in code.
+> **Status:** 🔄 **Partial** — `NdoToSpecification` (Layer 1) is in code as of #132; `NDOToProcess` (Layer 2) is not.
 
 **Intent:** Activate only the structural complexity that the current coordination environment demands. Do not pay coordination costs in advance of need.
 
-**Structure:** Layer activation via link creation. Layer 1 activates when `NDOToSpecification` link is created. Layer 2 activates when `NDOToProcess` link is created. Both can be created retroactively, at any lifecycle stage.
+**Structure:** Layer activation via link creation. Layer 1 activates when the `NdoToSpecification` link is created. Layer 2 activates when the `NDOToProcess` link is created. Both can be created retroactively, at any lifecycle stage the target layer's gate permits: Layer 1 accepts `Specification` through `Active` (Section 5.2), and the Layer 2 gate is not yet enforced.
 
 **Rationale:** Benkler's information opportunity cost analysis: overhead that exceeds the value of the coordination it enables is pure waste. A tool being lent between friends does not need a full ValueFlows process. A community hardware standard being developed across fifty fabrication networks does. The NDO model allows the system's complexity to grow with the resource's social complexity, not ahead of it.
 
@@ -1166,20 +1166,22 @@ NdoByNature,          // Path "ndo.nature.{Nature:?}" → NondominiumIdentity
 NdoByPropertyRegime,  // Path "ndo.regime.{Regime:?}" → NondominiumIdentity
 NdoToSuccessor,       // deprecated NDO → successor NondominiumIdentity (REQ-NDO-LC-06)
 NdoToTransitionEvent, // NDO → EconomicEvent (link only; cross-zome event validation deferred)
+
+// Layer 1 activation and operational state (MVP — PR #132)
+NdoToSpecification,          // NondominiumIdentity → ResourceSpecification (Layer 1 activation)
+ResourcesByOperationalState, // Path "resources.operational.{State:?}" → EconomicResource
 ```
 
-Legacy resource links (`SpecificationToResource`, `ResourcesByState`, etc.) remain for pre-NDO `ResourceSpecification` / `EconomicResource` flows.
+Legacy resource links (`SpecificationToResource`, `ResourcesByLocation`, etc.) remain for pre-NDO `ResourceSpecification` / `EconomicResource` flows. `ResourcesByState` was replaced by `ResourcesByOperationalState` in #132.
 
 **Planned additions (post-MVP — not yet in `LinkTypes` enum):**
 
 ```rust
-NDOToSpecification,     // NondominiumIdentity → ResourceSpecification (Layer 1 activation)
 NDOToProcess,           // NondominiumIdentity → Process (Layer 2 activation)
 NDOToComponent,         // NondominiumIdentity → NondominiumIdentity (holonic composition)
 CapabilitySlot,         // NondominiumIdentity → capability target (typed by tag)
 NDOLifecycleHistory,    // NondominiumIdentity → LifecycleEvent (audit trail alternative/complement to NdoToTransitionEvent)
-ResourcesByLifecycleStage,   // split from ResourcesByState (REQ-NDO-OS-06)
-ResourcesByOperationalState, // split from ResourcesByState (REQ-NDO-OS-06)
+ResourcesByLifecycleStage,   // NDO-facing complement to ResourcesByOperationalState (REQ-NDO-OS-06)
 ```
 
 **Implemented in `zome_gouvernance` (federation — PR #103):** `NdoToHardLinks`, `HardLinkByType` (for `NdoHardLink` entries). See §11.7.
@@ -1283,7 +1285,7 @@ Normative requirements below remain valid as design targets. Status reflects the
 | Track | Status | Notes |
 |---|---|---|
 | Layer 0 (`NondominiumIdentity`, discovery, lifecycle validation) | ✅ MVP (#80) | Initiator-only transitions; optional `NdoToTransitionEvent` |
-| Layer 1 activation (`NDOToSpecification`) | ❌ Post-MVP | Legacy `ResourceSpecification` exists unlinked |
+| Layer 1 activation (`NdoToSpecification`) | ✅ MVP (#132) | Created on every `create_resource_specification`; spec carries `ndo_identity_hash` + `ndo_state_hash` and a lifecycle gate |
 | Layer 2 activation (`NDOToProcess`) | ❌ Post-MVP | Governance events exist unlinked to NDO identity |
 | `OperationalState` split | ✅ Data layer | `operational_state` on `EconomicResource`; `ResourcesByOperationalState`; governance-operator transitions deferred |
 | Governance-as-operator lifecycle (REQ-NDO-LC-02/03/07) | 🔄 Partial | Integrity validation only; no role-gated governance zome path |
@@ -1306,10 +1308,10 @@ Legend: ✅ implemented · 🔄 partial · ❌ not started
 
 ### 9.2 Layer 1 — Specification Requirements
 
-> **Status:** ❌ Post-MVP (requirements normative; `NDOToSpecification` not in code). Project-type know-how bundles: [`post-mvp/project-type-ndo-specifications.md`](post-mvp/project-type-ndo-specifications.md).
+> **Status:** 🔄 Partial (MVP, #132) — activation, the Layer 0 pointer pair, and the lifecycle gate are in code; asset attachment (REQ-NDO-L1-06) and role-gated activation remain post-MVP. Project-type know-how bundles: [`post-mvp/project-type-ndo-specifications.md`](post-mvp/project-type-ndo-specifications.md).
 
-- **REQ-NDO-L1-01** ❌: Layer 1 shall be activated by creating an `NDOToSpecification` link from the NDO identity hash to a `ResourceSpecification` entry. No modification of the `NondominiumIdentity` entry is required for activation.
-- **REQ-NDO-L1-02**: Layer 1 may be activated at any lifecycle stage at or after `Ideation`. Retroactive activation (for NDOs that began at `Ideation` without a spec) shall be fully supported.
+- **REQ-NDO-L1-01** ✅: Layer 1 shall be activated by creating an `NdoToSpecification` link from the NDO identity hash to a `ResourceSpecification` entry. No modification of the `NondominiumIdentity` entry is required for activation. The specification additionally carries `ndo_identity_hash` (the immutable Layer 0 pointer) and `ndo_state_hash` (the NDO action the author observed), because integrity validation cannot resolve "the latest state" by walking an update chain forward.
+- **REQ-NDO-L1-02** ✅: Layer 1 may be activated at any lifecycle stage from `Specification` through `Active`, matching the activation table in Section 5.2. `Ideation` is excluded (an idea has no form to specify yet), and `Hibernating`, `Deprecated`, and `EndOfLife` are excluded as suspended or terminal. Retroactive activation is fully supported for any NDO that has reached `Specification`.
 - **REQ-NDO-L1-03**: Multiple `ResourceSpecification` entries may be linked to one NDO identity, representing version evolution. The most recent link shall be considered the canonical Layer 1 specification.
 - **REQ-NDO-L1-04**: When Layer 1 enters dormant state (hibernation or end of life), the specification shall be marked `is_active: false`. The `NDOToSpecification` link shall remain readable.
 - **REQ-NDO-L1-05**: `GovernanceRule` entries shall continue to be linked to `ResourceSpecification` entries as currently implemented. They are considered Layer 1 assets.

--- a/documentation/requirements/post-mvp/flowsta-integration.md
+++ b/documentation/requirements/post-mvp/flowsta-integration.md
@@ -13,7 +13,7 @@
 2. [Rationale: why Flowsta, why a capability](#2-rationale-why-flowsta-why-a-capability)
 3. [How Flowsta entered the foundational documents](#3-how-flowsta-entered-the-foundational-documents)
 4. [Architecture summary](#4-architecture-summary)
-5. [Relationship to Unyt and the foundational spec](#5-relationship-to-unyt-and-the-foundational-spec)
+5. [Relationship to Unyt and the prima materia](#5-relationship-to-unyt-and-the-prima-materia)
 6. [Integration path (three phases)](#6-integration-path-three-phases)
 7. [Requirements traceability](#7-requirements-traceability)
 8. [Current MVP vs planned enforcement](#8-current-mvp-vs-planned-enforcement)

--- a/documentation/requirements/post-mvp/flowsta-integration.md
+++ b/documentation/requirements/post-mvp/flowsta-integration.md
@@ -159,7 +159,7 @@ Phases are **independent and cumulative** — no rollback of earlier phases requ
 
 As of the Nondominium MVP codebase:
 
-- **`GovernanceRule`** in `zome_resource` remains **`rule_type: String` / `rule_data: String`** — not a typed enum — and **Flowsta zomes are not yet part of the shipped DNA** unless explicitly added in a future milestone.
+- **`GovernanceRule`** in `zome_resource` is now the typed **`rule_data: RuleData`** enum (#132), but its four variants are `AccessRequirement`, `UsageLimit`, `TransferCondition`, and `MaintenanceSchedule`: there is **no `IdentityVerification` variant**, and **Flowsta zomes are not part of the shipped DNA** unless explicitly added in a future milestone.
 - **`zome_gouvernance`** exposes flows such as **`validate_agent_for_promotion`** and **`validate_agent_for_custodianship`** for **private-field** validation, **not** for Flowsta **`IdentityVerification`**.
 
 Therefore **Tier 2** and **Phase 3** are **specified and documented** but **not yet implemented** in WASM. This document and the archive sections describe **target behavior**; `governance.md` §3.7 states the folding of identity checks into unified **transition evaluation** explicitly.

--- a/documentation/requirements/post-mvp/source-valueflows-integration.md
+++ b/documentation/requirements/post-mvp/source-valueflows-integration.md
@@ -283,7 +283,7 @@ Adding **one** primitive (`vf:Source`) removes **three fictions and four residue
 | `EconomicEvent.resource_inventoried_as` | `ActionHash` → `EconomicResource`                                                           | REQ-SOURCE-EVENT-01 also targets Source Layer 0 hash |
 | `primaryAccountable`                    | `EconomicResource.custodian`                                                                | Inappropriate for Source-NDO                         |
 | `Commitment` / `Claim`                  | `zome_gouvernance` entries                                                                  | Need Source-aware evaluation                         |
-| `GovernanceRule`                        | `rule_type: String`, `rule_data: String`                                                    | Untyped; sufficient for MVP adaptive rules           |
+| `GovernanceRule`                        | `rule_data: RuleData` (4 typed variants, #132)                                              | No Source-aware variant; adaptive rules need a new one |
 | Layer 0 identity                        | `NondominiumIdentity`                                                                       | Permanent anchor; Source-NDO uses same entry         |
 | NDO federation links                    | `NdoHardLink` (`Component`, `DerivedFrom`, `Supersedes`)                                    | Cross-NDO; not Source coupling                       |
 | `VfAction`                              | 16 variants in `crates/shared/src/types.rs`                                                 | No `Extract`                                         |

--- a/documentation/requirements/post-mvp/unyt-integration.md
+++ b/documentation/requirements/post-mvp/unyt-integration.md
@@ -9,7 +9,7 @@
 
 ## Table of Contents
 
-1. [Framing: The Generic NDO and Nondominium as Instantiation](#1-framing)
+1. [Framing: The Generic NDO and Nondominium as Instantiation](#1-framing-the-generic-ndo-and-nondominium-as-instantiation)
 2. [The Economic Closure Problem](#2-the-economic-closure-problem)
 3. [The NDO Economic Loop](#3-the-ndo-economic-loop)
 4. [Unyt as Economic Operator](#4-unyt-as-economic-operator)

--- a/documentation/requirements/post-mvp/valueflows-dsl.md
+++ b/documentation/requirements/post-mvp/valueflows-dsl.md
@@ -11,7 +11,7 @@
 | **Version**      | 1.0 (2025-12-28)                                                             |
 | **Repository**   | [github.com/sensorica/nondominium](https://github.com/sensorica/nondominium) |
 
-> **Technical Specifications**: See [Valueflows DSL Technical Specifications](../specifications/valueflows-dsl-specs.md) for implementation details, syntax specifications, and technical architecture.
+> **Technical Specifications**: See [Valueflows DSL Technical Specifications](../../specifications/post-mvp/valueflows-dsl-specs.md) for implementation details, syntax specifications, and technical architecture.
 
 > **Scope note (ValueFlows version)**: This document specifies a DSL for **ValueFlows 1.0** — the current, ratified vocabulary that Nondominium implements today (two flow-endpoint primitives: `Agent` and `EconomicResource`). A separate, in-progress design proposes an **augmented ValueFlows** profile that adds a third primitive, **`vf:Source`**, for generative non-ownable systems (watersheds, forests, knowledge commons). Anywhere this document refers to `Source`, `vf:Source`, `extract`, or Source-NDOs, it is describing **future/work-in-progress** capability, not the MVP DSL. See [`source-valueflows-integration.md`](source-valueflows-integration.md) and [`source-ndo-requirements.md`](source-ndo-requirements.md). The delineation is made explicit throughout (see §2.1.1).
 
@@ -768,7 +768,7 @@ Support for the `Source` primitive (§6.1.7, §9.7) — `source` declarations, t
 - **hREA Project:** https://github.com/h-REA/hREA
 - **REA Ontology:** https://wiki.p2pfoundation.net/Resource-Event-Agent_Model
 - **Holochain Documentation:** https://developer.holochain.org/
-- **Technical Specifications:** [Valueflows DSL Technical Specifications](../specifications/valueflows-dsl-specs.md)
+- **Technical Specifications:** [Valueflows DSL Technical Specifications](../../specifications/post-mvp/valueflows-dsl-specs.md)
 - **Augmented ValueFlows — Source integration (planned/WIP):** [`source-valueflows-integration.md`](source-valueflows-integration.md)
 - **Source-NDO requirements (planned/WIP):** [`source-ndo-requirements.md`](source-ndo-requirements.md)
 

--- a/documentation/requirements/requirements.md
+++ b/documentation/requirements/requirements.md
@@ -50,12 +50,12 @@ Optional, pay-as-you-grow integrations and application profiles (communities may
 
 | Integration | Role | Normative detail | Design stub |
 |-------------|------|------------------|-------------|
-| **Lobby DNA** | Multi-network federation: entry point (Lobby DHT) + per-group coordination (Group DHT) + NDO-to-NDO hard links, Contributions, Smart Agreements; dual deployment (standalone + Moss applet) | REQ-LOBBY-*, REQ-GROUP-*, REQ-NDO-EXT-* | [lobby-dna.md](post-mvp/lobby-dna.md) / [lobby-architecture.md](../specifications/post-mvp/lobby-architecture.md) |
+| **Lobby DNA** | Multi-network federation: entry point (Lobby DHT) + per-group coordination (Group DHT) + NDO-to-NDO hard links, Contributions, Smart Agreements; dual deployment (standalone + Moss applet) | REQ-LOBBY-*, REQ-GROUP-*, REQ-NDO-EXT-* | [lobby-dna.md](lobby-dna.md) / [lobby-architecture.md](../specifications/lobby-architecture.md) |
 | **Unyt** | Economic settlement (Smart Agreements, RAVE proofs, PPR↔RAVE provenance) | `ndo_prima_materia.md` §6.6, §11.5; REQ-NDO-CS-07–CS-11 | [unyt-integration.md](post-mvp/unyt-integration.md) |
 | **Flowsta** | Cross-app identity (Vault `IsSamePersonEntry`, `FlowstaIdentity` slot, DID, recovery); Tier 1 (Phase 1) vs Tier 2 (Phase 3) | `ndo_prima_materia.md` §6.5–6.7, §11.6; REQ-NDO-CS-12–CS-15; REQ-NDO-AGENT-07–08 | [flowsta-integration.md](post-mvp/flowsta-integration.md) |
 | **Source-NDO application profile** | Optional third primitive for applications governing generative ecological or knowledge systems. Not activated for ordinary Project NDOs (e.g. open-hardware design) or mature-resource mutualisation (e.g. sharing a 3D printer) unless the application explicitly needs to govern a generative Source and its boundary effects. | REQ-SOURCE-APP-*, REQ-SOURCE-ONT-*, REQ-SOURCE-GOV-*, REQ-SOURCE-DATA-*, REQ-SOURCE-EVENT-*; REQ-USER-ST-*, REQ-UI-SOURCE-* (§4.6) | [source-ndo-requirements.md](post-mvp/source-ndo-requirements.md) / [source-ndo-paper.md](post-mvp/source-ndo-paper.md) |
 
-**Knowledge-base context** (ontology, OVN alignment, gap analysis): [resources.md](../archives/resources.md), [agent.md](../archives/agent.md), [governance.md](../archives/governance.md), [source-ndo-requirements.md](post-mvp/source-ndo-requirements.md). This PRD remains the anchor for MVP user stories and REQ-USER / REQ-RES / REQ-GOV IDs; NDO-wide REQ-NDO-* IDs are defined in `ndo_prima_materia.md` §9; Source-NDO REQ-SOURCE-* IDs are defined in `source-ndo-requirements.md` §8.
+**Knowledge-base context** (ontology, OVN alignment, gap analysis): [resources.md](resources.md), [agent.md](agent.md), [governance.md](governance.md), [source-ndo-requirements.md](post-mvp/source-ndo-requirements.md). This PRD remains the anchor for MVP user stories and REQ-USER / REQ-RES / REQ-GOV IDs; NDO-wide REQ-NDO-* IDs are defined in `ndo_prima_materia.md` §9; Source-NDO REQ-SOURCE-* IDs are defined in `source-ndo-requirements.md` §8.
 
 ## 3. nondominium Resource Characteristics
 
@@ -147,7 +147,7 @@ The agent with physical possession (custodianship) of a material nondominium Res
 
 ## 4.4 Agent Ontology Requirements (Post-MVP)
 
-> **Status**: Post-MVP. Gaps identified against the OVN wiki ontology (15 years of commons-based peer production practice). See `documentation/archives/agent.md` for the full analysis. Requirements below are design targets for the generic NDO; the current MVP implements individual agents only.
+> **Status**: Post-MVP. Gaps identified against the OVN wiki ontology (15 years of commons-based peer production practice). See `documentation/requirements/agent.md` for the full analysis. Requirements below are design targets for the generic NDO; the current MVP implements individual agents only.
 
 ### Agent Type Taxonomy
 
@@ -431,7 +431,7 @@ boundary events → ledger on Source L0 hash → ecological interpretation
 
 ### 7.4 Privacy Tiers and Cross-Network Portability (Post-MVP)
 
-> **TODO**: The following requirements depend on post-MVP agent architecture (see `REQ-AGENT-12` through `REQ-AGENT-15` and `documentation/archives/agent.md` Sections 4.4–4.5).
+> **TODO**: The following requirements depend on post-MVP agent architecture (see `REQ-AGENT-12` through `REQ-AGENT-15` and `documentation/requirements/agent.md` Sections 4.4–4.5).
 
 - **REQ-PPR-13: Per-Interaction Privacy Level**: Agents must be able to choose their privacy level per interaction type: fully anonymous (no PPRs, no reputation accumulation), pseudonymous (PPRs linked to persistent pseudonym, not physical identity), or named (PPRs linked to public `Person` entry). The current model only supports named participation.
 - **REQ-PPR-14: ZKP-Compatible Reputation Sharing**: The reputation summary derived from PPRs must be ZKP-compatible, allowing agents to produce proofs of the form "I have at least N claims of type T" without revealing the counterparties, timestamps, or raw scores. This is a prerequisite for privacy-preserving meritocracy — governance access based on contribution without requiring surveillance.

--- a/documentation/requirements/resources.md
+++ b/documentation/requirements/resources.md
@@ -137,7 +137,7 @@ pub enum ResourceNature {
 
 > **Doc/code consistency:** `PropertyRegime` has **seven** canonical variants in Rust and the UI (`Private`, `Commons`, `Collective`, `Pool`, `CommonPool`, `Public`, `Nondominium`). See §2.6. `ResourceNature` in code adds `Service` and `Information` beyond the three-variant design in `ndo_prima_materia.md`; forward-map variants `Space`, `Method`, and `Currency` (§6.2) are not yet in code.
 
-**`ResourceSpecification`**
+**`ResourceSpecification`** (Layer 1 — ✅ activated, PR #132)
 ```rust
 pub struct ResourceSpecification {
     pub name: String,
@@ -146,6 +146,14 @@ pub struct ResourceSpecification {
     pub image_url: Option<String>,
     pub tags: Vec<String>,
     pub is_active: bool,
+    /// Visibility / discovery scope. Project-scoped specs skip the global anchor.
+    pub scope: ResourceScope,
+    /// Immutable pointer to the Layer 0 NondominiumIdentity this spec activates.
+    pub ndo_identity_hash: ActionHash,
+    /// The NDO action the author observed when activating Layer 1. Integrity
+    /// cannot walk an update chain forward deterministically, so the author names
+    /// the state they saw and validation resolves it backward to the identity.
+    pub ndo_state_hash: ActionHash,
 }
 ```
 This is the **knowledge layer** in ValueFlows terminology: the type or template of a resource. It corresponds to the OVN concept of "Resource Type" — an abstract representation that groups interchangeable concrete instances.
@@ -159,20 +167,32 @@ pub struct EconomicResource {
                                 // to support Collective, Project, Network, and Bot agents as
                                 // Primary Accountable Agents. Currently assumes individual agent.
     pub current_location: Option<String>,
-    - operational_state: OperationalState,
+    pub operational_state: OperationalState,
 }
 ```
 This is the **observation layer**: a specific instance of a resource at a point in time, held by a specific custodian.
 
-**`GovernanceRule`**
+**`GovernanceRule`** (typed as of PR #132)
 ```rust
 pub struct GovernanceRule {
-    pub rule_type: String,   // free-form string (e.g., "access_requirement")
-    pub rule_data: String,   // JSON-encoded, completely untyped
-    pub enforced_by: Option<String>,
+    pub rule_data: RuleData,         // tagged enum, replaces the rule_type/rule_data string pair
+    pub enforced_by: Option<String>, // role required to enforce this rule
+    /// Direct pointer to Layer 0 — required for constraint evaluation context.
+    pub ndo_identity_hash: ActionHash,
+    /// Denormalized from Layer 0 (immutable source) — enables zero-DHT-read validation.
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+    pub rivalry_override: Option<Rivalry>,
+}
+
+pub enum RuleData {
+    AccessRequirement(AccessRequirementData),
+    UsageLimit(UsageLimitData),
+    TransferCondition(TransferConditionData),
+    MaintenanceSchedule(MaintenanceScheduleData),
 }
 ```
-Economic rules governing access and use. Currently entirely untyped — `rule_data` is a free-form JSON string with no schema enforcement. - ToDo: explore how to make governance rules machine readable and executable, typed. 
+Economic rules governing access and use. The former untyped `rule_type: String` / `rule_data: String` pair is gone: `RuleData` is a tagged enum with a typed payload per variant, and `GovernanceRuleType` is derived from the discriminant rather than stored. Rules are checked against their NDO's classification by the predicates in [`crates/shared/src/constraints.rs`](../../crates/shared/src/constraints.rs) — `Hard` violations are rejected at integrity, `Soft` violations return as advisory warnings. Definitions: [`crates/shared/src/rule_data.rs`](../../crates/shared/src/rule_data.rs). 
 
 **`OperationalState`** (enum on `EconomicResource`) — ✅ **implemented** (`REQ-NDO-OS-01`)
 
@@ -203,7 +223,9 @@ The link types model resource discovery and navigation:
 - `NdoToSuccessor` — deprecated NDO → successor `NondominiumIdentity` (REQ-NDO-LC-06)
 - `NdoToTransitionEvent` — NDO → triggering `EconomicEvent` action hash (REQ-NDO-L0-05; link only, cross-zome event validation deferred)
 
-> **Not yet implemented:** `NDOToSpecification` and `NDOToProcess` links (Layers 1 & 2 activation per `ndo_prima_materia.md` §4).
+> **Layer 1 activation** (✅ implemented, PR #132): `NdoToSpecification` — NDO identity hash → `ResourceSpecification`, created on every `create_resource_specification`.
+>
+> **Not yet implemented:** `NDOToProcess` (Layer 2 activation per `ndo_prima_materia.md` §4).
 
 ### 2.3 What the MVP Does Well
 
@@ -222,7 +244,7 @@ The link types model resource discovery and navigation:
 | ~~`ResourceState` conflates lifecycle and operational dimensions~~ | ~~Cannot model in-transit, in-storage, or in-maintenance instances independently of Layer 0 lifecycle~~ | ✅ **`OperationalState` on `EconomicResource`** (`REQ-NDO-OS-01`); governance-operator transitions deferred (`REQ-NDO-OS-02`–`05`) |
 | ~~No property regime field~~ | ~~Cannot distinguish nondominium from commons from individual stewardship~~ | ✅ **`PropertyRegime` on `NondominiumIdentity`** (see §2.6 — seven variants) |
 | ~~No resource nature field~~ | ~~Cannot distinguish digital from physical from hybrid~~ | ✅ **`ResourceNature` on `NondominiumIdentity`** (5 variants in code; see §2.6) |
-| `GovernanceRule.rule_data` is untyped JSON string | No schema enforcement, no tooling support, no peer validation of rule semantics | 🔄 `GovernanceRuleType` enum with typed schemas (`ndo_prima_materia.md` + `unyt-integration.md`) |
+| ~~`GovernanceRule.rule_data` is untyped JSON string~~ | ~~No schema enforcement, no tooling support, no peer validation of rule semantics~~ | ✅ **Typed `RuleData` enum** (#132) — four variants with typed payloads, classification predicates enforced Hard/Soft; `EconomicAgreement` / `IdentityVerification` rule families remain post-MVP |
 | ~~No lifecycle before `PendingValidation`~~ | ~~Cannot model resources in ideation, design, development stages~~ | ✅ **`LifecycleStage` (10 stages) on Layer 0** with full transition validation |
 | Single custodian only | Cannot model shared tools, collective custody, resource pools | 🔄 Many-to-many flows (post-MVP) |
 | ~~No resource-level identity separate from specification hash~~ | ~~Identity changes when specification is updated~~ | ✅ **`NondominiumIdentity` Layer 0** — stable action hash independent of spec updates |
@@ -233,7 +255,7 @@ The link types model resource discovery and navigation:
 | No resource reliability | No way to track a tool's track record independent of custodian reputation | Gap — see Section 5 |
 | No cross-app identity or DID | Agents cannot prove identity across Holochain apps or networks; reputation is local to this DHT; no key recovery mechanism | 🔄 `FlowstaIdentity` CapabilitySlot on `Person` entry hash (`ndo_prima_materia.md` Section 6.7) |
 | No agent key recovery | If agent loses device, signing key (and all private entries/PPRs) are inaccessible; no deterministic key regeneration | 🔄 Flowsta Vault BIP39 recovery phrases; auto-backup; CAL-compliant data export (`ndo_prima_materia.md` Section 6.7) |
-| Layers 1 & 2 not linked to Layer 0 | Specification and process activity not activated via `NDOToSpecification` / `NDOToProcess` | 🔄 `ndo_prima_materia.md` §4 |
+| Layer 2 not linked to Layer 0 | Process activity not activated via `NDOToProcess` | 🔄 `ndo_prima_materia.md` §4 (Layer 1 activated via `NdoToSpecification`, #132) |
 | Governance-as-operator for lifecycle transitions | Transitions validated in integrity zome only; no automatic EconomicEvent generation | 🔄 REQ-NDO-LC-02, REQ-NDO-LC-03, REQ-NDO-LC-07 |
 
 ### 2.5 Federation, versioning & contribution layer (`zome_gouvernance`, ✅ PR #103)
@@ -305,7 +327,7 @@ The following improvements are designed in the post-MVP documentation. Items mar
 The most significant architectural change. Replaces the flat `ResourceSpecification + EconomicResource` model with a progressive three-layer structure:
 
 - **Layer 0 — NondominiumIdentity**: ✅ **Implemented** (PR #80/#84). A permanent, immutable identity anchor. The genesis entry whose action hash becomes the stable identifier for the resource across its entire existence. Contains `name`, `description`, `initiator`, `property_regime`, `resource_nature`, `lifecycle_stage`, `created_at`, `successor_ndo_hash`, `hibernation_origin`. Never voided — serves as the tombstone at end of life.
-- **Layer 1 — ResourceSpecification** (activated by `NDOToSpecification` link): 🔄 **Not started**. The form of the resource — design, governance rules, assets, digital integrity manifests. Activated when the resource has a form worth sharing. Legacy `ResourceSpecification` entries exist but are not yet linked to Layer 0.
+- **Layer 1 — ResourceSpecification** (activated by the `NdoToSpecification` link): ✅ **Implemented** (PR #132). The form of the resource — design, typed governance rules, scope. `create_resource_specification` writes the link and the spec carries `ndo_identity_hash` / `ndo_state_hash`, so a spec can no longer exist without an NDO parent. Activation is gated to lifecycle stages `Specification` through `Active`. Digital asset manifests (REQ-NDO-L1-06) remain post-MVP.
 - **Layer 2 — Process** (activated by `NDOToProcess` link): 🔄 **Not started**. The activity around the resource — EconomicEvents, Commitments, Claims, PPRs. Activated when multi-agent coordination begins. ValueFlows cycle exists in `zome_gouvernance` but is not yet linked to NDO identity via `NDOToProcess`.
 
 This model directly implements the complexity matching principle: coordination overhead grows with actual social complexity, not at resource creation. The three-layer structure describes the **resource face** of any entity — including collective entities. When a collective (project-organisation, cooperative, network) has an associated NDO, that NDO is its digital twin as a Resource: its permanent identity, lifecycle, specification, and governance. The collective also has an **agent face** (`AgentContext`) through which it participates in economic events. These are distinct — see `agent.md §3.1` for the dual-face model.

--- a/documentation/specifications/governance/cross-zome-api.md
+++ b/documentation/specifications/governance/cross-zome-api.md
@@ -1,5 +1,7 @@
 # Cross-Zome API Specification
 
+> **Implementation status (2026-08-29, post-#132).** `GovernanceTransitionRequest`, `TransitionContext`, and `GovernanceTransitionResult` are defined in `crates/shared/src/io/governance.rs`, and `evaluate_state_transition` is live in `zome_gouvernance/src/transition.rs`. `request_resource_transition` does **not** exist: the resource zome does not yet call into this path, so evaluation runs **parallel and advisory** alongside `propose_commitment` / `log_economic_event` rather than as the mandatory funnel. Treat the request side of this document as the design target, not current behaviour. Status: `documentation/IMPLEMENTATION_STATUS.md` § Governance-as-Operator Architecture.
+
 Cross-zome contracts described here reflect the **MVP** split: `zome_resource` holds data; `zome_gouvernance` evaluates transitions. **Post-MVP**, typed rules for **Unyt** (`EconomicAgreement`, RAVE) and **Flowsta** (`IdentityVerification`) are specified in `documentation/requirements/ndo_prima_materia.md` §§6.6–6.7 and the integration stubs under `documentation/requirements/post-mvp/` — see also `governance-operator-architecture.md` §1.3.
 
 ## 1. Resource Zome API

--- a/documentation/specifications/governance/governance-operator-architecture.md
+++ b/documentation/specifications/governance/governance-operator-architecture.md
@@ -6,6 +6,8 @@
 
 *zome_resource stores entries only — no business logic. zome_gouvernance evaluates rules, approves or rejects transitions, and generates audit trail events. The clean boundary enables independent evolution and swappable governance schemes.*
 
+> **Implementation status (2026-08-29, post-#132).** `GovernanceTransitionRequest`, `TransitionContext`, and `GovernanceTransitionResult` are defined in `crates/shared/src/io/governance.rs`, and `evaluate_state_transition` is live in `zome_gouvernance/src/transition.rs`. `request_resource_transition` does **not** exist: the resource zome does not yet call into this path, so evaluation runs **parallel and advisory** alongside `propose_commitment` / `log_economic_event` rather than as the mandatory funnel. Treat the request side of this document as the design target, not current behaviour. Status: `documentation/IMPLEMENTATION_STATUS.md` § Governance-as-Operator Architecture.
+
 The governance-as-operator architecture establishes a clear separation between data management and business logic enforcement in the nondominium system. This design enables independent evolution of resource data structures and governance rules, providing a foundation for modular, maintainable, and extensible decentralized resource management.
 
 ### 1.1 Core Principles

--- a/documentation/specifications/ndo-v1-architecture-design.md
+++ b/documentation/specifications/ndo-v1-architecture-design.md
@@ -30,7 +30,7 @@ Nondominium runs as a **dual-DNA hApp** — `hrea` DNA + `ndo` DNA, both registe
 | Commitment, Agreement, Plan     | GovernanceRule, CapabilitySlot         |
 | ResourceSpecification (VF core) | PrivateParticipationClaim (PPR)        |
 | Process, Intent (post-v1.0)     | ValidationReceipt, ResourceValidation  |
-| ReaAgent, ReaUnit               | EncryptedProfile, Person               |
+| ReaAgent, ReaUnit               | PrivatePersonData, Person               |
 | All VF 1.0 types                | All NDO governance/identity extensions |
 
 NDO zomes interact with hREA via:

--- a/documentation/specifications/post-mvp/valueflows-dsl-specs.md
+++ b/documentation/specifications/post-mvp/valueflows-dsl-specs.md
@@ -1,6 +1,6 @@
 # ValueFlows DSL - Technical Specifications
 
-Companion document to [ValueFlows DSL Requirements](../requirements/valueflows-dsl.md)
+Companion document to [ValueFlows DSL Requirements](../../requirements/post-mvp/valueflows-dsl.md)
 
 ---
 

--- a/documentation/specifications/protocol-bridge-specifications.md
+++ b/documentation/specifications/protocol-bridge-specifications.md
@@ -652,7 +652,7 @@ interface SyncMapping {
   platformUser: HolochainAgent;
   platformResource: EconomicResource;
   platformTransaction: Commitment + EconomicEvent[];
-  platformProfile: Person + EncryptedProfile;
+  platformProfile: Person + PrivatePersonData;
 }
 
 // Bidirectional sync rules
@@ -1629,7 +1629,7 @@ volumes:
 
 ### A.10 Tiki-Specific Sequence Diagrams (Original User Story Versions)
 
-These are the original sequence diagrams using the Tiki-specific participants (Sarah/Sensorica, Marco/FabLab) from the [user story](../Applications/user-story/user-story-resource-transaction.md).
+These are the original sequence diagrams using the Tiki-specific participants (Sarah/Sensorica, Marco/FabLab) from the [ERP bridge user story](../Applications/user-story/user-story-ERP-bridge.md).
 
 #### Resource Registration (Sarah/Sensorica)
 

--- a/documentation/specifications/specifications.md
+++ b/documentation/specifications/specifications.md
@@ -33,10 +33,12 @@ This separation enables independent evolution of data structures and governance 
 
 ### 3.2 Cross-Zome Interface
 
+> **Implementation status (2026-08-29, post-#132).** `GovernanceTransitionRequest`, `TransitionContext`, and `GovernanceTransitionResult` are defined in `crates/shared/src/io/governance.rs`, and `evaluate_state_transition` is live in `zome_gouvernance/src/transition.rs`. `request_resource_transition` does **not** exist: the resource zome does not yet call into this path, so evaluation runs **parallel and advisory** alongside `propose_commitment` / `log_economic_event` rather than as the mandatory funnel. Treat the request side of this document as the design target, not current behaviour. Status: `documentation/IMPLEMENTATION_STATUS.md` § Governance-as-Operator Architecture.
+
 The primary interface between zomes follows the governance operator pattern:
 
 ```rust
-// Resource zome requests state transition
+// Resource zome requests state transition (design target — not yet in code)
 #[hdk_extern]
 pub fn request_resource_transition(
     request: GovernanceTransitionRequest,
@@ -98,19 +100,28 @@ A template for a class of resources.
 - **Fields**:
   - `name: String`
   - `description: String`
+  - `category: String`
   - `image_url: Option<String>`
-  - `governance_rules: Vec<GovernanceRule>`: Embedded rules for resource access and management. Fulfills `REQ-GOV-06`.
+  - `tags: Vec<String>`
+  - `is_active: bool`
+  - `scope: ResourceScope`: `Project` | `Network` | `Public` — discovery visibility (mutable)
+  - `ndo_identity_hash: ActionHash`: immutable pointer to the Layer 0 `NondominiumIdentity` this spec activates
+  - `ndo_state_hash: ActionHash`: the NDO action the author observed at activation, resolved backward by validation
 - **Links**:
-  - `AllResourceSpecifications -> ResourceSpecification`: Anchor for discovery.
+  - `AllResourceSpecifications -> ResourceSpecification`: Anchor for discovery (`Project` scope skips it).
+  - `NdoToSpecification`: Layer 0 identity -> this spec. Creating it **is** Layer 1 activation (`REQ-NDO-L1-01`).
+  - `SpecificationToGovernanceRule -> GovernanceRule`: rules are separate entries, not an embedded vector.
 
 #### 3.2.2. `GovernanceRule`
 
 A rule embedded within a ResourceSpecification that defines how resources can be accessed and managed.
 
 - **Fields**:
-  - `rule_type: String`: e.g., "access_requirement", "usage_limit", "transfer_conditions"
-  - `rule_data: String`: JSON-encoded rule parameters
-  - `enforced_by: Option<AgentRole>`: Role required to enforce this rule
+  - `rule_data: RuleData`: tagged enum — `AccessRequirement` | `UsageLimit` | `TransferCondition` | `MaintenanceSchedule`, each with a typed payload. `GovernanceRuleType` is derived from the discriminant, never stored.
+  - `enforced_by: Option<String>`: Role required to enforce this rule
+  - `ndo_identity_hash: ActionHash`: Layer 0 pointer, required for constraint evaluation
+  - `property_regime: PropertyRegime`, `resource_nature: ResourceNature`: denormalized from Layer 0 so validation needs no DHT read
+  - `rivalry_override: Option<Rivalry>`: overrides the rivalry implied by the regime
 
 #### 3.2.3. `EconomicResource`
 
@@ -411,15 +422,17 @@ pub struct GovernanceTransitionResult {
     /// Whether the transition was approved
     pub success: bool,
     /// Updated resource state (if approved)
-    pub new_resource_state: Option<EconomicResource>,
-    /// Generated economic event for audit trail
-    pub economic_event: Option<EconomicEvent>,
-    /// Validation receipts from governance evaluation
-    pub validation_receipts: Vec<ValidationReceipt>,
+    pub new_resource_state: Option<EconomicResourceView>,
+    /// Reserved for when event generation is wired; currently always None on this path.
+    pub economic_event_hash: Option<ActionHash>,
     /// Detailed reasons for rejection (if applicable)
     pub rejection_reasons: Option<Vec<String>>,
     /// Required next steps or additional validation needed
     pub next_steps: Option<Vec<String>>,
+    /// Soft constraint violations — non-blocking advisory feedback
+    pub advisory_warnings: Option<Vec<String>>,
+    /// Soft violations in structured form, for UI dry-run parity
+    pub soft_violations: Option<Vec<ConstraintViolation>>,
 }
 ```
 
@@ -441,7 +454,7 @@ pub struct GovernanceTransitionResult {
 
 ### 4.2. `zome_resource` Functions
 
-- `create_resource_spec(name: String, description: String, governance_rules: Vec<GovernanceRule>) -> Record`: Creates a new resource specification with embedded governance rules. Fulfills `REQ-GOV-06`.
+- `create_resource_specification(input: ResourceSpecificationInput) -> CreateResourceSpecificationOutput`: Activates Layer 1 — creates the spec, its nested typed `GovernanceRule` entries, and the `NdoToSpecification` link. Fulfills `REQ-GOV-06` and `REQ-NDO-L1-01`.
   - **Capability**: `restricted_access` (Only Accountable Agents can define new resource types)
 - `create_economic_resource(spec_hash: ActionHash, quantity: f64, unit: String) -> Record`: Creates a new Economic Resource. This is the first step for a Simple Agent (`REQ-USER-S-05`). Automatically triggers validation process (`REQ-GOV-02`).
   - **Capability**: `general_access`

--- a/documentation/zomes/governance_zome.md
+++ b/documentation/zomes/governance_zome.md
@@ -90,6 +90,7 @@ pub struct EconomicEvent {
     pub resource_quantity: f64,           // Quantity involved in the event
     pub event_time: Timestamp,            // When the event occurred
     pub note: Option<String>,             // Optional event description
+    pub ndo_identity_hash: ActionHash,    // Layer 0 pointer for action-constraint evaluation (#132)
 }
 ```
 
@@ -112,6 +113,7 @@ pub struct Commitment {
     pub due_date: Timestamp,              // Commitment due date
     pub note: Option<String>,             // Optional commitment description
     pub committed_at: Timestamp,          // When commitment was made
+    pub ndo_identity_hash: ActionHash,    // Layer 0 pointer for action-constraint evaluation (#132)
 }
 ```
 
@@ -293,11 +295,15 @@ pub struct LogEconomicEventInput {
     pub provider: AgentPubKey,
     pub receiver: AgentPubKey,
     pub resource_inventoried_as: ActionHash,
-    pub affects: ActionHash,
     pub resource_quantity: f64,
     pub note: Option<String>,
+    pub commitment_hash: Option<ActionHash>, // Commitment being fulfilled
+    pub generate_pprs: Option<bool>,         // Auto-generate PPR claims
+    pub ndo_identity_hash: ActionHash,       // Layer 0 identity, required (#132)
 }
 ```
+
+`affects` is not an input field: the coordinator sets it from `resource_inventoried_as`.
 
 **Business Logic**:
 
@@ -349,14 +355,16 @@ Creates a new economic commitment.
 ```rust
 pub struct ProposeCommitmentInput {
     pub action: VfAction,
+    pub resource_hash: Option<ActionHash>,      // Specific resource, if any
+    pub resource_spec_hash: Option<ActionHash>, // Resource specification, if general
     pub provider: AgentPubKey,
-    pub receiver: AgentPubKey,
-    pub resource_conforms_to: Option<ActionHash>,
-    pub input_of: Option<ActionHash>,
     pub due_date: Timestamp,
     pub note: Option<String>,
+    pub ndo_identity_hash: ActionHash,          // Layer 0 identity, required (#132)
 }
 ```
+
+The caller is the receiver, so `receiver` is not an input field; `input_of` is set by the process path, not by this input.
 
 **Business Logic**:
 

--- a/documentation/zomes/resource_zome.md
+++ b/documentation/zomes/resource_zome.md
@@ -108,21 +108,21 @@ The joining agent and join time are **not** stored in the entry: they come from 
 
 ```rust
 pub struct ResourceSpecification {
-    pub name: String,                     // Resource specification name
-    pub description: String,              // Detailed description
-    pub category: String,                 // Category for efficient queries
-    pub image_url: Option<String>,        // Optional resource image
-    pub tags: Vec<String>,               // Flexible discovery tags
-    pub governance_rules: Vec<ActionHash>, // Embedded governance
-    pub created_by: AgentPubKey,         // Creator agent
-    pub created_at: Timestamp,           // Creation timestamp
-    pub is_active: bool,                 // Active/inactive filter
+    pub name: String,              // Resource specification name
+    pub description: String,       // Detailed description
+    pub category: String,          // Category for efficient queries
+    pub image_url: Option<String>, // Optional resource image
+    pub tags: Vec<String>,         // Flexible discovery tags
+    pub is_active: bool,           // Active/inactive filter
+    pub scope: ResourceScope,      // Project | Network | Public (mutable)
+    pub ndo_identity_hash: ActionHash, // Immutable Layer 0 pointer (original create_ndo hash)
+    pub ndo_state_hash: ActionHash,    // The NDO action the author observed at activation
 }
 ```
 
+**Layer 1 activation**: creating a spec writes an `NdoToSpecification` link from `ndo_identity_hash` and is gated to lifecycle stages `Specification` through `Active` (#132). `governance_rules`, `created_by`, and `created_at` are not fields on this entry: rules are separate `GovernanceRule` entries reached through `SpecificationToGovernanceRule`, and authorship comes from the action.
 **ValueFlows**: Compliant with resource specification standards
-**Governance**: Embedded rules for access and usage control
-**Discovery**: Category and tag-based efficient queries
+**Discovery**: Category and tag-based efficient queries; `Project`-scoped specs skip the global anchor
 
 ### EconomicResource Entry
 
@@ -176,23 +176,30 @@ pub enum OperationalState {
 
 ```rust
 pub struct GovernanceRule {
-    pub rule_type: String,           // Rule category (access, usage, transfer)
-    pub rule_data: String,          // JSON-encoded rule parameters
-    pub enforced_by: Option<String>, // Role required for enforcement
-    pub created_by: AgentPubKey,    // Rule creator
-    pub created_at: Timestamp,      // Creation timestamp
+    pub rule_data: RuleData,           // Tagged payload; replaces the rule_type/rule_data strings
+    pub enforced_by: Option<String>,   // Role required for enforcement
+    pub ndo_identity_hash: ActionHash, // Layer 0 pointer for constraint evaluation
+    pub property_regime: PropertyRegime, // Denormalized from Layer 0 (zero-DHT-read validation)
+    pub resource_nature: ResourceNature,
+    pub rivalry_override: Option<Rivalry>,
     // TODO (post-MVP, governance.md §4.8): add `expires_at: Option<Timestamp>` for temporal
     // governance. Rules with an expiry become inactive after the deadline without requiring a
     // manual update. Enables sunset clauses and time-limited access grants.
-    // TODO (post-MVP): add `EconomicAgreement` to typed `GovernanceRuleType` for Unyt Smart
-    // Agreement integration. See ndo_prima_materia.md §6.6, REQ-NDO-CS-07–CS-11, and
-    // documentation/specifications/governance/governance.md (EconomicAgreement TODO).
+    // TODO (post-MVP): add `EconomicAgreement` and `IdentityVerification` variants to `RuleData`
+    // for Unyt and Flowsta integration. See ndo_prima_materia.md §6.6-6.7, REQ-NDO-CS-07–CS-15.
+}
+
+pub enum RuleData {
+    AccessRequirement(AccessRequirementData),
+    UsageLimit(UsageLimitData),
+    TransferCondition(TransferConditionData),
+    MaintenanceSchedule(MaintenanceScheduleData),
 }
 ```
 
-**Flexibility**: JSON-encoded parameters for complex rule logic
+**Typing**: `GovernanceRuleType` is derived from the `RuleData` discriminant, never stored. `created_by` / `created_at` are not fields: authorship and time come from the action.
+**Constraints**: each rule is checked against its NDO's classification by `check_rule_data_permitted` in [`crates/shared/src/constraints.rs`](../../crates/shared/src/constraints.rs). `Hard` violations are rejected by the integrity zome; `Soft` violations surface as advisory warnings.
 **Enforcement**: Role-based rule enforcement delegation
-**Governance**: Community-driven rule creation and management
 
 ## API Functions
 
@@ -472,9 +479,16 @@ Creates a new governance rule.
 
 ```rust
 pub struct GovernanceRuleInput {
-    pub rule_type: String,
-    pub rule_data: String,
+    pub rule_data: RuleData,
     pub enforced_by: Option<String>,
+    pub ndo_identity_hash: ActionHash,
+    pub property_regime: PropertyRegime,
+    pub resource_nature: ResourceNature,
+    pub rivalry_override: Option<Rivalry>,
+    /// When set, also create `SpecificationToGovernanceRule` so the rule appears
+    /// in `get_resource_specification_with_rules`. Omitting it creates an orphan
+    /// rule that no read path surfaces.
+    pub specification_hash: Option<ActionHash>,
 }
 ```
 

--- a/pai/conventions.md
+++ b/pai/conventions.md
@@ -69,7 +69,7 @@ Source: `REVIEW.md` — read before proposing any PR-shaped change
 
 - Every new `#[hdk_extern]` needs a Sweettest test
 - ValueFlows: EconomicEvents must have all required fields; PPR claim types from the 16-category enum
-- Capability checks on functions that expose EncryptedProfile or role-privileged data
+- Capability checks on functions that expose PrivatePersonData or role-privileged data
 - Documentation updated per the table in `REVIEW.md §6`
 
 ## `pai/` Editing Workflow

--- a/pai/cursor-rules/20-architecture.md
+++ b/pai/cursor-rules/20-architecture.md
@@ -32,9 +32,14 @@ Source: `documentation/specifications/specifications.md §3`, `documentation/req
 
 Resource zome owns data. Governance zome owns transitions.
 ```
-request_resource_transition(GovernanceTransitionRequest) → evaluate_state_transition() → GovernanceTransitionResult
+evaluate_state_transition(GovernanceTransitionRequest) → GovernanceTransitionResult
 ```
 This separation means governance logic can evolve without touching data structures.
+
+**Current status:** `evaluate_state_transition` exists and evaluates the Hard/Soft classification
+constraints in `crates/shared/src/constraints.rs`. It is a **parallel advisory path**, not yet the
+mandatory funnel: `propose_commitment` and `log_economic_event` still write directly. The
+`request_resource_transition` entry point named in the design docs does not exist in code.
 
 ## NDO Three-Layer Model
 Source: `documentation/requirements/ndo_prima_materia.md §4–§5`

--- a/pai/cursor-rules/20-architecture.md
+++ b/pai/cursor-rules/20-architecture.md
@@ -3,8 +3,23 @@
 > **Navigation index.** Sources of truth are in `documentation/`. When content here
 > conflicts with `documentation/`, `documentation/` wins.
 
-## Three-Zome Structure
-Source: `documentation/specifications/specifications.md §2`, `CLAUDE.md — Architecture Overview`
+## Multi-DNA Topology
+Source: `workdir/happ.yaml`, `documentation/zomes/architecture_overview.md`, `README.md — Architecture`
+
+The hApp is **not** a single DNA. `workdir/happ.yaml` declares five roles:
+
+| Role | Provisioning | Purpose |
+|---|---|---|
+| `lobby` | provisioned, fixed seed `nondominium-lobby-v1` | Permissionless entry: `LobbyAgentProfile`, `GroupAnnouncement` |
+| `nondominium` | provisioned | The 3-zome core below |
+| `hrea` | provisioned (`vendor/hrea` submodule) | Canonical ValueFlows event recording |
+| `group` | cloned per group, `clone_limit: 64` | `GroupProfile`, `GroupMembership`, `WorkLog`, `SoftLink` |
+| `ndo` | cloned per NDO, `clone_limit: 512` | One DHT per Nondominium Object; clone DNA hash is the permanent NDO identity (#112) |
+
+Group and NDO cells are `deferred: true` — created on demand via `clone_cell`, not at install time.
+
+## Three-Zome Structure (Nondominium DNA core)
+Source: `documentation/specifications/specifications.md §2`, `.rules — Architecture Overview`
 
 - `zome_person` — Agent identity, profiles, roles, capability-based access, PPR storage
 - `zome_resource` — Pure data model: ResourceSpecification, EconomicResource, GovernanceRule,

--- a/pai/cursor-rules/30-rust-zomes.md
+++ b/pai/cursor-rules/30-rust-zomes.md
@@ -87,4 +87,4 @@ Source: `REVIEW.md` — read in full before any PR
 
 - ACCEPT: `Ok(())`, exhaustive `match` arms, anchor discovery chains
 - FLAG: Cross-zome direct imports (must use `call()`), PPR grants >30 days,
-  missing capability check on EncryptedProfile exposure
+  missing capability check on PrivatePersonData exposure

--- a/tests/DEPRECATED.md
+++ b/tests/DEPRECATED.md
@@ -8,27 +8,23 @@ This directory (`tests/`) contains the legacy Tryorama (TypeScript + Vitest) tes
 
 ## Migration
 
-The active test suite is **Sweettest (Rust)** located at:
+The active test suite is **Sweettest (Rust)**. Each DNA has its own package:
 
 ```
-dnas/nondominium/tests/src/
+dnas/nondominium/tests/src/    # nondominium_sweettest
+dnas/group/tests/src/          # group_sweettest
+dnas/lobby/tests/src/          # lobby_sweettest
 ```
 
-Run Sweettest tests with:
+Quick start:
 
 ```bash
-# Prerequisites: build the DNA bundles first
-bun run build:happ
-
-# Run all Sweettest tests
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest
-
-# Run a specific test module
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test person
-
-# Run a specific test function
-CARGO_TARGET_DIR=target/native-tests cargo test --package nondominium_sweettest --test person person_create_populates_hrea_agent_hash
+bun run build:happ    # prerequisite: build the DNA bundles first
+bun run sweettest     # build + run the nondominium suite
 ```
+
+Full command reference for every suite, plus the Playwright E2E suite:
+[`documentation/TEST_COMMANDS.md`](../documentation/TEST_COMMANDS.md).
 
 ## Why Sweettest
 
@@ -45,6 +41,16 @@ nondominium is a Rust-native Holochain application. Sweettest runs the conductor
 | `person/person-scenario-tests.test.ts` | pending | Not started |
 | `person/person-capability-based-sharing.test.ts` | pending | Not started |
 | `person/device-*.test.ts` | pending | Not started |
-| `resource/*.test.ts` | pending | Not started |
-| `governance/*.test.ts` | pending | Not started |
+| `resource/*.test.ts` | `dnas/nondominium/tests/src/resource/mod.rs` | Partial |
+| `governance/*.test.ts` | `dnas/nondominium/tests/src/governance/mod.rs` | Partial |
 | `governance/ppr-system/*.test.ts` | pending | Not started |
+
+Sweettest coverage added since this suite was frozen, with no Tryorama predecessor:
+
+| Sweettest module | Covers |
+|---|---|
+| `dnas/nondominium/tests/src/nondominium/` | NDO Layer 0 (`NondominiumIdentity`) lifecycle |
+| `dnas/lobby/tests/src/lobby/` | Lobby agent profiles, group announcements |
+| `dnas/group/tests/src/group/` | Group lifecycle, membership, work logs, soft links |
+| `dnas/group/tests/src/ndo_anchor/` | NDO anchors on the group DHT |
+| `ui/tests/` (Playwright) | Browser-level Lobby → Group → NDO flows |

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,15 @@
-# Nondominium Test Suite
+# Nondominium Test Suite (Tryorama) — DEPRECATED
 
-Comprehensive testing framework for the nondominium Holochain application, organized following domain-driven patterns for maximum maintainability and coverage.
+> **⚠️ This suite is deprecated and unmaintained.** It is kept as historical reference only.
+> Do not add tests here.
+>
+> - **Active suite:** Sweettest (Rust) in `dnas/*/tests/` — see [`DEPRECATED.md`](DEPRECATED.md) for migration status
+> - **Commands for every suite:** [`documentation/TEST_COMMANDS.md`](../documentation/TEST_COMMANDS.md)
+> - **E2E (Playwright):** [`ui/tests/README.md`](../ui/tests/README.md)
+
+Everything below describes the legacy Tryorama (TypeScript + Vitest) suite as it stood when
+it was frozen. It reflects the single-DNA, 3-zome shape of the project at that time; the hApp
+is now multi-DNA (see [`README.md`](../README.md#architecture)).
 
 ## 🏗️ **Test Architecture Overview**
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,38 +1,73 @@
-# sv
+# Nondominium UI
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+SvelteKit frontend for the Nondominium hApp. Renders the **Lobby → Group → NDO** holarchy and
+talks to the Holochain conductor through a typed service + store layer.
 
-## Creating a project
+- **Stack:** SvelteKit 2 + Svelte 5 (runes) + TypeScript + Vite 7 + UnoCSS + Melt UI next-gen + Effect-TS
+- **Client:** `@holochain/client` ^0.20.0
+- **Architecture:** [`documentation/specifications/ui_architecture.md`](../documentation/specifications/ui_architecture.md)
+- **Requirements:** [`documentation/requirements/ui_design.md`](../documentation/requirements/ui_design.md)
 
-If you're seeing this, you've probably already done this step. Congrats!
+> All commands run inside the nix dev shell (`nix develop`) from the repository root.
+> This project uses **bun**, never npm or npx.
 
-```sh
-# create a new project in the current directory
-npx sv create
+## Running
 
-# create a new project in my-app
-npx sv create my-app
+The UI is not meant to be started on its own for normal development. Use the multi-agent
+harness from the repo root, which boots a bootstrap server, the conductors, and one Vite dev
+server per agent:
+
+```bash
+bun run start              # 2 agents, one browser tab each
+AGENTS=3 bun run network   # custom agent count
+NO_OPEN=1 bun run start    # don't auto-open browser tabs
 ```
 
-## Developing
+Each agent gets its own port (`5173 + agent-1`) and therefore its own origin, which keeps
+`localStorage` isolated between agents. The conductor an origin binds to is pinned by
+`VITE_DEV_AGENT`; `?agent=N` is a manual override.
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+To run only the Vite dev server against an already-running conductor:
 
-```sh
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+```bash
+bun run --filter ui start  # requires UI_PORT and a live ui/static/hc-connection.json
 ```
 
-## Building
+## Checks and tests
 
-To create a production version of your app:
+```bash
+bun run --filter ui check     # svelte-check against tsconfig.json
+bun run --filter ui lint      # prettier --check + eslint
+bun run --filter ui format    # prettier --write
 
-```sh
-npm run build
+bun run e2e                   # Playwright E2E against real conductors (from repo root)
+bun run e2e:ui                # Playwright UI mode
 ```
 
-You can preview the production build with `npm run preview`.
+E2E details, architecture, and debugging: [`tests/README.md`](tests/README.md).
 
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+## Layout
+
+```
+ui/src/lib/
+├── components/   # lobby/, group/, ndo/, shell/ + HolochainProvider.svelte
+├── services/     # holochain.service, cell.manager, group-clone.helpers, zomes/
+├── stores/       # Svelte 5 rune stores: app.context, lobby, group, ndo-cache,
+│                 #   person, resource, governance
+├── schemas/      # Runtime validation schemas
+├── errors/       # Tagged error types and the error-context registry
+└── utils/        # hc-connect and helpers
+ui/tests/         # Playwright E2E suite
+ui/static/        # hc-connection.json is written here by the launcher
+```
+
+Shared types live in [`packages/shared-types`](../packages/shared-types). A first
+`bun install` may need `cd packages/shared-types && bun run build` before the UI type-checks,
+since types resolve from its gitignored `dist/`.
+
+## Distribution
+
+```bash
+bun run --filter ui package   # build + zip to ui/dist.zip
+bun run package               # from repo root: full .webhapp bundle
+```


### PR DESCRIPTION
> **SoushAI analysis.** Drafted by Soushi's AI assistant, reviewed and posted by @Soushi888.

## Intent

The docs had drifted apart from each other and from the code. A reader landing on `CLAUDE.md` was told this is a "3-zome Holochain hApp" while `README.md` correctly described a five-role multi-DNA hApp. `TEST_COMMANDS.md` said Tryorama was "still the primary test suite" while every other doc said it was deprecated. Five files pinned Vite 6.2.5 when `ui/package.json` has been on Vite 7. Eleven files referenced an `EncryptedProfile` entry type that does not exist anywhere in the codebase.

This is a full documentation sync pass: every doc-to-doc contradiction found, arbitrated against code evidence, and resolved with one canonical home per claim. Two commits: the original `/CodeDocs Sync` pass, and a re-sync against NDO Layer 1 that issue #135 deliberately sequenced behind PR #132.

## Changes

### Commit 1 — harmonization pass

**Contradictions resolved against code (7).** Each was checked against the source, not against whichever doc looked newest.

| Topic | Was | Now | Evidence |
|---|---|---|---|
| Vite version | `Vite 6.2.5` in 5 files | Vite 7 | `ui/package.json:45` -> `^7.0.4` |
| Holochain client | `0.19.0` in 5 files | `^0.20.0` (UI), `^0.19.1` (root tooling) | `ui/package.json:51`, root `package.json` |
| hApp architecture | "3-zome Holochain hApp" | Multi-DNA, 5 roles; "3-zome" now always scoped to the Nondominium DNA | `workdir/happ.yaml:5-60` -> lobby, nondominium, hrea, group, ndo |
| Primary test suite | `TEST_COMMANDS.md`: Tryorama "still the primary test suite" | Sweettest primary, Tryorama deprecated | agrees with README, `.rules`, `tests/DEPRECATED.md`, IMPLEMENTATION_STATUS |
| Private-data entry | `EncryptedProfile` (11 files) | `PrivatePersonData` | `zome_person/src/lib.rs:59` -> no `EncryptedProfile` type exists |
| Sweettest binaries | "Four `[[test]]` binaries" | 5 nondominium + 2 group + 1 lobby | the three `tests/Cargo.toml` manifests |
| Ontology doc paths | `documentation/archives/{agent,resources,governance}.md` | `documentation/requirements/` | those files are not in `archives/` |

**Superseded content refreshed.** `.rules` development status was three months behind `README.md` and now points at it. `tests/DEPRECATED.md` claimed the resource and governance migrations were "Not started" when both Sweettest modules exist (137 and 307 lines); the table now reflects reality and lists the Sweettest coverage that has no Tryorama predecessor. `tests/README.md` had no deprecation banner at all despite sitting beside `DEPRECATED.md`; it has one now.

**Duplication collapsed to canonical homes.** The tech-stack block was repeated verbatim in five files, each carrying the same two stale versions. It now lives once in `README.md` § Technology Stack; the others link. Same for the Sweettest command block (five copies) which now lives in `documentation/TEST_COMMANDS.md`.

**Structure.**
- `ui/README.md` was still the untouched SvelteKit scaffold: titled `# sv`, instructing `npx sv create` and `npm run dev`. Replaced with a real README covering the multi-agent dev harness, per-agent origin isolation via `VITE_DEV_AGENT`, checks, E2E, and the `lib/` layout.
- `README.md` setup was missing `git submodule update --init --recursive`, which is genuinely required: `build:happ` runs `cd vendor/hrea && cargo build` and packs `vendor/hrea/dnas/hrea/workdir`, so the build fails without it.
- `README.md` still listed "NPM Workspaces" and Tryorama as current stack, contradicting the bun-only convention stated 200 lines above it.
- Four competing documentation indexes now have declared roles: `documentation/README.md` is the hub, `DOCUMENTATION_INDEX.md` the annotated guide, `SUMMARY.md` the flat TOC, and the root README a short pointer. Each links to the others; previously the hub linked to neither of the other two.
- The Playwright E2E suite was documented in `ui/tests/README.md` but linked from nowhere. Now reachable from README, the hub, TEST_COMMANDS, and `.rules`.
- `pai/cursor-rules/20-architecture.md` gained a Multi-DNA Topology section; it is always-loaded agent context and described only the three zomes.

**Links: 34 broken -> 0.** All were path moves after files were relocated (`archives/{agent,resources,governance}.md` -> `requirements/`, `post-mvp/lobby-dna.md` -> `requirements/lobby-dna.md`, `versioning.md` -> `ndo-versioning.md`, and the lobby-architecture and valueflows-dsl pairs). Two dead anchors fixed against their real headings. One link pointed at `user-story-resource-transaction.md`, which exists nowhere; retargeted to `user-story-ERP-bridge.md`, the actual home of the Sarah/Sensorica and Marco/FabLab participants that sentence describes.

### Commit 2 — re-sync against NDO Layer 1 (#132)

Issue #135 sequenced this pass behind #132 because Layer 1 changes what these documents describe. Every claim below was checked against the merged source.

**False status claims corrected.**

| Document | Said | Code says |
|---|---|---|
| `IMPLEMENTATION_STATUS.md` | Governance-as-operator "specified, not implemented"; six named types and functions absent | `GovernanceTransitionRequest` / `TransitionContext` / `GovernanceTransitionResult` are in `crates/shared/src/io/governance.rs`; `evaluate_state_transition` is live in `zome_gouvernance/src/transition.rs`. Only `request_resource_transition` and `evaluate_governance_transition` are still absent, which is why the path is parallel and advisory rather than the mandatory funnel |
| `IMPLEMENTATION_STATUS.md` | "GovernanceRule semantics are not evaluated" | `crates/shared/src/constraints.rs` enforces classification predicates Hard at integrity and Soft as advisory. The row is split: classification constraints enforced, per-rule runtime conditions not |
| `ndo_prima_materia.md` (4 sites) | Layer 1 activation not in code | `NdoToSpecification` is in `LinkTypes` and is created on every `create_resource_specification` |
| `ndo_prima_materia.md` REQ-NDO-L1-02 | Layer 1 may activate "at or after `Ideation`" | The integrity gate rejects `Ideation` and accepts `Specification` through `Active`, matching §5.2's own activation table |

**Struct listings regenerated from source** in `resources.md`, `zomes/resource_zome.md`, `zomes/governance_zome.md`, `API_REFERENCE.md` and `specifications/specifications.md`. `ResourceSpecification` gained `scope`, `ndo_identity_hash`, `ndo_state_hash`. `GovernanceRule` replaced the `rule_type`/`rule_data` string pair with the typed `RuleData` enum plus three denormalized classification fields. `EconomicEvent`, `Commitment`, `LogEconomicEventInput` and `ProposeCommitmentInput` all gained `ndo_identity_hash`. `created_by` and `created_at` were documented on entries that never carried them, and the API reference's `ResourceSpecificationInput` / `GovernanceRuleInput` blocks described a schema with no counterpart in code at all.

**Status banners** on `specifications/governance/cross-zome-api.md` and `governance-operator-architecture.md`. They keep their target architecture, but a reader can no longer mistake `request_resource_transition` for a callable function. The same correction lands in `pai/cursor-rules/20-architecture.md`, which is always-loaded agent context and taught the wrong call chain.

**`SUMMARY.md` now lists every document in the tree.** The Source-NDO set, the Phase B design record, ADR-010-013, the hREA release plan and two Applications pages were unreachable from the mdBook TOC.

## Decisions

| Option | Rejected because |
| ------ | ---------------- |
| Edit `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` directly | All three are symlinks to `.rules`. Edits go to `.rules`, which is tracked and is itself the source (only `.cursor/rules` is nix-materialized from `pai/`). |
| Delete the stale Tryorama sections from `TEST_COMMANDS.md` | Content moves, it does not vanish. They are demoted under an explicit deprecation banner and kept as archaeology. |
| Rewrite the three governance design docs to match code | They specify the target architecture, which is still the plan. A status banner naming which half exists is honest without discarding the design. |
| Rewrite the archived `P2PMODELS_COMPARISON_REPORT.md` versions | It is a dated archive document; its stale versions are accurate as of its own date. |
| Rebase-resolve conflicts by taking one side wholesale | Five files conflicted against the new `dev`. Each hunk was resolved against code: `dev`'s newer prose where it was richer, this branch's corrections where `dev` was stale (Vite 7, client `^0.20.0`, five roles not four, the 13 link paths `dev` reintroduced). |

## How to test

```bash
# Link integrity across all 105 docs
bun ~/.claude/skills/CodeDocs/Tools/DocSync.ts links --repo .
```

Expect `broken: 1`. The single remaining hit is a false positive: `ndo_prima_materia.md:19` targets `#6-the-surface-of-attachment--capability-slots`, and the heading contains an em-dash. GitHub strips the em-dash and leaves both surrounding spaces, producing two hyphens; the checker collapses them to one. The link resolves correctly on GitHub.

Spot-check the code-arbitrated claims:

```bash
grep -rn "EncryptedProfile" --include="*.md" . | grep -v vendor/   # expect none
grep -n '"vite"\|"@holochain/client"' ui/package.json              # ^7.0.4, ^0.20.0
grep -c "name = " dnas/*/tests/Cargo.toml                          # binary counts
grep -n "pub struct ResourceSpecification" -A 25 \
  dnas/nondominium/zomes/integrity/zome_resource/src/lib.rs        # 9 fields incl. the Layer 0 pair
```

Every document in the tree is reachable from `SUMMARY.md`:

```bash
python3 - <<'EOF'
import pathlib, re
linked = set(re.findall(r'\]\(([^)]+\.md)\)', pathlib.Path('documentation/SUMMARY.md').read_text()))
missing = [str(p.relative_to('documentation')) for p in sorted(pathlib.Path('documentation').rglob('*.md'))
           if str(p.relative_to('documentation')) not in linked | {'SUMMARY.md'}]
print(missing or 'none')
EOF
```

No code changed, so no build or test run is required.

## Documentation

This PR is documentation only. 33 files: `README.md`, `.rules`, `REVIEW.md`, `ui/README.md`, `tests/README.md`, `tests/DEPRECATED.md`, 3 files under `pai/`, and 24 under `documentation/`.

## Related

Closes #135

Follows PR #132, which this branch is rebased onto. Two items the first commit deliberately deferred are closed by #132 rather than here:

- **`PropertyRegime` 6-vs-4 split — resolved.** `crates/shared/src/types.rs` and `packages/shared-types/src/resource.types.ts` now both carry seven variants (`Private`, `Commons`, `Collective`, `Pool`, `CommonPool`, `Public`, `Nondominium`), and every doc that states a count states seven.
- **`complete-resource-specification.md` was 0 bytes — resolved.** It is now the 54KB Phase B design record for #132, and is linked from both `DOCUMENTATION_INDEX.md` and `SUMMARY.md`.

Still open, deliberately out of scope:

- **`documentation/specifications/protocol-bridge-specifications.md` cites a user story that does not exist.** The original link targeted `user-story-resource-transaction.md`. It was retargeted to `user-story-ERP-bridge.md`, which contains the participants that sentence describes, but whether the intended document was renamed or never written is a question for its author.
- **The three governance design documents still specify `request_resource_transition`.** They now carry a status banner, but reconciling the design with what #132 actually built is a design decision, not doc drift. Filed as #145: the funnel-versus-parallel question from `complete-resource-specification.md` §5 has to be answered before those banners can come off.