### PR TITLE
chore(nix): pin the holochain agent skill to v1.0.0-rc.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,16 +70,17 @@
     "holochain-agent-skill": {
       "flake": false,
       "locked": {
-        "lastModified": 1775526113,
-        "narHash": "sha256-9A3qw0LG3IxA8KpunF1Ef+aRPjXFRwDifvIl3yrsEIo=",
+        "lastModified": 1788506911,
+        "narHash": "sha256-i3g6ZJbX/IRE6ZztDsBqcA74GPUxKX/LyMwAFiIcSCM=",
         "owner": "Soushi888",
-        "repo": "holochain-agent-skill",
-        "rev": "ab02c4f11edef175e438664adc4536e5da12cbc2",
+        "repo": "holochain-agent-skills",
+        "rev": "28b00fc0ef7f5a25d04e2acdcb0c97e2f8ffb54a",
         "type": "github"
       },
       "original": {
         "owner": "Soushi888",
-        "repo": "holochain-agent-skill",
+        "ref": "v1.0.0-rc.1",
+        "repo": "holochain-agent-skills",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,11 +7,15 @@
     nixpkgs.follows    = "holonix/nixpkgs";
     flake-parts.follows = "holonix/flake-parts";
 
-    # Agent skills — plain source trees (not flakes).
+    # Agent skills — consumed as plain source trees (flake = false), even where
+    # upstream ships its own flake.
     # Pin: set url to "github:owner/repo/vX.Y.Z"
     # Update to latest: nix flake update holochain-agent-skill
+    # The upstream repo was renamed to holochain-agent-skills (plural) at
+    # v1.0.0-rc.1. The input attribute stays singular so the update command above
+    # and the references in CONTRIBUTING.md / pai/README.md keep working.
     holochain-agent-skill = {
-      url   = "github:Soushi888/holochain-agent-skill";
+      url   = "github:Soushi888/holochain-agent-skills/v1.0.0-rc.1";
       flake = false;
     };
   };
@@ -65,7 +69,10 @@
           # Materialize agent skills into .claude/, .cursor/, and .agents/
           mkdir -p .cursor/skills .agents/skills
           ${agentSkillsHook [
-            { src = inputs.holochain-agent-skill;                        name = "holochain"; }
+            # Since v1.0.0-rc.1 the skill lives under skills/<name>/ rather than at
+            # the repo root, so the whole workshop (book.toml, docs/, .github/)
+            # no longer lands inside the installed skill.
+            { src = "${inputs.holochain-agent-skill}/skills/holochain";        name = "holochain"; }
             { src = "${./pai/claude}/skills/nondominium-domain"; name = "nondominium-domain"; }
             { src = "${./pai/claude}/skills/complexity-oriented-programming"; name = "complexity-oriented-programming"; }
           ]}


### PR DESCRIPTION
> **SoushAI analysis.** Drafted by Soushi's AI assistant, reviewed and posted by @Soushi888.

## Intent

The `holochain-agent-skill` flake input was never pinned to a tag, and `flake.lock` still held `ab02c4f` from **2026-04-06**, which predates every tagged release upstream. Every `nix develop` in this repo has been materializing a five-month-old skill into `.claude/skills/holochain/`, `.cursor/skills/holochain/` and `.agents/skills/holochain/`.

This pins the input to the newest upstream release, **v1.0.0-rc.1** (2026-09-04).

## Changes

**The pin.** `url` now names an explicit tag instead of tracking the default branch, so the skill an agent gets is a decision rather than whatever `main` happened to be that day.

**Two upstream breaking changes absorbed.**

- The repository was renamed to `holochain-agent-skills` (plural). GitHub redirects, but a lock file should not depend on a redirect, so the URL names the new repo. The **input attribute stays singular** (`holochain-agent-skill`) so the `nix flake update holochain-agent-skill` command documented in `CONTRIBUTING.md` and the diagrams in `pai/README.md` keep working unchanged.
- The skill moved from the repository root to `skills/holochain/`. Fetching the root used to drag `book.toml`, `SUMMARY.md`, `CHANGELOG.md`, `CLAUDE.md`, `docs/` and `.github/` into the installed skill directory; the `src` now names the subpath, so only the skill lands.

## Decisions

**v1.0.0-rc.1 targets Holochain 0.7 only, and `dev` is still on 0.6** (`hdk = "^0.6.0"`, `holochain = "=0.6.0"`, `holonix ref=main-0.6`). The release notes are explicit that 0.6 content was removed. This is a deliberate choice to land the skill ahead of the 0.7 upgrade in #130 rather than after it, and it is worth naming so a reviewer is not surprised.

| Option | Rejected because |
| ------ | ---------------- |
| Pin `v0.2.0` (latest 0.6-compatible release) | Matches `dev`'s toolchain exactly, but leaves the repo one major version behind and needs a second bump the moment #130 lands. |
| Leave the input unpinned on `main` | The current state. A `nix flake update` at an arbitrary moment silently changes what every agent in this repo reads. |

Two consequences worth tracking while `dev` is on 0.6:

- The installed skill teaches 0.7 APIs, including the Action model rewrite. `documentation/TELOS.md` and `pai/claude/skills/nondominium-domain/SKILL.md` both route general HDK questions to this skill.
- It carries an `UpgradeHolochain07` workflow, which is directly useful to #130.

## How to test

```bash
nix develop
ls .claude/skills/holochain/            # assets  LICENSE  references  SKILL.md
grep 'version:' .claude/skills/holochain/SKILL.md   # "1.0.0-rc.1"
ls .claude/skills/holochain/ | grep -E 'book.toml|SUMMARY.md|docs'   # no match
```

Verified locally: the shellHook completes, all three harness paths (`.claude/`, `.cursor/`, `.agents/`) receive the same four-entry tree, and no workshop files leak in. The locked rev `28b00fc` is the `v1.0.0-rc.1` tag HEAD.

## Documentation

docs: none. Branch prefix is `chore/`, and the two docs that reference this input (`CONTRIBUTING.md` line 168, `pai/README.md`) stay accurate because the input attribute name is unchanged.

## Related

- Relates to #130 (`chore(deps): upgrade to Holochain 0.7`) — that PR is where the 0.7 skill and a 0.7 codebase line up.
