### PR TITLE
test(e2e): fix red dev e2e (leaked guard clone) + add Sweettest CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,85 @@ jobs:
       - name: Build happ
         run: nix develop --command bun run build:happ
 
-  # Browser-level e2e against real conductors (ui/tests/e2e). Gated behind the
-  # build job; when a Sweettest CI job lands, gate this behind that instead so
-  # backend regressions fail fast before the slower browser suite runs.
-  e2e:
+  # Primary backend suite (CLAUDE.md): pure predicate unit tests in
+  # crates/shared, then Sweettest against real conductors. Runs before e2e so a
+  # backend regression fails fast instead of surfacing as a confusing browser
+  # failure ten minutes later.
+  #
+  # Sharded one job per [[test]] target. Measured on the first CI run of the
+  # whole suite in a single job (run 31736241424): 61 min total — 16 min of
+  # compile plus 40 min of tests executed back-to-back. Sharding overlaps the
+  # test time so wall clock tracks the slowest target rather than their sum:
+  #
+  #   nondominium 16m · resource 13m · governance 6m · person 4m · misc 1.5m
+  #
+  # Two details make this work and are easy to undo by accident:
+  #
+  #   * NO custom CARGO_TARGET_DIR. `CLAUDE.md` documents
+  #     `CARGO_TARGET_DIR=target/native-tests` for local runs, which keeps the
+  #     native test artifacts away from the wasm build. In CI that path falls
+  #     outside what Swatinem/rust-cache saves, so every run recompiled
+  #     holochain's test_utils from scratch — the 16 min. The default `target/`
+  #     is cached, and cargo already separates wasm by target triple.
+  #   * `shared-key` so all shards restore ONE cache rather than fighting over
+  #     five. The first run on a new lockfile still pays the compile in
+  #     parallel; later runs restore it.
+  #
+  # --test-threads 2: each Sweettest spawns conductors, and 6 threads with 11
+  # conductor tests in flight gets the runner OOM-killed (SIGTERM mid-suite).
+  sweettest:
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      # Report every failing target, not just the first — a shared regression
+      # usually breaks several, and seeing which ones is the diagnosis.
+      fail-fast: false
+      matrix:
+        target: [misc, person, governance, resource, nondominium]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: cachix/cachix-action@v14
+        with:
+          name: holochain-ci
+          skipPush: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: sweettest
+          workspaces: |
+            . -> target
+            vendor/hrea -> vendor/hrea/target
+
+      - name: Install dependencies
+        run: nix develop --command bun install
+
+      # Sweettest loads the packaged .happ, so the WASM build is a prerequisite.
+      - name: Build happ
+        run: nix develop --command bun run build:happ
+
+      # Pure predicate tests — no conductors, seconds to run. Only needs to run
+      # once, so it rides the cheapest shard.
+      - name: Run shared-crate unit tests
+        if: matrix.target == 'misc'
+        run: nix develop --command cargo test --package nondominium_shared
+
+      - name: Run Sweettest target
+        run: |
+          nix develop --command cargo test --package nondominium_sweettest \
+            --test ${{ matrix.target }} -- --test-threads 2
+
+  # Browser-level e2e against real conductors (ui/tests/e2e). Gated behind
+  # sweettest so backend regressions fail before the slower browser suite runs.
+  e2e:
+    runs-on: ubuntu-latest
+    needs: sweettest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/ui/tests/e2e/specs/core-flows.spec.ts
+++ b/ui/tests/e2e/specs/core-flows.spec.ts
@@ -22,6 +22,7 @@ import {
   createGroup,
   createNdo,
   ensureLobbyProfile,
+  expectEmptyLobby,
   expectEventually,
   gotoAgent
 } from '../utils/e2e-helpers.js';
@@ -82,13 +83,27 @@ test.describe.serial('nondominium core flows', () => {
       modifiers: { network_seed: `e2e-clone-guard-${Date.now()}` }
     });
     await authorizeWithRetry(seed.admin, clone.cell_id);
-    const myGroup = await seed.app.callZome({
-      cell_id: clone.cell_id,
-      zome_name: 'zome_group',
-      fn_name: 'get_my_group',
-      payload: null
-    });
-    expect(myGroup).toBeNull();
+    try {
+      const myGroup = await seed.app.callZome({
+        cell_id: clone.cell_id,
+        zome_name: 'zome_group',
+        fn_name: 'get_my_group',
+        payload: null
+      });
+      expect(myGroup).toBeNull();
+    } finally {
+      // The UI enumerates group clone cells straight off appInfo, so a leftover
+      // guard clone shows up in the sidebar as a real group and makes the next
+      // test's "empty lobby" precondition false. Tear it down here — the guard
+      // owns this cell, nothing downstream should see it.
+      await seed.app.disableCloneCell({
+        clone_cell_id: { type: 'dna_hash', value: clone.cell_id[0] }
+      });
+      await seed.admin.deleteCloneCell({
+        app_id: seed.appId,
+        clone_cell_id: { type: 'dna_hash', value: clone.cell_id[0] }
+      });
+    }
   });
 
   // ── Phase 1: single-agent core flows ──────────────────────────────────────
@@ -103,6 +118,10 @@ test.describe.serial('nondominium core flows', () => {
   });
 
   test('empty lobby shows the create-or-join onboarding CTA', async () => {
+    // The CTA only renders when the agent has no groups, so the emptiness is a
+    // precondition rather than part of what is under test. Assert it first —
+    // when it breaks, the message should say so.
+    await expectEmptyLobby(page);
     await expect(page.getByText('Create or join a group to see NDOs')).toBeVisible();
   });
 

--- a/ui/tests/e2e/utils/e2e-helpers.ts
+++ b/ui/tests/e2e/utils/e2e-helpers.ts
@@ -120,6 +120,31 @@ export async function saveGroupProfileIfPrompted(page: Page): Promise<void> {
 }
 
 /**
+ * Asserts the agent has no groups yet.
+ *
+ * Several lobby behaviours (the create-or-join onboarding CTA above all) are
+ * only reachable from a genuinely empty lobby, and that emptiness is a property
+ * of shared conductor state rather than of the test itself. Any earlier test —
+ * or any spec file that happens to sort earlier, since the suite runs
+ * `workers: 1`, `fullyParallel: false` — can quietly invalidate it.
+ *
+ * Assert it explicitly so the failure names the broken precondition instead of
+ * surfacing ten seconds later as an inscrutable "element not found" on whatever
+ * the empty state was supposed to render.
+ */
+export async function expectEmptyLobby(page: Page): Promise<void> {
+  const groupLinks = page.locator('nav a[href^="/group/"]');
+  const count = await groupLinks.count();
+  const names = count > 0 ? await groupLinks.allInnerTexts() : [];
+  expect(
+    count,
+    `precondition failed: expected an empty lobby, found ${count} group(s) in the sidebar ` +
+      `(${names.join(', ')}). Some earlier test leaked conductor state — check for a ` +
+      `clone cell or group that was created and never torn down.`
+  ).toBe(0);
+}
+
+/**
  * Creates a group through the sidebar and lands on /group/{seed}. Handles the
  * first-visit GroupProfileModal.
  */
@@ -140,7 +165,14 @@ export async function createGroup(page: Page, name: string): Promise<string> {
 
 export interface NdoFormInput {
   name: string;
-  regime?: 'Private' | 'Commons' | 'Nondominium' | 'CommonPool';
+  regime?:
+    | 'Private'
+    | 'Commons'
+    | 'Collective'
+    | 'Pool'
+    | 'CommonPool'
+    | 'Public'
+    | 'Nondominium';
   nature?: 'Physical' | 'Digital' | 'Service' | 'Hybrid' | 'Information';
   stage?: string;
   description?: string;

--- a/ui/tests/setup/harness.ts
+++ b/ui/tests/setup/harness.ts
@@ -123,6 +123,8 @@ export async function authorizeWithRetry(
 export interface SeedClient {
   app: AppWebsocket;
   admin: AdminWebsocket;
+  /** Installed app id — needed for admin calls scoped to the app (e.g. deleteCloneCell). */
+  appId: string;
   close: () => Promise<void>;
 }
 
@@ -152,8 +154,10 @@ export async function createSeedClient(agent = 1): Promise<SeedClient> {
     await authorizeWithRetry(admin, cellId);
   }
 
+  const appId = ready.appId || APP_ID;
+
   const { token } = await admin.issueAppAuthenticationToken({
-    installed_app_id: ready.appId || APP_ID,
+    installed_app_id: appId,
     single_use: false,
     expiry_seconds: 3600
   });
@@ -168,6 +172,7 @@ export async function createSeedClient(agent = 1): Promise<SeedClient> {
   return {
     app,
     admin,
+    appId,
     close: async () => {
       try {
         await app.client.close();


### PR DESCRIPTION
## Intent

`dev` has been red on e2e since #126 merged (2026-08-09): `build: success, e2e: failure` on every run since, which also fails the CI of every PR against `dev` (visible as a deterministic failure on the docs-only #131). This PR fixes the root cause on `dev` directly and adds the Sweettest CI gate, extracted from #132 so it does not have to wait on a 98-file review.

## Root cause

The `clone guard` test provisions a group clone cell with a unique network seed and never tears it down. The UI enumerates group clone cells straight off `appInfo`, so the leaked guard clone renders in the sidebar as a real group. The next serial test, `empty lobby shows the create-or-join onboarding CTA`, requires an empty lobby and fails. #126's group-persistence work made the sidebar reliably re-enumerate cells, turning a latent leak into a deterministic failure. Playwright retries share conductor state, so the original attempt and both retries fail identically.

## Changes

- **`core-flows.spec.ts`**: the guard test tears its clone cell down in a `finally` (disable + admin delete); the empty-lobby test asserts its precondition first via `expectEmptyLobby`, so a future leak fails with a message naming the leaked groups instead of "element not found".
- **`e2e-helpers.ts`**: new `expectEmptyLobby(page)` helper with a diagnostic message; widens the `NdoFormInput.regime` union (inert typing, no test uses the new values).
- **`harness.ts`**: exposes `appId` on `SeedClient`, needed by `deleteCloneCell`.
- **`build.yml`**: Sweettest lands in CI as a five-target shard matrix (`misc`, `person`, `governance`, `resource`, `nondominium`), `fail-fast: false`, shared rust-cache, `--test-threads 2`; the e2e job is re-gated behind sweettest so backend regressions fail before the slower browser suite. Same workflow content as validated on #132.

Both files taken verbatim from the `ndo-layer1` branch, where they are green (the only difference: this branch does not carry the rest of Layer 1). The e2e hunks reference no Layer 1 UI or zome surface; the five sweettest targets, the `nondominium_shared` package, and the `vendor/hrea` workspace all already exist on `dev`.

## How to test

- `nix develop --command bun run build:happ`
- `nix develop --command bash -c "cd packages/shared-types && bun run build"`
- `nix develop --command bun run e2e` -> **18 passed (2.2m)**, including `empty lobby shows the create-or-join onboarding CTA` (23ms)
- CI on this PR: build + all five sweettest shards + e2e

## Risk

`dev`'s Sweettest suite has never run in CI. If a shard comes back red, that is a latent `dev` regression surfaced by the new gate; it gets fixed in this PR, not by weakening the gate.
