### PR TITLE
fix(nix): make the materialized .claude/ writable so the skills hook can write

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,12 @@
           # Materialize .claude/ from pai/claude/
           mkdir -p .claude/skills
           rsync -a --delete ${./pai/claude}/ .claude/
+          # Nix store paths are read-only, and `rsync -a` preserves that mode on
+          # the copy. Without this the NEXT write into .claude/ fails — the skills
+          # hook below cannot mkdir .claude/skills/holochain, which is the
+          # "Permission denied (13)" rsync error seen on every CI run and in every
+          # local nix shell. Same treatment .cursor/ already gets.
+          chmod -R u+w .claude 2>/dev/null || true
           chmod u+x .claude/hooks/*.hook.ts 2>/dev/null || true
 
           # Materialize Cursor rules from pai/


### PR DESCRIPTION
## Intent

Every `nix develop` entry and every CI job logs this, three times:

```
rsync: [Receiver] mkdir ".claude/skills/holochain" failed: Permission denied (13)
rsync error: error in file IO (code 11) at main.c(791)
```

It is non-fatal, but it is noise on every run and an active red herring when diagnosing real failures: in PR #130's failing e2e run the error appears immediately before `launch-happ.mjs exited before ready`, which invites the conclusion that they are related. They are not, and confirming that costs time each round.

## Root cause

The shellHook materializes `.claude/` out of the nix store:

```
rsync -a --delete ${./pai/claude}/ .claude/
```

`rsync -a` preserves permissions, and nix store paths are read-only, so `.claude/` lands as mode `555`. The agent-skills hook that runs a few lines later then cannot `mkdir .claude/skills/holochain` inside it.

`.cursor/` is materialized the same way and already carries `chmod -R u+w .cursor` for exactly this reason. `.claude/` was simply missing the equivalent line.

## Change

One line, mirroring the `.cursor/` treatment, placed after the rsync and before the skills hook, with a comment recording why it is load-bearing.

## How to test

```bash
chmod -R u+w .claude && rm -rf .claude
nix develop --command true    # first run: materializes
nix develop --command true    # second run: this is the one that used to fail
```

Verified locally: `.claude` is now `drwxr-xr-x`, `.claude/skills/holochain` is created, and the second run produces no rsync output at all. Before the fix the second run reproduced the error every time.

## Related

Clears one of the two prerequisites listed for reviewing #130 (the other being the 0.7 launcher timeout, which is genuinely unrelated and remains open).
